### PR TITLE
chore: adjust labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,26 @@
-":package: core":
-  - 'packages/core/**/*'
-  - 'packages/core/**/.*'
-  - 'packages/core/.**/*'
-  - 'packages/core/.**/.*'
+":package: analytics":
+  - 'packages/analytics/**/*'
+  - 'packages/analytics/**/.*'
+  - 'packages/analytics/.**/*'
+  - 'packages/analytics/.**/.*'
+
+":package: client":
+  - 'packages/client/**/*'
+  - 'packages/client/**/.*'
+  - 'packages/client/.**/*'
+  - 'packages/client/.**/.*'
 
 ":package: react":
   - 'packages/react/**/*'
   - 'packages/react/**/.*'
   - 'packages/react/.**/*'
   - 'packages/react/.**/.*'
+
+":package: redux":
+  - 'packages/redux/**/*'
+  - 'packages/redux/**/.*'
+  - 'packages/redux/.**/*'
+  - 'packages/redux/.**/.*'
 
 "type: maintenance":
   - any: ['.github/**/*', '!**/*.md', '!.**/*.md']


### PR DESCRIPTION
## Description

- This adjust labeler configuration to add the
  labels for `analytics` and `redux` packages
  and replace `core` label with `client` in next.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
