### PR TITLE
chore: add badges to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Blackout
 
+[![Pipeline](https://github.com/Farfetch/blackout/actions/workflows/CI.yml/badge.svg)](https://github.com/Farfetch/blackout/actions/workflows/CI.yml)
+[![MIT License](https://img.shields.io/apm/l/atomic-design-ui)](https://github.com/Farfetch/blackout/blob/main/LICENSE)
+[![GitHub last commit](https://img.shields.io/github/last-commit/Farfetch/blackout)](https://github.com/Farfetch/blackout/graphs/commit-activity)
+
 Blackout is the codename for the Farfetch Platform Solutions (FPS) projects. It's a monorepo with Yarn workspaces and Lerna.
 
 Useful to build e-commerce applications using the FPS APIs and integrating business logic.
@@ -25,9 +29,11 @@ Pull requests are welcome! For major changes, please open an issue first to disc
 Please read the [CONTRIBUTING](CONTRIBUTING) file to know what we expect from your contribution and the guidelines you should follow.
 
 ## About
+
 Blackout is a project maintained by some awesome [contributors](https://github.com/Farfetch/blackout/graphs/contributors) from [Farfetch Platform Solutions](https://www.farfetchplatformsolutions.com/).
 
 ## Maintainers
+
 - [Helder Burato Berto](https://github.com/helderburato)
 - [João Ramalho Costa](https://github.com/joaoprcosta)
 - [Nelson Leite](https://github.com/nelsonleite)


### PR DESCRIPTION
## Description

This adds 3 badges on the main `README`, resulting in 

![image](https://user-images.githubusercontent.com/5464401/143014756-b70637b6-9b25-49bc-9a74-eb7b9a1addf4.png)

(the "last commit" badge isn't ready yet because the repo is private thus not being able to be found)

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
