### PR TITLE
chore: remove duplicate lint staged configuration

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,0 @@
-{
-    "*.{js,json,md}": ["prettier --write"],
-    "*.js": ["eslint --fix"]
-}


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

It removes the file `lintstaged` considering we already have the configuration into the `package.json`.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
