### PR TITLE
fix(redux): remove entries in server initial state of product/details

### DIFF
--- a/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/index.test.ts.snap
@@ -73,22 +73,10 @@ Object {
     },
   },
   "products": Object {
-    "attributes": Object {
-      "error": Object {},
-      "isLoading": Object {},
-    },
-    "colorGrouping": Object {
-      "error": Object {},
-      "isLoading": Object {},
-    },
     "details": Object {
       "error": Object {},
       "id": null,
       "isHydrated": Object {},
-      "isLoading": Object {},
-    },
-    "fittings": Object {
-      "error": Object {},
       "isLoading": Object {},
     },
     "lists": Object {
@@ -101,19 +89,7 @@ Object {
         "listing/woman?pageindex=1&sort=price&sortdirection=asc": false,
       },
     },
-    "measurements": Object {
-      "error": Object {},
-      "isLoading": Object {},
-    },
-    "sizeGuides": Object {
-      "error": Object {},
-      "isLoading": Object {},
-    },
     "sizes": Object {
-      "error": Object {},
-      "isLoading": Object {},
-    },
-    "variantsByMerchantsLocations": Object {
       "error": Object {},
       "isLoading": Object {},
     },
@@ -282,18 +258,6 @@ Object {
     },
   },
   "products": Object {
-    "attributes": Object {
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
-    "colorGrouping": Object {
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
     "details": Object {
       "error": Object {},
       "id": 11766695,
@@ -304,35 +268,13 @@ Object {
         "11766695": false,
       },
     },
-    "fittings": Object {
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
     "lists": Object {
       "error": Object {},
       "hash": null,
       "isHydrated": Object {},
       "isLoading": Object {},
     },
-    "measurements": Object {
-      "error": Object {},
-      "isLoading": Object {},
-    },
-    "sizeGuides": Object {
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
     "sizes": Object {
-      "error": Object {},
-      "isLoading": Object {
-        "11766695": false,
-      },
-    },
-    "variantsByMerchantsLocations": Object {
       "error": Object {},
       "isLoading": Object {
         "11766695": false,

--- a/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/products.test.ts.snap
+++ b/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/products.test.ts.snap
@@ -2,37 +2,13 @@
 
 exports[`products serverInitialState() should initialize server state for a non products related page 1`] = `
 Object {
-  "attributes": Object {
-    "error": Object {},
-    "isLoading": Object {},
-  },
-  "colorGrouping": Object {
-    "error": Object {},
-    "isLoading": Object {},
-  },
   "details": Object {
     "error": Object {},
     "id": null,
     "isHydrated": Object {},
     "isLoading": Object {},
   },
-  "fittings": Object {
-    "error": Object {},
-    "isLoading": Object {},
-  },
-  "measurements": Object {
-    "error": Object {},
-    "isLoading": Object {},
-  },
-  "sizeGuides": Object {
-    "error": Object {},
-    "isLoading": Object {},
-  },
   "sizes": Object {
-    "error": Object {},
-    "isLoading": Object {},
-  },
-  "variantsByMerchantsLocations": Object {
     "error": Object {},
     "isLoading": Object {},
   },
@@ -41,18 +17,6 @@ Object {
 
 exports[`products serverInitialState() should initialize server state for products 1`] = `
 Object {
-  "attributes": Object {
-    "error": Object {},
-    "isLoading": Object {
-      "11766695": false,
-    },
-  },
-  "colorGrouping": Object {
-    "error": Object {},
-    "isLoading": Object {
-      "11766695": false,
-    },
-  },
   "details": Object {
     "error": Object {},
     "id": 11766695,
@@ -221,29 +185,7 @@ Object {
       },
     },
   },
-  "fittings": Object {
-    "error": Object {},
-    "isLoading": Object {
-      "11766695": false,
-    },
-  },
-  "measurements": Object {
-    "error": Object {},
-    "isLoading": Object {},
-  },
-  "sizeGuides": Object {
-    "error": Object {},
-    "isLoading": Object {
-      "11766695": false,
-    },
-  },
   "sizes": Object {
-    "error": Object {},
-    "isLoading": Object {
-      "11766695": false,
-    },
-  },
-  "variantsByMerchantsLocations": Object {
     "error": Object {},
     "isLoading": Object {
       "11766695": false,

--- a/packages/redux/src/products/serverInitialState/products.ts
+++ b/packages/redux/src/products/serverInitialState/products.ts
@@ -1,12 +1,6 @@
-import { INITIAL_STATE as ATTRIBUTES_INITIAL_STATE } from '../reducer/attributes';
-import { INITIAL_STATE as COLOR_GROUPING_INITIAL_STATE } from '../reducer/colorGrouping';
 import { INITIAL_STATE as DETAILS_INITIAL_STATE } from '../reducer/details';
-import { INITIAL_STATE as FITTINGS_INITIAL_STATE } from '../reducer/fittings';
-import { INITIAL_STATE as MEASUREMENTS_INITIAL_STATE } from '../reducer/measurements';
 import { normalize } from 'normalizr';
-import { INITIAL_STATE as SIZE_GUIDES_INITIAL_STATE } from '../reducer/sizeGuides';
 import { INITIAL_STATE as SIZES_INITIAL_STATE } from '../reducer/sizes';
-import { INITIAL_STATE as VARIANTS_BY_MERCHANTS_LOCATIONS_INITIAL_STATE } from '../reducer/variantsByMerchantsLocations';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import productSchema from '../../entities/schemas/product';
@@ -32,29 +26,16 @@ const serverInitialState = ({
   model: Model;
   options?: { productImgQueryParam?: string };
 }): {
-  attributes: StoreState['products']['attributes'];
-  colorGrouping: StoreState['products']['colorGrouping'];
   details: StoreState['products']['details'];
   entities?: StoreState['entities'];
-  fittings: StoreState['products']['fittings'];
-  measurements: StoreState['products']['measurements'];
-  sizeGuides: StoreState['products']['sizeGuides'];
   sizes: StoreState['products']['sizes'];
-  variantsByMerchantsLocations: StoreState['products']['variantsByMerchantsLocations'];
 } => {
   // Check if a model object is of a product detail page (type === 'Product')
   // - if not, do nothing
   if (isEmpty(model) || get(model, 'dataLayer.general.type') !== 'Product') {
     return {
-      attributes: ATTRIBUTES_INITIAL_STATE,
-      colorGrouping: COLOR_GROUPING_INITIAL_STATE,
       details: DETAILS_INITIAL_STATE,
-      fittings: FITTINGS_INITIAL_STATE,
-      measurements: MEASUREMENTS_INITIAL_STATE,
-      sizeGuides: SIZE_GUIDES_INITIAL_STATE,
       sizes: SIZES_INITIAL_STATE,
-      variantsByMerchantsLocations:
-        VARIANTS_BY_MERCHANTS_LOCATIONS_INITIAL_STATE,
     };
   }
 
@@ -111,18 +92,6 @@ const serverInitialState = ({
   const { result: id, entities } = normalize(productInfo, productSchema);
 
   return {
-    attributes: {
-      error: {},
-      isLoading: {
-        [id]: false,
-      },
-    },
-    colorGrouping: {
-      error: {},
-      isLoading: {
-        [id]: false,
-      },
-    },
     details: {
       error: {},
       id,
@@ -134,29 +103,7 @@ const serverInitialState = ({
       },
     },
     entities,
-    fittings: {
-      error: {},
-      isLoading: {
-        [id]: false,
-      },
-    },
-    measurements: {
-      error: {},
-      isLoading: {},
-    },
-    sizeGuides: {
-      error: {},
-      isLoading: {
-        [id]: false,
-      },
-    },
     sizes: {
-      error: {},
-      isLoading: {
-        [id]: false,
-      },
-    },
-    variantsByMerchantsLocations: {
       error: {},
       isLoading: {
         [id]: false,


### PR DESCRIPTION
## Description
This removes the entries `attributes`, `colorGrouping`, `fittings`, `measurements`,
`sizeguides` and `variantsByMerchantsLocations` from serverInitialState to avoid having false
positives in the `isLoading` and `isFetched` status when using server-side rendering.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
