### PR TITLE
fix(redux): make `getBagItems` return empty array

### DIFF
--- a/packages/redux/src/bags/__tests__/selectors.test.ts
+++ b/packages/redux/src/bags/__tests__/selectors.test.ts
@@ -107,6 +107,31 @@ describe('bags redux selectors', () => {
 
       expect(selectors.getBagItems(mockState)).toEqual(expectedResult);
     });
+
+    it('should return an empty array when there are no bag or bag items', () => {
+      const mockStateWithoutBagItems = {
+        ...mockState,
+        bag: {
+          error: null,
+          id: null,
+          isLoading: false,
+          result: null,
+          items: {
+            ids: null,
+            item: {
+              error: {},
+              isLoading: {},
+            },
+          },
+        },
+        entities: {
+          ...mockState.entities,
+          bagItems: {},
+        },
+      };
+
+      expect(selectors.getBagItems(mockStateWithoutBagItems)).toEqual([]);
+    });
   });
 
   describe('getBagItemsCounter()', () => {
@@ -198,17 +223,17 @@ describe('bags redux selectors', () => {
 
   describe('getBagItemsUnavailable()', () => {
     it('should not return any items if all items are available', () => {
-      expect(selectors.getBagItemsUnavailable(mockState)).toHaveLength(0);
+      expect(selectors.getBagItemsUnavailable(mockState)).toEqual([]);
     });
 
-    it('should return null if there is no bag loaded', () => {
+    it('should return an empty array if there is no bag loaded', () => {
       expect(
         // @ts-expect-error Changing only what's necessary for this test
         selectors.getBagItemsUnavailable({
           bag: fromBag.INITIAL_STATE,
           entities: {},
         }),
-      ).toBeUndefined();
+      ).toEqual([]);
     });
 
     it('should return an empty array if bag items does not exist', () => {
@@ -224,7 +249,7 @@ describe('bags redux selectors', () => {
           },
           entities: {},
         }),
-      ).toHaveLength(0);
+      ).toEqual([]);
     });
 
     it('should return a list with the unavailable items', () => {

--- a/packages/redux/src/bags/selectors.ts
+++ b/packages/redux/src/bags/selectors.ts
@@ -171,7 +171,7 @@ export const getBagItemsIds = (state: StoreState): BagItemsState['ids'] =>
  *
  * @param {object} state - Application state.
  *
- * @returns {Array|undefined} - List of each bag item entity (with the respective products) from the current user's bag.
+ * @returns {Array} - List of each bag item entity (with the respective products) from the current user's bag.
  *
  * @example
  * import { getBagItems } from '@farfetch/blackout-redux/bags';
@@ -186,7 +186,7 @@ export const getBagItems = createSelector(
     (state: StoreState) => getEntities(state, 'bagItems'),
     (state: StoreState) => getEntities(state, 'products'),
   ],
-  (bagItemsIds, bagItems, products): BagItemHydrated[] | undefined =>
+  (bagItemsIds, bagItems, products): BagItemHydrated[] =>
     bagItemsIds?.reduce<BagItemHydrated[]>((acc, bagItemId) => {
       const bagItem = bagItems?.[bagItemId];
       const productId = bagItem?.product;
@@ -202,7 +202,7 @@ export const getBagItems = createSelector(
       }
 
       return acc;
-    }, []),
+    }, []) || [],
 );
 
 /**
@@ -270,7 +270,7 @@ export const getBagItemsCounter = (
  * });
  */
 export const getBagItemsUnavailable = createSelector([getBagItems], bagItems =>
-  bagItems?.filter(bagItem => !bagItem?.isAvailable),
+  bagItems.filter(bagItem => !bagItem?.isAvailable),
 );
 
 /**
@@ -307,7 +307,7 @@ export const getBagTotalQuantity = (
 ): number => {
   const bagItems = getBagItems(state);
 
-  if (!bagItems || bagItems.length === 0) {
+  if (bagItems.length === 0) {
     return 0;
   }
 


### PR DESCRIPTION
## Description

Our `getBagItems` selector is returning `undefined` when the bag or bag items don't exist but that
output breaks consistency and might create an error in other selectors that use `getBagItems` without
validating if it is an array or undefined. To validate if the bag is fetched or not we have other,
more specific, selectors.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
