### PR TITLE
fix(core): make `getItemWholeQuantity` return 0 when there's no bag

### DIFF
--- a/packages/core/src/bags/redux/__tests__/selectors.test.js
+++ b/packages/core/src/bags/redux/__tests__/selectors.test.js
@@ -450,5 +450,24 @@ describe('bags redux selectors', () => {
         }),
       ).toBe(expectedResult);
     });
+
+    it('should return 0 if there is no bag', () => {
+      const mockStateWithoutBag = {
+        ...mockState,
+        bag: {},
+        entities: {
+          ...mockState.entities,
+          bag: {},
+          bagItems: {},
+        },
+      };
+
+      expect(
+        selectors.getItemWholeQuantity(mockStateWithoutBag, {
+          product: { id: mockProductId },
+          size: 1,
+        }),
+      ).toBe(0);
+    });
   });
 });

--- a/packages/core/src/bags/redux/selectors.js
+++ b/packages/core/src/bags/redux/selectors.js
@@ -356,6 +356,19 @@ export const getBagItemAvailableSizes = createSelector(
 );
 
 /**
+ * @typedef {Function} GetItemInBag
+ *
+ * @alias GetItemInBag
+ *
+ * @param   {object} productParams - Product params needed to this selector.
+ * @param   {object} productParams.product - Product object with its id.
+ * @param   {object} productParams.size - Size selected, with stock and scale.
+ * @param   {object} [productParams.customAttributes] - Custom attributes of the product.
+ *
+ * @returns {object | undefined} - Bag item if it exists, undefined otherwise.
+ */
+
+/**
  * Creates a function responsible for checking if a certain product exists in the bag.
  * This selector uses the `buildBagItem` util, so there are some `productParams`
  * that are optional like `quantity` and `customAttributes`, because in the `buildBagItem`
@@ -364,12 +377,8 @@ export const getBagItemAvailableSizes = createSelector(
  * @function
  *
  * @param   {object} state - Application state.
- * @param   {object} productParams - Product params needed to this selector.
- * @param   {object} productParams.product - Product object with its id.
- * @param   {object} productParams.size - Size selected, with stock and scale.
- * @param   {object} [productParams.customAttributes] - Custom attributes of the product.
  *
- * @returns {Function} - Function that returns an item object in the bag if search had results, undefined otherwise.
+ * @returns {GetItemInBag} - Function that returns an item object in the bag if search had results, undefined otherwise.
  *
  * @example
  * import { createGetItemInBag } from '@farfetch/blackout-core/bags/redux';
@@ -440,7 +449,7 @@ export const getItemWholeQuantity = (state, bagItem) => {
   const productId = bagItem.product.id;
   const bagItems = getBagItems(state);
 
-  const quantity = bagItems.reduce((acc, item) => {
+  const quantity = bagItems?.reduce((acc, item) => {
     if (item.product.id === productId && item.size.id === bagItem.size.id) {
       return acc + item.quantity;
     }
@@ -448,5 +457,5 @@ export const getItemWholeQuantity = (state, bagItem) => {
     return acc;
   }, 0);
 
-  return quantity;
+  return quantity || 0;
 };


### PR DESCRIPTION
## Description
The `getItemWholeQuantity` selector uses internally the `getBagItems` selector
and then iterates through the bag items to get the whole quantity. When the `getBagItems`
runs before the bag is fetched, its return value is `undefined` by default, which throws
an error when trying to `reduce`. This fix avoids that and makes this selector
return 0 if there are no bag or bag items.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->



<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
