### PR TITLE
fix(core|react): handle guest users expired in authentication provider

### DIFF
--- a/packages/core/src/helpers/client/interceptors/authentication/AuthenticationConfigOptions.js
+++ b/packages/core/src/helpers/client/interceptors/authentication/AuthenticationConfigOptions.js
@@ -22,5 +22,24 @@ export default {
   IsClientCredentialsTokenRequest: '__isClientCredentialsTokenRequest',
   // This indicates a callback to be called with the access token used for the request.
   // Can be used to match request responses with the current active token.
+  // This is useful when you do not have access to the axios's config object directly.
   UsedAccessTokenCallback: '__usedAccessTokenCallback',
+  // This indicates that the current request is to get the current user's profile.
+  // Used to set the user id to the current guest/user tokens.
+  IsGetUserProfileRequest: '__isGetUserProfileRequest',
+  // This indicates the access token used in the request.
+  // Useful to query if the request is being done with a guest or authenticated user token.
+  UsedAccessToken: '__usedAccessToken',
+  // This indicates that the current request is a login request.
+  // Used to change the tokens context.
+  IsLoginRequest: '__isLoginRequest',
+  // This indicates that the current request is a logout request.
+  // Used to change the tokens context.
+  IsLogoutRequest: '__isLogoutRequest',
+  // This value is set on the request by the token manager
+  // after it evaluated if the request is supposed to need
+  // authentication or not.
+  NeedsAuthentication: '__needsAuthentication',
+  // This indicates the kind of the used access token for a request.
+  UsedAccessTokenKind: '__usedAccessTokenKind',
 };

--- a/packages/core/src/helpers/client/interceptors/authentication/errors.js
+++ b/packages/core/src/helpers/client/interceptors/authentication/errors.js
@@ -11,11 +11,7 @@ export class UserSessionExpiredError extends AuthenticationManagerBaseError {
   }
 }
 
-export class RefreshAccessTokenError extends AuthenticationManagerBaseError {
-  constructor(message, originalError) {
-    super(message, originalError);
-  }
-}
+export class RefreshAccessTokenError extends AuthenticationManagerBaseError {}
 
 export class RefreshGuestUserAccessTokenError extends RefreshAccessTokenError {
   constructor(originalError) {
@@ -31,6 +27,7 @@ export class RefreshUserAccessTokenError extends RefreshAccessTokenError {
 
 export class RefreshClientCredentialsAccessTokenError extends RefreshAccessTokenError {
   constructor(originalError) {
+    /* istanbul ignore next */
     super('Unable to refresh client credentials access token.', originalError);
   }
 }

--- a/packages/core/src/helpers/client/interceptors/authentication/token-providers/TokenProvider.js
+++ b/packages/core/src/helpers/client/interceptors/authentication/token-providers/TokenProvider.js
@@ -1,6 +1,5 @@
 import isEqual from 'lodash/isEqual';
 import TokenData from './TokenData';
-import TokenKinds from './TokenKinds';
 
 let TokenListenerIdInternalCount = 0;
 
@@ -83,10 +82,20 @@ class TokenProvider {
    * Gets the kind of tokens that are supported by this
    * provider.
    *
-   * @returns {TokenKinds} The kind of tokens supported.
+   * @throws
    */
   getSupportedTokenKind() {
     throw new TypeError('Not implemented exception');
+  }
+
+  async invalidateCurrentAccessToken() {
+    if (this.tokenData) {
+      const newTokenData = { ...this.tokenData };
+      delete newTokenData.accessToken;
+      await this.setTokenData(newTokenData);
+    }
+
+    return Promise.resolve();
   }
 
   /**
@@ -137,7 +146,7 @@ class TokenProvider {
    *
    * @param {boolean} useCache - If cache should be used or not.
    *
-   * @returns {Promise} Promise that will be resolved with a valid access token to be used.
+   * @throws
    */
   // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
   getAccessToken(useCache) {

--- a/packages/core/src/helpers/client/interceptors/authentication/token-providers/UserTokenProvider.js
+++ b/packages/core/src/helpers/client/interceptors/authentication/token-providers/UserTokenProvider.js
@@ -73,19 +73,27 @@ class UserTokenProvider extends TokenProvider {
           [AuthenticationConfigOptions.NoAuthentication]: true,
           [AuthenticationConfigOptions.IsUserRefreshTokenRequest]: true,
         },
-      ).then(async response => {
-        this.currentGetAccessTokenPromise = null;
+      ).then(
+        async response => {
+          this.currentGetAccessTokenPromise = null;
 
-        const responseTokenData = new TokenData(response);
+          const responseTokenData = new TokenData(response);
 
-        if (!responseTokenData.userId && this.userId) {
-          responseTokenData.userId = this.userId;
-        }
+          if (!responseTokenData.userId && this.userId) {
+            responseTokenData.userId = this.userId;
+          }
 
-        await this.setTokenData(responseTokenData);
+          await this.setTokenData(responseTokenData);
 
-        return this.tokenData.accessToken;
-      });
+          return this.tokenData.accessToken;
+        },
+        error => {
+          // Clear current get access token promise
+          this.currentGetAccessTokenPromise = null;
+
+          return Promise.reject(error);
+        },
+      );
 
       return this.currentGetAccessTokenPromise;
     }

--- a/packages/core/src/helpers/client/interceptors/authentication/token-providers/__tests__/GuestTokenProvider.test.js
+++ b/packages/core/src/helpers/client/interceptors/authentication/token-providers/__tests__/GuestTokenProvider.test.js
@@ -1,0 +1,80 @@
+import GuestTokenProvider from '../GuestTokenProvider';
+
+jest.useFakeTimers();
+
+describe('GuestTokenProvider', () => {
+  describe('setTokenContext', () => {
+    it('should not set token data if the new token context is equal to the current token context', () => {
+      const requester = jest.fn();
+      const tokenContext = { contextProp1: 'dummy', contextProp2: 'dummy' };
+      const instance = new GuestTokenProvider(requester);
+      const setTokenDataSpy = jest.spyOn(instance, 'setTokenData');
+
+      instance.setTokenContext(tokenContext);
+
+      expect(setTokenDataSpy).toHaveBeenCalledWith(null);
+
+      jest.clearAllMocks();
+
+      // Clone the object to test a deep comparison instead of a reference one
+      const tokenContextClone = { ...tokenContext };
+
+      instance.setTokenContext(tokenContextClone);
+
+      expect(setTokenDataSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAccessToken', () => {
+    it('should not set token data if the token context has changed between requests', async () => {
+      const requester = jest.fn(() => {
+        return new Promise(resolve => {
+          // Resolve after a timeout to give a change to setTokenContext to be ran
+          // while the request is not finished.
+          setTimeout(() => {
+            resolve({ accessToken: 'dummy_access_token', expiresIn: 12000 });
+          }, 1000);
+        });
+      });
+
+      const instance = new GuestTokenProvider(requester);
+      const setTokenDataSpy = jest.spyOn(instance, 'setTokenData');
+      const getAccessTokenPromise = instance.getAccessToken(false);
+
+      instance.setTokenContext({ contextProp1: 'dummy' });
+
+      // Clear all mocks because the call to setTokenContext will call setTokenData
+      jest.clearAllMocks();
+
+      // Force the setTimeout to run, so that the promise can be resolved
+      jest.runAllTimers();
+
+      await getAccessTokenPromise;
+
+      expect(setTokenDataSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getCachedAccessToken', () => {
+    it('should return the access token from cache if available', async () => {
+      const accessToken = 'dummy_access_token';
+
+      const instance = new GuestTokenProvider(
+        jest.fn(() => Promise.resolve({ accessToken })),
+      );
+
+      expect(instance.getCachedAccessToken()).toBeUndefined();
+
+      const receivedAccessToken = await instance.getAccessToken(false);
+
+      expect(receivedAccessToken).toEqual(accessToken);
+
+      const getAccessTokenSpy = jest.spyOn(instance, 'getAccessToken');
+      const cachedAccessToken = instance.getCachedAccessToken();
+
+      expect(cachedAccessToken).toEqual(accessToken);
+
+      expect(getAccessTokenSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/helpers/client/interceptors/authentication/token-providers/__tests__/TokenData.test.js
+++ b/packages/core/src/helpers/client/interceptors/authentication/token-providers/__tests__/TokenData.test.js
@@ -1,0 +1,7 @@
+import TokenData from '../TokenData';
+
+describe('TokenData', () => {
+  it('should throw if data is not set when creating a new instance', () => {
+    expect(() => new TokenData()).toThrow('');
+  });
+});

--- a/packages/core/src/helpers/client/interceptors/authentication/token-providers/__tests__/TokenProvider.test.js
+++ b/packages/core/src/helpers/client/interceptors/authentication/token-providers/__tests__/TokenProvider.test.js
@@ -1,0 +1,33 @@
+import TokenProvider from '../TokenProvider';
+
+class MyTokenProvider extends TokenProvider {}
+
+describe('TokenProvider', () => {
+  describe('virtual methods', () => {
+    it('should throw when a virtual method is not overriden by a derived class', () => {
+      const instance = new MyTokenProvider(jest.fn());
+
+      expect(() => instance.getSupportedTokenKind()).toThrow(
+        'Not implemented exception',
+      );
+
+      expect(() => instance.getAccessToken()).toThrow(
+        'Not implemented exception',
+      );
+    });
+  });
+
+  describe('canRetrieveTokens', () => {
+    it('should return false by default', () => {
+      expect(new TokenProvider().canRetrieveTokens()).toBe(false);
+    });
+  });
+
+  describe('setCanSaveTokenData', () => {
+    it('should throw if parameter passed is not a boolean', () => {
+      expect(() => new TokenProvider().setCanSaveTokenData({})).toThrow(
+        "Called 'setCanSaveTokenData' with a value that is not a boolean: [object Object]",
+      );
+    });
+  });
+});

--- a/packages/react/src/authentication/contexts/UserProfileProvider.js
+++ b/packages/react/src/authentication/contexts/UserProfileProvider.js
@@ -50,6 +50,9 @@ const reducer = (state, action) => {
         isLoading: false,
       };
     }
+
+    default:
+      return state;
   }
 };
 
@@ -74,6 +77,7 @@ const reducer = (state, action) => {
  * @param {boolean} [props.fetchProfileOnTokenChanges=false] - Boolean to indicate if the provider should try to keep the user profile data in sync with the active token data.
  * @param {boolean} [props.onProfileChange] - Callback that runs after the profile changes.
  *
+ * @returns {React.ReactElement} An element that wraps the children with the UserProfileContext.Provider element.
  */
 const UserProfileProvider = ({
   children,
@@ -97,6 +101,7 @@ const UserProfileProvider = ({
       const userData = await getProfile({
         [AuthenticationConfigOptions.UsedAccessTokenCallback]:
           setAccessTokenRef,
+        [AuthenticationConfigOptions.IsGetUserProfileRequest]: true,
       });
 
       const tokenManagerCurrentActiveToken =
@@ -110,12 +115,6 @@ const UserProfileProvider = ({
       if (tokenManagerCurrentActiveToken !== usedAccessTokenRef.current) {
         throw new ProfileChangedError();
       }
-
-      // HACK: While the guestTokens/tokens endpoints do not return
-      // the userId, we need to use the response from the getProfile
-      // client to associate a userId with a previously obtained token.
-      // When these endpoints include this data, we can safely remove this call.
-      await tokenManager.setUserInfo(userData);
 
       dispatch({
         type: ActionTypes.GetProfileSucceeded,
@@ -183,6 +182,7 @@ const UserProfileProvider = ({
     activeTokenData,
     fetchProfileOnTokenChanges,
     loadProfile,
+    onProfileChange,
     tokenManager,
     userProfileState,
   ]);


### PR DESCRIPTION
## Description

- Fixes the bug that happens when the guest user has expired
but the authentication provider continues to use the expired
guest user id when obtaining new guest tokens.

- Fixes a bug that the get access token promise was not
being set to null when the request to get access token fails
in both GuestTokenProvider and UserTokenProvider.

- Refactored the logic to change current token provider to live
inside AxiosAuthenticationTokenManager instead of being
spread out in UserProfileProvider.

- Increase test coverage.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
