### PR TITLE
chore: fix lerna publish permissions

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@v2
         with:
@@ -76,10 +77,12 @@ jobs:
           MAKE_RELEASE_COMMIT_MESSAGE: "chore: make release"
           PUBLISH_COMMIT_MESSAGE: "chore: publish [skip ci]"
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN}}
+          GIT_AUTHOR_NAME: ${{ secrets.RELEASE_BOT_GIT_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.RELEASE_BOT_GIT_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ secrets.RELEASE_BOT_GIT_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ secrets.RELEASE_BOT_GIT_EMAIL }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor}}@users.noreply.github.com"
-
           SOURCE_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
           if [[ ${SOURCE_BRANCH_NAME} = main ]]; then


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

- This works around the problem that when lerna
  runs against a protected branch, an error occurs
  when pushing the version commit to a protected
  branch. The workaround is to use a Personal
  Access Token as the token that will be run by the
  action of a user that has admin role and untick the
  "Enforce all configured restrictions above for administrators."
  option in branch protection settings.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
