### PR TITLE
chore: add extension to CONTRIBUTING and LICENSE links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Each package has its own `package.json` file and defines its dependencies, havin
 
 Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.
 
-Please read the [CONTRIBUTING](CONTRIBUTING) file to know what we expect from your contribution and the guidelines you should follow.
+Please read the [CONTRIBUTING](CONTRIBUTING.md) file to know what we expect from your contribution and the guidelines you should follow.
 
 ## About
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -87,7 +87,7 @@ Since this package is published in its original structure, all the source code i
 
 Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.
 
-Please read the [CONTRIBUTING](../../CONTRIBUTING) file to know what we expect from your contribution and the guidelines you should follow.
+Please read the [CONTRIBUTING](../../CONTRIBUTING.md) file to know what we expect from your contribution and the guidelines you should follow.
 
 ## License
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -65,7 +65,7 @@ Since this package is published in its original structure, all the source code i
 
 Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.
 
-Please read the [CONTRIBUTING](../../CONTRIBUTING) file to know what we expect from your contribution and the guidelines you should follow.
+Please read the [CONTRIBUTING](../../CONTRIBUTING.md) file to know what we expect from your contribution and the guidelines you should follow.
 
 ## License
 


### PR DESCRIPTION
## Description

This just adds the extension to CONTRIBUTING and LICENSE links in documentation.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
