### PR TITLE
feat(core|react): add productAggregatorId to add to bag requests

### DIFF
--- a/packages/core/src/bags/hooks/useBagItem.js
+++ b/packages/core/src/bags/hooks/useBagItem.js
@@ -51,8 +51,10 @@ export function useBagItem(
   // Function that provides all tenant logic to deal with add,
   // update or add the next merchant available.
   const addOrUpdateItem = async ({
-    size = productSize,
+    productAggregatorId = bagItem.productAggregator.id,
     quantity = bagItem.quantity,
+    size = productSize,
+    ...otherParams
   }) => {
     let quantityToHandle = quantity;
 
@@ -66,8 +68,10 @@ export function useBagItem(
         customAttributes: bagItem?.customAttributes,
         merchantId,
         product: bagItem.product,
+        productAggregatorId,
         quantity: quantityToAdd,
         size,
+        ...otherParams,
       });
       // Checks if the item we want to add is already in bag
       // by comparing the bag items' hash
@@ -125,7 +129,7 @@ export function useBagItem(
         oldQuantity: bagItem.quantity
           ? bagItem.quantity
           : bagItem.product.quantity,
-        oldSize: bagItem.size ? bagItem.size : bagItem.product.size,
+        oldSize: bagItem.size || bagItem.product.size,
       });
       return;
     }

--- a/packages/core/src/bags/redux/utils/__tests__/buildBagItem.test.js
+++ b/packages/core/src/bags/redux/utils/__tests__/buildBagItem.test.js
@@ -1,16 +1,21 @@
 import { buildBagItem } from '../';
-import { mockBagItem } from 'tests/__fixtures__/bags';
+import { mockBagItem, mockProductAggregatorId } from 'tests/__fixtures__/bags';
 
 describe('buildBagItem()', () => {
   it('should return a valid bag item object', () => {
     expect(
       buildBagItem({
+        customAttributes: mockBagItem.customAttributes,
+        merchantId: mockBagItem.merchantId,
         product: mockBagItem.product,
-        ...mockBagItem,
+        quantity: mockBagItem.quantity,
+        size: mockBagItem.size,
       }),
     ).toEqual({
+      authCode: undefined,
       customAttributes: mockBagItem.customAttributes,
       merchantId: mockBagItem.merchantId,
+      productAggregatorId: undefined,
       productId: mockBagItem.product.id,
       quantity: mockBagItem.quantity,
       scale: mockBagItem.size.scale,
@@ -19,16 +24,18 @@ describe('buildBagItem()', () => {
   });
 
   it('should return a valid bag item object with a default `quantity`', () => {
-    const { quantity, ...bagItem } = mockBagItem;
-
     expect(
       buildBagItem({
+        customAttributes: mockBagItem.customAttributes,
+        merchantId: mockBagItem.merchantId,
         product: mockBagItem.product,
-        ...bagItem,
+        size: mockBagItem.size,
       }),
     ).toEqual({
+      authCode: undefined,
       customAttributes: mockBagItem.customAttributes,
       merchantId: mockBagItem.merchantId,
+      productAggregatorId: undefined,
       productId: mockBagItem.product.id,
       quantity: 1,
       scale: mockBagItem.size.scale,
@@ -37,16 +44,18 @@ describe('buildBagItem()', () => {
   });
 
   it('should return a valid bag item object with default `customAttributes`', () => {
-    const { customAttributes, ...bagItem } = mockBagItem;
-
     expect(
       buildBagItem({
+        merchantId: mockBagItem.merchantId,
         product: mockBagItem.product,
-        ...bagItem,
+        quantity: mockBagItem.quantity,
+        size: mockBagItem.size,
       }),
     ).toEqual({
+      authCode: undefined,
       customAttributes: '',
       merchantId: mockBagItem.merchantId,
+      productAggregatorId: undefined,
       productId: mockBagItem.product.id,
       quantity: mockBagItem.quantity,
       scale: mockBagItem.size.scale,
@@ -60,12 +69,39 @@ describe('buildBagItem()', () => {
     expect(
       buildBagItem({
         authCode: mockAuthCode,
-        ...mockBagItem,
+        customAttributes: mockBagItem.customAttributes,
+        merchantId: mockBagItem.merchantId,
+        product: mockBagItem.product,
+        quantity: mockBagItem.quantity,
+        size: mockBagItem.size,
       }),
     ).toEqual({
       authCode: mockAuthCode,
       customAttributes: mockBagItem.customAttributes,
       merchantId: mockBagItem.merchantId,
+      productAggregatorId: undefined,
+      productId: mockBagItem.product.id,
+      quantity: mockBagItem.quantity,
+      scale: mockBagItem.size.scale,
+      size: mockBagItem.size.id,
+    });
+  });
+
+  it('should return a valid bag item object with a `productAggregatorId`', () => {
+    expect(
+      buildBagItem({
+        productAggregatorId: mockProductAggregatorId,
+        customAttributes: mockBagItem.customAttributes,
+        merchantId: mockBagItem.merchantId,
+        product: mockBagItem.product,
+        quantity: mockBagItem.quantity,
+        size: mockBagItem.size,
+      }),
+    ).toEqual({
+      authCode: undefined,
+      customAttributes: mockBagItem.customAttributes,
+      merchantId: mockBagItem.merchantId,
+      productAggregatorId: mockProductAggregatorId,
       productId: mockBagItem.product.id,
       quantity: mockBagItem.quantity,
       scale: mockBagItem.size.scale,

--- a/packages/core/src/bags/redux/utils/__tests__/createBagItemHash.test.js
+++ b/packages/core/src/bags/redux/utils/__tests__/createBagItemHash.test.js
@@ -1,5 +1,6 @@
 import { createBagItemHash } from '../';
 import { mockBagItem } from 'tests/__fixtures__/bags';
+import omit from 'lodash/omit';
 
 describe('createBagItemHash()', () => {
   describe('error handling', () => {
@@ -37,12 +38,32 @@ describe('createBagItemHash()', () => {
   });
 
   describe('hash creation', () => {
-    const baseHashPattern = `${mockBagItem.merchantId}!${mockBagItem.product.id}!${mockBagItem.sizeId}!${mockBagItem.size.scale}!`;
+    const baseHashPattern = `${mockBagItem.merchantId}!${mockBagItem.product.id}!${mockBagItem.sizeId}!${mockBagItem.size.scale}`;
 
-    it('should create a valid hash when no custom attributes are provided', () => {
-      const { customAttributes, ...item } = mockBagItem;
+    it('should create a valid hash when no other parameters are provided', () => {
+      expect(
+        createBagItemHash(
+          omit(mockBagItem, ['customAttributes', 'productAggregator']),
+        ),
+      ).toBe(baseHashPattern);
+    });
 
-      expect(createBagItemHash(item)).toBe(baseHashPattern);
+    it('should create a valid hash when `customAttributes` are provided', () => {
+      expect(createBagItemHash(omit(mockBagItem, ['productAggregator']))).toBe(
+        `${baseHashPattern}!${mockBagItem.customAttributes}`,
+      );
+    });
+
+    it('should create a valid hash when a `productAggregatorId` is provided', () => {
+      expect(createBagItemHash(omit(mockBagItem, ['customAttributes']))).toBe(
+        `${baseHashPattern}!${mockBagItem.productAggregator.id}`,
+      );
+    });
+
+    it('should create a valid hash from a valid bag item', () => {
+      expect(createBagItemHash(mockBagItem)).toBe(
+        `${baseHashPattern}!${mockBagItem.customAttributes}!${mockBagItem.productAggregator.id}`,
+      );
     });
   });
 });

--- a/packages/core/src/bags/redux/utils/buildBagItem.js
+++ b/packages/core/src/bags/redux/utils/buildBagItem.js
@@ -3,16 +3,15 @@
  *
  * @function buildBagItem
  * @memberof module:bags/utils
- *
  * @param {object} data - Details of the bag item to build.
  * @param {string} [data.authCode=''] - Authorization code (for SMS
  * restrictions, for example).
  * @param {string} [data.customAttributes=''] - Custom attributes.
  * @param {number} data.merchantId - Specific merchant id.
  * @param {object} data.product - Product with all information.
+ * @param {number} data.productAggregatorId - Product's aggregator (bundle variant) id.
  * @param {number} [data.quantity=1] - Number of units.
  * @param {object} data.size - Size information.
- *
  * @returns {object} Bag item data ready to perform add or update requests.
  */
 export default ({
@@ -20,8 +19,10 @@ export default ({
   customAttributes = '',
   merchantId,
   product,
+  productAggregatorId,
   quantity = 1,
   size,
+  ...otherParams
 }) => {
   const sizeHydrated = product.sizes.find(({ id }) => id === size.id);
 
@@ -29,9 +30,11 @@ export default ({
     authCode,
     customAttributes,
     merchantId: merchantId || sizeHydrated.stock[0].merchantId,
+    productAggregatorId,
     productId: product.id,
     quantity,
     scale: size.scale,
     size: size.id,
+    ...otherParams,
   };
 };

--- a/packages/core/src/bags/redux/utils/createBagItemHash.js
+++ b/packages/core/src/bags/redux/utils/createBagItemHash.js
@@ -16,6 +16,8 @@ export default params => {
   const sizeId = get(params, 'size.id') || get(params, 'size');
   const sizeScale = get(params, 'size.scale') || get(params, 'scale');
   const customAttributes = get(params, 'customAttributes');
+  const productAggregatorId =
+    get(params, 'productAggregatorId') || get(params, 'productAggregator.id');
 
   if (!merchantId || !productId || !sizeId || !sizeScale) {
     throw new Error(
@@ -23,7 +25,7 @@ export default params => {
     );
   }
 
-  return `${merchantId}!${productId}!${sizeId}!${sizeScale}!${
-    customAttributes || ''
-  }`;
+  return `${merchantId}!${productId}!${sizeId}!${sizeScale}${
+    customAttributes ? `!${customAttributes}` : ''
+  }${productAggregatorId ? `!${productAggregatorId}` : ''}`;
 };

--- a/packages/core/src/products/__tests__/withProductActions.test.js
+++ b/packages/core/src/products/__tests__/withProductActions.test.js
@@ -8,18 +8,19 @@ import {
   mockSize,
   mockSizePreferedMerchant,
 } from '../__fixtures__/productActions.fixtures';
+import { mockProductAggregatorId } from 'tests/__fixtures__/bags';
 import { shallow } from 'enzyme';
 import React from 'react';
 import withProductActions from '../withProductActions';
 
 const mockProductId = 123;
+const mockBagItems = [{ ...mockBagItem }];
+
 const getShallowTree = props => {
   const Component = withProductActions(() => <div>foo-bar</div>);
 
   return shallow(<Component {...props} />);
 };
-
-const mockBagItems = [{ ...mockBagItem }];
 
 describe('withProductActions HOC', () => {
   beforeEach(jest.clearAllMocks);
@@ -67,6 +68,23 @@ describe('withProductActions HOC', () => {
             quantity: 1,
             scale: mockSizePreferedMerchant.scale,
             size: mockSizePreferedMerchant.id,
+          });
+        });
+
+        it('should add an item to bag with a productAggregatorId', () => {
+          tree.props().onAddBagItem({
+            ...mockData,
+            productAggregatorId: mockProductAggregatorId,
+          });
+
+          expect(addBagItem).toHaveBeenCalledWith({
+            customAttributes: '',
+            merchantId: 10937,
+            productId: mockProduct.id,
+            productAggregatorId: mockProductAggregatorId,
+            quantity: mockQuantity,
+            scale: mockSize.scale,
+            size: mockSize.id,
           });
         });
 

--- a/packages/core/src/products/withProductActions.js
+++ b/packages/core/src/products/withProductActions.js
@@ -25,16 +25,18 @@ const customHandlers = {
   onAddBagItem:
     ({ addBagItem, updateBagItem, bagItems }) =>
     async ({
-      product,
-      size,
-      quantity = 1,
-      from,
       affiliation,
       coupon,
       discount,
+      from,
       index,
       listName,
       locationId,
+      product,
+      productAggregatorId,
+      quantity = 1,
+      size,
+      ...otherParams
     }) => {
       let quantityToHandle = quantity;
 
@@ -47,8 +49,10 @@ const customHandlers = {
         const requestData = buildBagItem({
           merchantId,
           product,
+          productAggregatorId,
           quantity: quantityToAdd,
           size,
+          ...otherParams,
         });
         // Checks if the item we want to add is already in bag
         // by comparing the bag items' hash

--- a/packages/react/src/bags/hooks/__tests__/useBagItem.test.js
+++ b/packages/react/src/bags/hooks/__tests__/useBagItem.test.js
@@ -106,7 +106,7 @@ describe('useBagItem', () => {
 
       await handleAddOrUpdateItem({});
 
-      // This ensures `handleAddOrUpdateItem` is correctly working. It's logic is
+      // This ensures `handleAddOrUpdateItem` is correctly working. Its logic is
       // already extensively tested within `handleQuantityChange` and `handleSizeChange`
       expect(mockDispatch).toHaveBeenCalledTimes(2);
       expect(mockDispatch).toHaveBeenCalledWith({ type: 'update' });

--- a/packages/react/src/bags/hooks/useBagItem.js
+++ b/packages/react/src/bags/hooks/useBagItem.js
@@ -71,6 +71,8 @@ export default bagItemId => {
    * @param {object} [item.product=bagItem.product] - Product of the bag item
    * to handle. Defaults to the product of the bag item that instantiated the
    * hook.
+   * @param {number} [item.productAggregatorId = bagItem.productAggregator.id] - Product
+   * aggregator id that represents the bundle variant that owns it.
    * @param {number} [item.quantity=bagItem.quantity] - Quantity of the
    * product to add/update. Defaults to the quantity of the bag item that
    * instantiated the hook.
@@ -81,8 +83,10 @@ export default bagItemId => {
   const handleAddOrUpdateItem = async ({
     customAttributes = bagItem.customAttributes,
     product = bagItem.product,
+    productAggregatorId = bagItem.productAggregator.id,
     quantity = bagItem.quantity,
     size = productSize,
+    ...otherParams
   }) => {
     let quantityToHandle = quantity;
     // Iterate through the stock of different merchants
@@ -99,8 +103,10 @@ export default bagItemId => {
         customAttributes,
         merchantId,
         product,
+        productAggregatorId,
         quantity: quantityToAdd,
         size,
+        ...otherParams,
       });
       // Checks if the item we want to add is already in bag
       // by comparing the bag items' hash
@@ -307,6 +313,7 @@ export default bagItemId => {
         merchantId,
         product: bagItem.product,
         quantity: quantityToManage,
+        productAggregatorId: bagItem.productAggregator?.id,
         size,
       });
 

--- a/tests/__fixtures__/bags/bag.fixtures.js
+++ b/tests/__fixtures__/bags/bag.fixtures.js
@@ -89,7 +89,12 @@ export const mockState = {
     bag: { [mockBagId]: mockBagEntity },
     bagItems: {
       [mockBagItemId]: mockBagItemEntity,
-      101: { ...mockBagItemEntity, id: 101, customAttributes: null },
+      101: {
+        ...mockBagItemEntity,
+        id: 101,
+        customAttributes: null,
+        productAggregator: null,
+      },
       102: {
         id: 102,
         product: 1002,

--- a/tests/__fixtures__/bags/bagItem.fixtures.js
+++ b/tests/__fixtures__/bags/bagItem.fixtures.js
@@ -2,6 +2,7 @@ import { mockBagId } from './bag.fixtures';
 import { mockMerchantId, mockProduct, mockProductId } from '../products';
 
 export const mockBagItemId = 134;
+export const mockProductAggregatorId = 321;
 
 export const mockBagEntity = {
   id: mockBagId,
@@ -28,6 +29,10 @@ export const mockBagItem = {
   sizeId: 23,
   isAvailable: true,
   product: mockProduct,
+  productAggregator: {
+    bundleSlug: '/slug',
+    id: mockProductAggregatorId,
+  },
 };
 
 export const mockBagItemEntity = {


### PR DESCRIPTION
## Description

This adds the parameter `productAggregatorId` to add to bag requests handled by both `useBagItem` hook and `withProductActions` hoc.

It also modifies the `createBagItemHash` method to include this parameter so we can differentiate between items in different bundles.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
