### PR TITLE
fix(core): remove entries in server initial state of product/details

### DIFF
--- a/packages/core/src/products/details/redux/__tests__/__snapshots__/serverInitialState.test.js.snap
+++ b/packages/core/src/products/details/redux/__tests__/__snapshots__/serverInitialState.test.js.snap
@@ -3,66 +3,13 @@
 exports[`details serverInitialState() should initialize server state 1`] = `
 Object {
   "details": Object {
-    "attributes": Object {
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
-    "colorGrouping": Object {
-      "currentPageIndex": Object {},
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
     "error": Object {},
-    "fittings": Object {
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
     "id": 11766695,
     "isHydrated": Object {
       "11766695": true,
     },
     "isLoading": Object {
       "11766695": false,
-    },
-    "measurements": Object {
-      "error": Object {},
-      "isLoading": Object {},
-    },
-    "merchantsLocations": Object {
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
-    "recommendedSets": Object {
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
-    "sets": Object {
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
-    "sizeScale": Object {
-      "error": null,
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
-    "sizeguides": Object {
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
     },
     "sizes": Object {
       "error": Object {},

--- a/packages/core/src/products/details/redux/serverInitialState.js
+++ b/packages/core/src/products/details/redux/serverInitialState.js
@@ -75,26 +75,7 @@ export default ({ model, options: { productImgQueryParam } = {} }) => {
 
   return {
     details: {
-      attributes: {
-        error: {},
-        isLoading: {
-          [id]: false,
-        },
-      },
-      colorGrouping: {
-        currentPageIndex: {},
-        error: {},
-        isLoading: {
-          [id]: false,
-        },
-      },
       error: {},
-      fittings: {
-        error: {},
-        isLoading: {
-          [id]: false,
-        },
-      },
       id,
       isHydrated: {
         [id]: true,
@@ -102,42 +83,8 @@ export default ({ model, options: { productImgQueryParam } = {} }) => {
       isLoading: {
         [id]: false,
       },
-      measurements: {
-        error: {},
-        isLoading: {},
-      },
-      merchantsLocations: {
-        error: {},
-        isLoading: {
-          [id]: false,
-        },
-      },
-      recommendedSets: {
-        error: {},
-        isLoading: {
-          [id]: false,
-        },
-      },
-      sets: {
-        error: {},
-        isLoading: {
-          [id]: false,
-        },
-      },
-      sizeguides: {
-        error: {},
-        isLoading: {
-          [id]: false,
-        },
-      },
       sizes: {
         error: {},
-        isLoading: {
-          [id]: false,
-        },
-      },
-      sizeScale: {
-        error: null,
         isLoading: {
           [id]: false,
         },


### PR DESCRIPTION
## Description
This removes the entries `attributes`, `colorGrouping`, `fittings`, `measurements`, `merchantsLocations`, `recommendedSets`, `sets`, `sizeGuides` and `sizeScale` from `serverInitialState` to avoid having false positives in the `isLoading` and `isFetched` state when using server side rendering.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
