### PR TITLE
feat(react|redux): provide product aggregator id to bag

### DIFF
--- a/packages/react/src/bags/hooks/types/useBagItem.ts
+++ b/packages/react/src/bags/hooks/types/useBagItem.ts
@@ -15,13 +15,18 @@ import type {
 import type { Error } from '@farfetch/blackout-client/types';
 
 export type HandleAddOrUpdateItemType = ({
-  product,
   customAttributes,
+  product,
+  productAggregatorId,
   quantity,
   size,
 }: {
-  product?: ProductEntity;
   customAttributes?: CustomAttributesAdapted;
+  product?: ProductEntity;
+  productAggregatorId?: Exclude<
+    BagItemHydrated['productAggregator'],
+    null
+  >['id'];
   quantity?: number;
   size?: SizeAdapted;
 }) => Promise<void>;

--- a/packages/react/src/bags/hooks/useBagItem.ts
+++ b/packages/react/src/bags/hooks/useBagItem.ts
@@ -86,6 +86,8 @@ const useBagItem: UseBagItem = bagItemId => {
    * @param {object} [item.product=bagItem.product] - Product of the bag item
    * to handle. Defaults to the product of the bag item that instantiated the
    * hook.
+   * @param {number} [item.productAggregatorId=bagItem.productAggregator.id] -
+   * Product aggregator identifier.
    * @param {number} [item.quantity=bagItem.quantity] - Quantity of the
    * product to add/update. Defaults to the quantity of the bag item that
    * instantiated the hook.
@@ -96,8 +98,10 @@ const useBagItem: UseBagItem = bagItemId => {
   const handleAddOrUpdateItem: HandleAddOrUpdateItemType = async ({
     customAttributes = bagItem?.customAttributes,
     product = bagItem?.product,
+    productAggregatorId = bagItem?.productAggregator?.id,
     quantity = bagItem?.quantity,
     size = productSize,
+    ...otherParams
   }) => {
     let quantityToHandle = quantity;
 
@@ -119,8 +123,10 @@ const useBagItem: UseBagItem = bagItemId => {
         customAttributes,
         merchantId,
         product,
+        productAggregatorId,
         quantity: quantityToAdd,
         size,
+        ...otherParams,
       });
       // Checks if the item we want to add is already in bag
       // by comparing the bag items' hash
@@ -329,6 +335,7 @@ const useBagItem: UseBagItem = bagItemId => {
         merchantId,
         product: bagItem.product,
         quantity: quantityToManage,
+        productAggregatorId: bagItem?.productAggregator?.id,
         size,
       });
 

--- a/packages/redux/src/bags/utils/__tests__/buildBagItem.test.ts
+++ b/packages/redux/src/bags/utils/__tests__/buildBagItem.test.ts
@@ -1,16 +1,21 @@
 import { buildBagItem } from '../';
-import { mockBagItem } from 'tests/__fixtures__/bags';
+import { mockBagItem, mockProductAggregatorId } from 'tests/__fixtures__/bags';
 
 describe('buildBagItem()', () => {
   it('should return a valid bag item object', () => {
     expect(
       buildBagItem({
+        customAttributes: mockBagItem.customAttributes,
+        merchantId: mockBagItem.merchantId,
         product: mockBagItem.product,
-        ...mockBagItem,
+        quantity: mockBagItem.quantity,
+        size: mockBagItem.size,
       }),
     ).toEqual({
+      authCode: undefined,
       customAttributes: mockBagItem.customAttributes,
       merchantId: mockBagItem.merchantId,
+      productAggregatorId: undefined,
       productId: mockBagItem.product.id,
       quantity: mockBagItem.quantity,
       scale: mockBagItem.size.scale,
@@ -19,19 +24,18 @@ describe('buildBagItem()', () => {
   });
 
   it('should return a valid bag item object with a default `quantity`', () => {
-    const {
-      quantity, // eslint-disable-line  @typescript-eslint/no-unused-vars
-      ...bagItem
-    } = mockBagItem;
-
     expect(
       buildBagItem({
+        customAttributes: mockBagItem.customAttributes,
+        merchantId: mockBagItem.merchantId,
         product: mockBagItem.product,
-        ...bagItem,
+        size: mockBagItem.size,
       }),
     ).toEqual({
+      authCode: undefined,
       customAttributes: mockBagItem.customAttributes,
       merchantId: mockBagItem.merchantId,
+      productAggregatorId: undefined,
       productId: mockBagItem.product.id,
       quantity: 1,
       scale: mockBagItem.size.scale,
@@ -40,19 +44,18 @@ describe('buildBagItem()', () => {
   });
 
   it('should return a valid bag item object with default `customAttributes`', () => {
-    const {
-      customAttributes, // eslint-disable-line  @typescript-eslint/no-unused-vars
-      ...bagItem
-    } = mockBagItem;
-
     expect(
       buildBagItem({
+        merchantId: mockBagItem.merchantId,
         product: mockBagItem.product,
-        ...bagItem,
+        quantity: mockBagItem.quantity,
+        size: mockBagItem.size,
       }),
     ).toEqual({
+      authCode: undefined,
       customAttributes: '',
       merchantId: mockBagItem.merchantId,
+      productAggregatorId: undefined,
       productId: mockBagItem.product.id,
       quantity: mockBagItem.quantity,
       scale: mockBagItem.size.scale,
@@ -66,12 +69,39 @@ describe('buildBagItem()', () => {
     expect(
       buildBagItem({
         authCode: mockAuthCode,
-        ...mockBagItem,
+        customAttributes: mockBagItem.customAttributes,
+        merchantId: mockBagItem.merchantId,
+        product: mockBagItem.product,
+        quantity: mockBagItem.quantity,
+        size: mockBagItem.size,
       }),
     ).toEqual({
       authCode: mockAuthCode,
       customAttributes: mockBagItem.customAttributes,
       merchantId: mockBagItem.merchantId,
+      productAggregatorId: undefined,
+      productId: mockBagItem.product.id,
+      quantity: mockBagItem.quantity,
+      scale: mockBagItem.size.scale,
+      size: mockBagItem.size.id,
+    });
+  });
+
+  it('should return a valid bag item object with a `productAggregatorId`', () => {
+    expect(
+      buildBagItem({
+        productAggregatorId: mockProductAggregatorId,
+        customAttributes: mockBagItem.customAttributes,
+        merchantId: mockBagItem.merchantId,
+        product: mockBagItem.product,
+        quantity: mockBagItem.quantity,
+        size: mockBagItem.size,
+      }),
+    ).toEqual({
+      authCode: undefined,
+      customAttributes: mockBagItem.customAttributes,
+      merchantId: mockBagItem.merchantId,
+      productAggregatorId: mockProductAggregatorId,
       productId: mockBagItem.product.id,
       quantity: mockBagItem.quantity,
       scale: mockBagItem.size.scale,

--- a/packages/redux/src/bags/utils/__tests__/generateBagItemHash.test.ts
+++ b/packages/redux/src/bags/utils/__tests__/generateBagItemHash.test.ts
@@ -1,5 +1,6 @@
 import { generateBagItemHash } from '..';
 import { mockBagItem } from 'tests/__fixtures__/bags';
+import omit from 'lodash/omit';
 
 describe('generateBagItemHash()', () => {
   describe('error handling', () => {
@@ -61,15 +62,32 @@ describe('generateBagItemHash()', () => {
   });
 
   describe('hash creation', () => {
-    const baseHashPattern = `${mockBagItem.merchantId}!${mockBagItem.product.id}!${mockBagItem.sizeId}!${mockBagItem.size.scale}!`;
+    const baseHashPattern = `${mockBagItem.merchantId}!${mockBagItem.product.id}!${mockBagItem.sizeId}!${mockBagItem.size.scale}`;
 
-    it('should create a valid hash when no custom attributes are provided', () => {
-      const {
-        customAttributes, // eslint-disable-line  @typescript-eslint/no-unused-vars
-        ...item
-      } = mockBagItem;
+    it('should create a valid hash when no other parameters are provided', () => {
+      expect(
+        generateBagItemHash(
+          omit(mockBagItem, ['customAttributes', 'productAggregator']),
+        ),
+      ).toBe(baseHashPattern);
+    });
 
-      expect(generateBagItemHash(item)).toBe(baseHashPattern);
+    it('should create a valid hash when `customAttributes` are provided', () => {
+      expect(
+        generateBagItemHash(omit(mockBagItem, ['productAggregator'])),
+      ).toBe(`${baseHashPattern}!${mockBagItem.customAttributes}`);
+    });
+
+    it('should create a valid hash when a `productAggregatorId` is provided', () => {
+      expect(generateBagItemHash(omit(mockBagItem, ['customAttributes']))).toBe(
+        `${baseHashPattern}!${mockBagItem.productAggregator.id}`,
+      );
+    });
+
+    it('should create a valid hash from a valid bag item', () => {
+      expect(generateBagItemHash(mockBagItem)).toBe(
+        `${baseHashPattern}!${mockBagItem.customAttributes}!${mockBagItem.productAggregator.id}`,
+      );
     });
   });
 });

--- a/packages/redux/src/bags/utils/buildBagItem.ts
+++ b/packages/redux/src/bags/utils/buildBagItem.ts
@@ -13,6 +13,7 @@ type BuildBagItemParams = {
   customAttributes?: CustomAttributesAdapted;
   merchantId?: number;
   product: ProductEntity;
+  productAggregatorId?: Exclude<BagItemEntity['productAggregator'], null>['id'];
   quantity?: number;
   size: SizeAdapted | BagItemEntity['size'];
 };
@@ -38,6 +39,7 @@ type BuildBagItem = (arg0: BuildBagItemParams) => {
  * @param {string} [data.customAttributes=''] - Custom attributes.
  * @param {number} [data.merchantId] - Specific merchant id.
  * @param {object} data.product - Product with all information.
+ * @param {number} [data.productAggregatorId] - Product bundle aggregator id.
  * @param {number} [data.quantity=1] - Number of units.
  * @param {object} data.size - Size information.
  *
@@ -48,8 +50,10 @@ const buildBagItem: BuildBagItem = ({
   customAttributes = '',
   merchantId,
   product,
+  productAggregatorId,
   quantity = 1,
   size,
+  ...otherParams
 }) => {
   const sizeHydrated = product.sizes?.find(({ id }) => id === size.id);
 
@@ -58,9 +62,11 @@ const buildBagItem: BuildBagItem = ({
     customAttributes,
     merchantId: merchantId || sizeHydrated?.stock[0]?.merchantId,
     productId: product.id,
+    productAggregatorId,
     quantity,
     scale: size.scale,
     size: size.id,
+    ...otherParams,
   };
 };
 

--- a/packages/redux/src/bags/utils/generateBagItemHash.ts
+++ b/packages/redux/src/bags/utils/generateBagItemHash.ts
@@ -11,6 +11,8 @@ type Params = Partial<{
   customAttributes: CustomAttributesAdapted | string;
   merchantId: MerchantEntity['id'];
   merchant: MerchantEntity['id'];
+  productAggregator: BagItemEntity['productAggregator'];
+  productAggregatorId: Exclude<BagItemEntity['productAggregator'], null>['id'];
   size: BagItemEntity['size'] | number;
   scale: string | number;
 }>;
@@ -30,6 +32,8 @@ const generateBagItemHash = (params: Params): string => {
   let sizeId = params.size;
   let sizeScale = params.scale;
   const customAttributes = params.customAttributes;
+  const productAggregatorId =
+    params.productAggregatorId || params.productAggregator?.id;
 
   if (typeof params.size === 'object') {
     sizeId = params.size.id;
@@ -42,9 +46,9 @@ const generateBagItemHash = (params: Params): string => {
     );
   }
 
-  return `${merchantId}!${productId}!${sizeId}!${sizeScale}!${
-    customAttributes || ''
-  }`;
+  return `${merchantId}!${productId}!${sizeId}!${sizeScale}${
+    customAttributes ? `!${customAttributes}` : ''
+  }${productAggregatorId ? `!${productAggregatorId}` : ''}`;
 };
 
 export default generateBagItemHash;

--- a/tests/__fixtures__/bags/bag.fixtures.ts
+++ b/tests/__fixtures__/bags/bag.fixtures.ts
@@ -110,7 +110,12 @@ export const mockState = {
   entities: {
     bagItems: {
       [mockBagItemId]: mockBagItemEntity,
-      101: { ...mockBagItemEntity, id: 101, customAttributes: null },
+      101: {
+        ...mockBagItemEntity,
+        id: 101,
+        customAttributes: null,
+        productAggregator: null,
+      },
       102: {
         id: 102,
         product: 1002,

--- a/tests/__fixtures__/bags/bagItem.fixtures.ts
+++ b/tests/__fixtures__/bags/bagItem.fixtures.ts
@@ -1,6 +1,7 @@
 import { mockMerchantId, mockProduct, mockProductId } from '../products';
 
 export const mockBagItemId = 134;
+export const mockProductAggregatorId = 321;
 
 export const mockBagItem = {
   id: mockBagItemId,
@@ -22,6 +23,10 @@ export const mockBagItem = {
   sizeId: 23,
   isAvailable: true,
   product: mockProduct,
+  productAggregator: {
+    bundleSlug: '/slug',
+    id: mockProductAggregatorId,
+  },
 };
 
 export const mockBagItemEntity = {


### PR DESCRIPTION
## Description

This adds the parameter `productAggregatorId` to add to bag requests handled by the `useBagItem` hook and to `buildBagItem` util. It also allows the possibility to receive other future parameters.

It also modifies the `generateBagItemHash` method to include `productAggregatorId` so we can differentiate between items in
different bundles.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
