### PR TITLE
feat(core): add commerce pages redux

### DIFF
--- a/packages/core/src/contents/__tests__/utils.test.js
+++ b/packages/core/src/contents/__tests__/utils.test.js
@@ -1,4 +1,78 @@
-import { buildContentGroupHash, buildSEOPathname } from '../utils';
+import {
+  buildContentGroupHash,
+  buildSEOPathname,
+  getDefaultStrategy,
+  getMergeStrategy,
+  getPageRanking,
+  getRankedCommercePage,
+} from '../utils';
+import {
+  defaultStrategyResult,
+  mergeStrategyResult,
+  mockCommercePages,
+} from 'tests/__fixtures__/contents';
+
+describe('getPageRanking', () => {
+  it('should correctly construct a ranking number for a specific metadata', () => {
+    const metadata = {
+      custom: {
+        gender: '1',
+        brand: '2450',
+        category: '',
+        priceType: '',
+        id: '',
+      },
+    };
+    const expectedRanking = 110;
+    const ranking = getPageRanking(metadata);
+
+    expect(ranking).toBe(expectedRanking);
+  });
+
+  it('should correctly construct a ranking number for a specific metadata without data', () => {
+    const metadata = {
+      custom: {
+        gender: '',
+        brand: '',
+        category: '',
+        priceType: '',
+        id: '',
+      },
+    };
+    const expectedRanking = 0;
+    const ranking = getPageRanking(metadata);
+
+    expect(ranking).toBe(expectedRanking);
+  });
+});
+
+describe('getDefaultStrategy', () => {
+  it('should correctly apply commerce pages default strategy to the page result', () => {
+    const commercePagesResult = getDefaultStrategy(mockCommercePages);
+
+    expect(commercePagesResult).toMatchObject(defaultStrategyResult);
+  });
+});
+
+describe('getMergeStrategy', () => {
+  it('should correctly apply commerce pages merge strategy to the page result', () => {
+    const commercePagesResult = getMergeStrategy(mockCommercePages);
+
+    expect(commercePagesResult).toMatchObject(mergeStrategyResult);
+  });
+});
+
+describe('getRankedCommercePage', () => {
+  it('should correctly select the commerce pages strategy return the respective page result', () => {
+    const commercePagesResult = getRankedCommercePage(mockCommercePages);
+
+    expect(commercePagesResult).toMatchObject(defaultStrategyResult);
+
+    const mergeStrategy = getRankedCommercePage(mockCommercePages, 'merge');
+
+    expect(mergeStrategy).toMatchObject(mergeStrategyResult);
+  });
+});
 
 describe('buildContentGroupHash', () => {
   it('should correctly construct the correct hash a query object', () => {

--- a/packages/core/src/contents/redux/__tests__/reducer.test.js
+++ b/packages/core/src/contents/redux/__tests__/reducer.test.js
@@ -35,6 +35,15 @@ describe('contents redux reducer', () => {
       ).toEqual({ 'foo-biz': null });
     });
 
+    it('should handle GET_COMMERCE_PAGES_REQUEST action type', () => {
+      expect(
+        reducer(undefined, {
+          type: actionTypes.GET_COMMERCE_PAGES_REQUEST,
+          payload: { foo: 'bar', hash: 'foo-biz' },
+        }).error,
+      ).toEqual({ 'foo-biz': null });
+    });
+
     it('should handle GET_CONTENT_TYPES_REQUEST action type', () => {
       expect(
         reducer(undefined, {
@@ -47,6 +56,15 @@ describe('contents redux reducer', () => {
       expect(
         reducer(undefined, {
           type: actionTypes.GET_CONTENT_FAILURE,
+          payload: { error: 'Error - not loaded', hash: 'foo-biz' },
+        }).error,
+      ).toEqual({ 'foo-biz': 'Error - not loaded' });
+    });
+
+    it('should handle GET_COMMERCE_PAGES_FAILURE action type', () => {
+      expect(
+        reducer(undefined, {
+          type: actionTypes.GET_COMMERCE_PAGES_FAILURE,
           payload: { error: 'Error - not loaded', hash: 'foo-biz' },
         }).error,
       ).toEqual({ 'foo-biz': 'Error - not loaded' });
@@ -65,6 +83,15 @@ describe('contents redux reducer', () => {
       expect(
         reducer(undefined, {
           type: actionTypes.GET_CONTENT_SUCCESS,
+          payload: { result: { foo: 'bar' }, hash: 'foo-biz' },
+        }).error,
+      ).toEqual({});
+    });
+
+    it('should handle GET_COMMERCE_PAGES_SUCCESS action type', () => {
+      expect(
+        reducer(undefined, {
+          type: actionTypes.GET_COMMERCE_PAGES_SUCCESS,
           payload: { result: { foo: 'bar' }, hash: 'foo-biz' },
         }).error,
       ).toEqual({});
@@ -103,6 +130,15 @@ describe('contents redux reducer', () => {
       ).toEqual({ 'foo-biz': true });
     });
 
+    it('should handle GET_COMMERCE_PAGES_REQUEST action type', () => {
+      expect(
+        reducer(undefined, {
+          type: actionTypes.GET_COMMERCE_PAGES_REQUEST,
+          payload: { foo: 'bar', hash: 'foo-biz' },
+        }).isLoading,
+      ).toEqual({ 'foo-biz': true });
+    });
+
     it('should handle GET_CONTENT_FAILURE action type', () => {
       expect(
         reducer(undefined, {
@@ -112,10 +148,28 @@ describe('contents redux reducer', () => {
       ).toEqual({ 'foo-biz': undefined });
     });
 
+    it('should handle GET_COMMERCE_PAGES_FAILURE action type', () => {
+      expect(
+        reducer(undefined, {
+          type: actionTypes.GET_COMMERCE_PAGES_FAILURE,
+          payload: { error: '', hash: 'foo-biz' },
+        }).isLoading,
+      ).toEqual({ 'foo-biz': undefined });
+    });
+
     it('should handle GET_CONTENT_SUCCESS action type', () => {
       expect(
         reducer(undefined, {
           type: actionTypes.GET_CONTENT_SUCCESS,
+          payload: { result: { foo: 'bar' }, hash: 'foo-biz' },
+        }).isLoading,
+      ).toEqual({ 'foo-biz': false });
+    });
+
+    it('should handle GET_COMMERCE_PAGES_SUCCESS action type', () => {
+      expect(
+        reducer(undefined, {
+          type: actionTypes.GET_COMMERCE_PAGES_SUCCESS,
           payload: { result: { foo: 'bar' }, hash: 'foo-biz' },
         }).isLoading,
       ).toEqual({ 'foo-biz': false });

--- a/packages/core/src/contents/redux/actionTypes.js
+++ b/packages/core/src/contents/redux/actionTypes.js
@@ -4,6 +4,16 @@
  * @subcategory Actions
  */
 
+/** Action type dispatched when the get commerce pages request fails. */
+export const GET_COMMERCE_PAGES_FAILURE =
+  '@farfetch/blackout-core/GET_COMMERCE_PAGES_FAILURE';
+/** Action type dispatched when the get commerce pages request starts. */
+export const GET_COMMERCE_PAGES_REQUEST =
+  '@farfetch/blackout-core/GET_COMMERCE_PAGES_REQUEST';
+/** Action type dispatched when the get commerce pages request succeeds. */
+export const GET_COMMERCE_PAGES_SUCCESS =
+  '@farfetch/blackout-core/GET_COMMERCE_PAGES_SUCCESS';
+
 /** Action type dispatched when the get contents request fails. */
 export const GET_CONTENT_FAILURE =
   '@farfetch/blackout-core/GET_CONTENT_FAILURE';

--- a/packages/core/src/contents/redux/actions/__tests__/__snapshots__/doGetCommercePages.test.js.snap
+++ b/packages/core/src/contents/redux/actions/__tests__/__snapshots__/doGetCommercePages.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doGetCommercePages() action creator should create the correct actions for when the get commerce pages procedure is successful: Get commerce pages payload 1`] = `
+Object {
+  "meta": Object {
+    "query": Object {
+      "brand": 5030844,
+      "category": 136643,
+      "gender": 0,
+      "type": "LISTING",
+    },
+  },
+  "payload": Object {
+    "entities": Object {
+      "contentGroups": Object {
+        "commerce_pages!woman": Object {
+          "hash": "commerce_pages!woman",
+        },
+      },
+    },
+    "hash": "commerce_pages!woman",
+    "result": "commerce_pages!woman",
+  },
+  "type": "@farfetch/blackout-core/GET_COMMERCE_PAGES_SUCCESS",
+}
+`;

--- a/packages/core/src/contents/redux/actions/__tests__/doGetCommercePages.test.js
+++ b/packages/core/src/contents/redux/actions/__tests__/doGetCommercePages.test.js
@@ -1,0 +1,97 @@
+import {
+  commercePagesQuery,
+  expectedCommercePagesNormalizedPayload,
+  mockCommercePages,
+} from 'tests/__fixtures__/contents';
+import { doGetCommercePages } from '../';
+import { getRankedCommercePage } from '../../../utils';
+import { mockStore } from '../../../../../tests';
+import find from 'lodash/find';
+import reducer, { actionTypes } from '../../';
+
+jest.mock('../../../utils', () => ({
+  buildContentGroupHash: () => 'commerce_pages!woman',
+  buildSEOPathname: jest.fn(),
+  getRankedCommercePage: jest.fn(),
+}));
+
+const commercePagesMockStore = (state = {}) =>
+  mockStore({ contents: reducer() }, state);
+
+const normalizeSpy = jest.spyOn(require('normalizr'), 'normalize');
+const expectedConfig = undefined;
+let store;
+
+describe('doGetCommercePages() action creator', () => {
+  const getCommercePages = jest.fn();
+  const action = doGetCommercePages(getCommercePages, 'woman');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = commercePagesMockStore();
+  });
+
+  it('should create the correct actions for when the get commerce pages procedure fails', async () => {
+    const expectedError = new Error('Get commerce pages error');
+
+    getCommercePages.mockRejectedValueOnce(expectedError);
+
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(commercePagesQuery));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(getCommercePages).toHaveBeenCalledTimes(1);
+      expect(getCommercePages).toHaveBeenCalledWith(
+        commercePagesQuery,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining(
+            {
+              type: actionTypes.GET_COMMERCE_PAGES_FAILURE,
+            },
+            {
+              payload: { error: expectedError },
+              type: actionTypes.GET_COMMERCE_PAGES_FAILURE,
+            },
+          ),
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the get commerce pages procedure is successful', async () => {
+    getCommercePages.mockResolvedValueOnce(mockCommercePages);
+    getRankedCommercePage.mockResolvedValueOnce(mockCommercePages);
+
+    await store.dispatch(action(commercePagesQuery));
+
+    const actionResults = store.getActions();
+
+    expect(normalizeSpy).toHaveBeenCalledTimes(1);
+    expect(getCommercePages).toHaveBeenCalledTimes(1);
+    expect(getCommercePages).toHaveBeenCalledWith(
+      commercePagesQuery,
+      expectedConfig,
+    );
+    expect(store.getActions()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(
+          {
+            type: actionTypes.GET_COMMERCE_PAGES_REQUEST,
+          },
+          {
+            payload: expectedCommercePagesNormalizedPayload,
+            type: actionTypes.GET_COMMERCE_PAGES_SUCCESS,
+          },
+        ),
+      ]),
+    );
+    expect(
+      find(actionResults, { type: actionTypes.GET_COMMERCE_PAGES_SUCCESS }),
+    ).toMatchSnapshot('Get commerce pages payload');
+  });
+});

--- a/packages/core/src/contents/redux/actions/doGetCommercePages.js
+++ b/packages/core/src/contents/redux/actions/doGetCommercePages.js
@@ -1,0 +1,98 @@
+import * as actionTypes from '../actionTypes';
+import {
+  buildContentGroupHash,
+  GENDER,
+  getRankedCommercePage,
+  PRICETYPE,
+} from '../../utils';
+import { normalize } from 'normalizr';
+import contentGroup from '../../../entities/schemas/contentGroup';
+
+/**
+ * @typedef {string} Type
+ * @typedef {number} Gender
+ * @typedef {string} PriceType
+ */
+
+/**
+ * @enum {Type}
+ * @enum {Gender}
+ * @enum {PriceType}
+ */
+let Type = 'Product' | 'Listing' | 'Set';
+let Gender = GENDER;
+let PriceType = PRICETYPE;
+
+/**
+ * @typedef {object} GetCommercePagesQuery
+ * @property {Type}      type - Query by a page type (E.g. Product, Listing, Set).
+ * @property {number}    [id] - Query by a specified product or set identifier.
+ * @property {Gender}    [gender] - Query by a gender (E.g. 0 = Woman, 1 = Man, 2 = Unisex, 3 = Kid).
+ * @property {number}    [brand] - Query by a specified brand identifier.
+ * @property {string}    [category] - Query by a specified category identifiers, separated by commas
+ * (E.g. 139065,139088).
+ * @property {PriceType} [priceType] - Query by a specified price type, separated by commas (E.g. 0 = Full
+ * Price, 1 = Sale, 2 = PrivateSale).
+ * @property {number}    [sku] - Query by a specified sku identifier.
+ * @property {number}    [pageIndex] - Number of the page to get, starting at 1. The default is 1.
+ * @property {number}    [pageSize] - Size of each page, as a number between 1 and 180. The default is 60.
+ */
+
+/**
+ * @callback GetCommercePagesThunkFactory
+ * @param {GetCommercePagesQuery} query - Query object with commerce pages parameters to apply.
+ * @param {string} slug - List of codes that representing the content code (about-us|today-news|header|productId...).
+ * @param {string} [strategy] - String with the selected strategy for commerce pages.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Load commerce pages for a specific query object received.
+ *
+ * @function doGetCommercePages
+ * @memberof module:contents/actions
+ *
+ * @param {Function} getCommercePages - Get commerce pages client.
+ *
+ * @returns {GetCommercePagesThunkFactory} Thunk factory.
+ */
+export default getCommercePages =>
+  (query, slug, strategy, config) =>
+  async dispatch => {
+    const hash = buildContentGroupHash({
+      contentTypeCode: 'commerce_pages',
+      codes: slug,
+      pageSize: query?.pageSize,
+    });
+
+    dispatch({
+      meta: { query },
+      payload: { hash },
+      type: actionTypes.GET_COMMERCE_PAGES_REQUEST,
+    });
+
+    try {
+      const result = await getCommercePages(query, config);
+      const rankedResult = getRankedCommercePage(result, strategy);
+
+      dispatch({
+        meta: { query },
+        payload: {
+          ...normalize({ hash, ...rankedResult }, contentGroup),
+          hash,
+        },
+        type: actionTypes.GET_COMMERCE_PAGES_SUCCESS,
+      });
+    } catch (error) {
+      dispatch({
+        meta: { query },
+        payload: { error, hash },
+        type: actionTypes.GET_COMMERCE_PAGES_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/core/src/contents/redux/actions/index.js
+++ b/packages/core/src/contents/redux/actions/index.js
@@ -1,3 +1,12 @@
+/**
+ * Contents actions.
+ *
+ * @module contents/actions
+ * @category Contents
+ * @subcategory Actions
+ */
+
+export { default as doGetCommercePages } from './doGetCommercePages';
 export { default as doGetContent } from './doGetContent';
 export { default as doGetContentTypes } from './doGetContentTypes';
 export { default as doGetSEO } from './doGetSEO';

--- a/packages/core/src/contents/redux/reducer.js
+++ b/packages/core/src/contents/redux/reducer.js
@@ -25,11 +25,13 @@ export const INITIAL_STATE = {
 const error = (state = INITIAL_STATE.error, action) => {
   switch (action.type) {
     case actionTypes.GET_CONTENT_REQUEST:
+    case actionTypes.GET_COMMERCE_PAGES_REQUEST:
       return {
         ...state,
         [action.payload.hash]: null,
       };
     case actionTypes.GET_CONTENT_FAILURE:
+    case actionTypes.GET_COMMERCE_PAGES_FAILURE:
       return {
         ...state,
         [action.payload.hash]: action.payload.error,
@@ -45,16 +47,19 @@ const isLoading = (
 ) => {
   switch (action.type) {
     case actionTypes.GET_CONTENT_REQUEST:
+    case actionTypes.GET_COMMERCE_PAGES_REQUEST:
       return {
         ...state,
         [action.payload.hash]: true,
       };
     case actionTypes.GET_CONTENT_SUCCESS:
+    case actionTypes.GET_COMMERCE_PAGES_SUCCESS:
       return {
         ...state,
         [action.payload.hash]: false,
       };
     case actionTypes.GET_CONTENT_FAILURE:
+    case actionTypes.GET_COMMERCE_PAGES_FAILURE:
       return {
         ...state,
         [action.payload.hash]: undefined,

--- a/tests/__fixtures__/contents/commercePages.fixtures.js
+++ b/tests/__fixtures__/contents/commercePages.fixtures.js
@@ -1,0 +1,150 @@
+import { buildContentGroupHash } from '@farfetch/blackout-core/contents/utils';
+
+export const commercePagesQuery = {
+  type: 'LISTING',
+  gender: 0,
+  brand: 5030844,
+  category: 136643,
+};
+
+export const commercePagesHash = buildContentGroupHash(commercePagesQuery);
+
+export const mockCommercePages = {
+  number: 1,
+  totalPages: 1,
+  totalItems: 2,
+  entries: [
+    {
+      publicationId: 'dc9c0c95-9485-45c2-a76c-6923bb39b544',
+      versionId: '78f1922d-0ef1-46ed-b02c-ca541d0a0d80',
+      spaceCode: 'website',
+      contentTypeCode: 'commerce_pages',
+      environmentCode: 'live',
+      code: 'LISTING_gender_0/brand_5030844/category_136643',
+      target: {
+        contentzone: '10674',
+      },
+      metadata: {
+        custom: {
+          none: '',
+          id: '',
+          gender: '0',
+          brand: '5030844',
+          category: '136643',
+          slug: '',
+          priceType: '0',
+          sku: '',
+          type: 'LISTING',
+          eventDate: '0001-01-01T00:00:00Z',
+        },
+      },
+      publicationDate: '2021-08-20T15:40:39.0000132Z',
+      components: [
+        {
+          type: 'text',
+          name: 'Title',
+          displayOptions: {},
+        },
+        {
+          type: 'html',
+          content:
+            '<p>With delicate jewellery being her signature, Gigi Clozeau fine earrings are minature masterpieces. Taking inspiration from her beaded necklaces and bracelets, Gigi creates chain link huggie hoops using the same tiny resin beads, alongside diamond studs that can be worn as a pair or sepearately for a unique curated ear.</p>',
+          name: 'Listing Page Description',
+          displayOptions: {},
+        },
+      ],
+    },
+    {
+      publicationId: '264cb62c-04fe-4d54-a347-a9299568a227',
+      versionId: 'ce6b7c20-93cf-4f44-b80e-8447d0320f47',
+      spaceCode: 'website',
+      contentTypeCode: 'commerce_pages',
+      environmentCode: 'live',
+      code: 'LISTING_gender_0/brand_5030844',
+      target: {
+        contentzone: '10674',
+      },
+      metadata: {
+        custom: {
+          none: '',
+          id: '',
+          gender: '0',
+          brand: '5030844',
+          category: '',
+          slug: '',
+          priceType: '',
+          sku: '',
+          type: 'LISTING',
+          eventDate: '0001-01-01T00:00:00Z',
+        },
+      },
+      publicationDate: '2021-08-20T15:38:20.6658783Z',
+      components: [
+        {
+          type: 'text',
+          name: 'Title 2',
+          displayOptions: {},
+        },
+        {
+          type: 'html',
+          content:
+            '<p>What was once a keepsake from an island getaway has now become a permanent fixture in your jewellery collection thanks to Gigi Clozeau. Browsing her collection of anklets will keep you in the holiday mood all year round, so much so, you&#39;ll want one in every colour for every destination. Crafted from 18K gold, these delicate chains are perfectly accented with the addition of her signature resin beads in a mix of tropical colours. Browse Gigi Clozeau body jewellery below to be <em>vacay</em> ready at all times.</p>',
+          name: 'Listing Page Description 2',
+          displayOptions: {},
+        },
+      ],
+    },
+  ],
+};
+
+export const expectedCommercePagesNormalizedPayload = {
+  entities: {
+    contentGroups: {
+      [commercePagesHash]: {
+        hash: commercePagesHash,
+        number: 1,
+        totalPages: 1,
+        totalItems: 1,
+        entries: [mockCommercePages.entries[0].publicationId],
+      },
+    },
+    contents: {
+      [mockCommercePages.entries[0].publicationId]: {
+        ...mockCommercePages.entries[0],
+      },
+    },
+  },
+  contents: {
+    isLoading: {
+      [commercePagesHash]: false,
+    },
+    error: {},
+  },
+};
+
+export const defaultStrategyResult = {
+  number: 1,
+  totalPages: 1,
+  totalItems: 1,
+  entries: [
+    {
+      ...mockCommercePages.entries[0],
+      ranking: 1000010110,
+    },
+  ],
+};
+
+export const mergeStrategyResult = {
+  number: 1,
+  totalPages: 1,
+  totalItems: 1,
+  entries: [
+    {
+      ...mockCommercePages.entries[0],
+      components: [].concat(
+        mockCommercePages.entries[0].components,
+        mockCommercePages.entries[1].components,
+      ),
+    },
+  ],
+};

--- a/tests/__fixtures__/contents/index.js
+++ b/tests/__fixtures__/contents/index.js
@@ -1,3 +1,4 @@
+export * from './commercePages.fixtures';
 export * from './contentTypes.fixtures';
 export * from './contents.fixtures';
 export * from './seo.fixtures';


### PR DESCRIPTION
## Description

This feature adds the commerce pages logic into contents redux, more specifically:

. Add action doGetCommercePages
. Update Content reducer
. Add ranking logic to contents utils
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
