### PR TITLE
fix(core|react): handle guest users expired in authentication provider - next

### DIFF
--- a/packages/client/src/helpers/client/interceptors/authentication/AuthenticationConfigOptions.js
+++ b/packages/client/src/helpers/client/interceptors/authentication/AuthenticationConfigOptions.js
@@ -22,5 +22,24 @@ export default {
   IsClientCredentialsTokenRequest: '__isClientCredentialsTokenRequest',
   // This indicates a callback to be called with the access token used for the request.
   // Can be used to match request responses with the current active token.
+  // This is useful when you do not have access to the axios's config object directly.
   UsedAccessTokenCallback: '__usedAccessTokenCallback',
+  // This indicates that the current request is to get the current user's profile.
+  // Used to set the user id to the current guest/user tokens.
+  IsGetUserProfileRequest: '__isGetUserProfileRequest',
+  // This indicates the access token used in the request.
+  // Useful to query if the request is being done with a guest or authenticated user token.
+  UsedAccessToken: '__usedAccessToken',
+  // This indicates that the current request is a login request.
+  // Used to change the tokens context.
+  IsLoginRequest: '__isLoginRequest',
+  // This indicates that the current request is a logout request.
+  // Used to change the tokens context.
+  IsLogoutRequest: '__isLogoutRequest',
+  // This value is set on the request by the token manager
+  // after it evaluated if the request is supposed to need
+  // authentication or not.
+  NeedsAuthentication: '__needsAuthentication',
+  // This indicates the kind of the used access token for a request.
+  UsedAccessTokenKind: '__usedAccessTokenKind',
 };

--- a/packages/client/src/helpers/client/interceptors/authentication/__tests__/AxiosAuthenticationTokenManager.test.js
+++ b/packages/client/src/helpers/client/interceptors/authentication/__tests__/AxiosAuthenticationTokenManager.test.js
@@ -295,7 +295,7 @@ describe('AxiosAuthenticationTokenManager', () => {
         expect(mockGuestTokenRequester).toHaveBeenCalledTimes(2);
       });
 
-      it('should return the original error if a request fails with 401 and the access token refresh fails', async () => {
+      it('should return an error if a request fails with 401 and the access token refresh fails', async () => {
         moxios.stubRequest('/api/account/v1/users/me', {
           method: 'get',
           status: 401,
@@ -317,19 +317,111 @@ describe('AxiosAuthenticationTokenManager', () => {
             config,
             response: { status: 500 },
             request: { data },
+            isAxiosError: true,
           });
         });
 
-        expect.assertions(3);
+        expect.assertions(2);
 
         try {
           await getUser();
         } catch (e) {
-          expect(e).toBeInstanceOf(Error);
-          expect(e.response.status).toBe(401);
+          expect(e).toBeInstanceOf(RefreshGuestUserAccessTokenError);
         }
 
         expect(mockGuestTokenRequester).toHaveBeenCalledTimes(2);
+      });
+
+      it('should refresh guest token data when the get profile request fails because the guest user has expired', async () => {
+        // Set initial users/me request mock to return a successful result
+        // so that guest token data is set.
+        moxios.stubRequest('/api/account/v1/users/me', {
+          method: 'get',
+          response: { id: 10000, isGuest: true },
+          status: 200,
+        });
+
+        // Before any requests it should be null as it is not loading from storage.
+        expect(tokenManagerInstance.guestTokenProvider.getTokenData()).toBe(
+          null,
+        );
+
+        // Force a get profile request so that the guest token data is set with
+        // a user id.
+        await getUser({
+          [AuthenticationConfigOptions.IsGetUserProfileRequest]: true,
+        });
+
+        // Expect that the post guestTokens request was performed with a null
+        // guestUserId as it is the first request.
+        expect(mockGuestTokenRequester).toHaveBeenLastCalledWith(
+          expect.objectContaining({ guestUserId: null }),
+          expect.any(Object),
+        );
+
+        const guestTokenData =
+          tokenManagerInstance.guestTokenProvider.getTokenData();
+
+        expect(guestTokenData).toEqual(
+          expect.objectContaining({
+            userId: 10000,
+          }),
+        );
+
+        // Reinstall moxios on the client to clear mocks.
+        // Without this, we are unable to mock a successful response again.
+        moxios.uninstall(client);
+
+        moxios.install(client);
+
+        // Mock first a 400 error for the first users/me request mimicking the
+        // case where the guest user has expired.
+        // Then return a successful result for the next requests with a different
+        // user id.
+        stubMoxiosRequestOnce(
+          'get',
+          '/api/account/v1/users/me',
+          {
+            status: 400,
+          },
+          {
+            status: 200,
+            response: { id: 20000, isGuest: true },
+          },
+        );
+
+        // Clear mock data from mockGuestTokenRequester mock
+        jest.clearAllMocks();
+
+        // Force guest user token expiration.
+        // This is necessary so that a request to guestTokens is made
+        // with the guestUserId filled with the current guest token user id
+        // so that we can assert it.
+        guestTokenData.expiresTimeUtc = new Date().getTime();
+
+        // Perform the users/me request. It should not throw and should retry the request
+        // after getting the first 400 response.
+        await getUser({
+          [AuthenticationConfigOptions.IsGetUserProfileRequest]: true,
+        });
+
+        // Expect that the post guestTokens request was performed first with the
+        // current guest user id, and then with null
+        expect(mockGuestTokenRequester).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({ guestUserId: 10000 }),
+          expect.any(Object),
+        );
+
+        expect(mockGuestTokenRequester).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({ guestUserId: null }),
+          expect.any(Object),
+        );
+
+        expect(tokenManagerInstance.guestTokenProvider.getTokenData()).toEqual(
+          expect.objectContaining({ userId: 20000 }),
+        );
       });
     });
 
@@ -555,7 +647,7 @@ describe('AxiosAuthenticationTokenManager', () => {
         expect(mockUserTokenRequester).toHaveBeenCalledTimes(1);
       });
 
-      it('should return the original error if a request fails with 401 and the access token refresh fails', async () => {
+      it('should return an error if a request fails with 401 and the access token refresh fails', async () => {
         moxios.stubRequest('/api/account/v1/users/me', {
           method: 'get',
           status: 401,
@@ -566,16 +658,16 @@ describe('AxiosAuthenticationTokenManager', () => {
             config,
             response: { status: 500 },
             request: { data },
+            isAxiosError: true,
           });
         });
 
-        expect.assertions(4);
+        expect.assertions(3);
 
         try {
           await getUser();
         } catch (e) {
-          expect(e).toBeInstanceOf(Error);
-          expect(e.response.status).toBe(401);
+          expect(e).toBeInstanceOf(RefreshUserAccessTokenError);
         }
 
         expect(mockUserTokenRequester).toHaveBeenCalledTimes(1);

--- a/packages/client/src/helpers/client/interceptors/authentication/errors.js
+++ b/packages/client/src/helpers/client/interceptors/authentication/errors.js
@@ -31,6 +31,7 @@ export class RefreshUserAccessTokenError extends RefreshAccessTokenError {
 
 export class RefreshClientCredentialsAccessTokenError extends RefreshAccessTokenError {
   constructor(originalError) {
+    /* istanbul ignore next */
     super('Unable to refresh client credentials access token.', originalError);
   }
 }

--- a/packages/client/src/helpers/client/interceptors/authentication/token-providers/TokenProvider.js
+++ b/packages/client/src/helpers/client/interceptors/authentication/token-providers/TokenProvider.js
@@ -89,6 +89,16 @@ class TokenProvider {
     throw new TypeError('Not implemented exception');
   }
 
+  async invalidateCurrentAccessToken() {
+    if (this.tokenData) {
+      const newTokenData = { ...this.tokenData };
+      delete newTokenData.accessToken;
+      await this.setTokenData(newTokenData);
+    }
+
+    return Promise.resolve();
+  }
+
   /**
    * Sets user id with this instance. Will trigger a call to onTokenDataChanged if the passed user id
    * is different than the current one set. This is what will make the association of a previously obtained

--- a/packages/client/src/helpers/client/interceptors/authentication/token-providers/UserTokenProvider.js
+++ b/packages/client/src/helpers/client/interceptors/authentication/token-providers/UserTokenProvider.js
@@ -73,19 +73,27 @@ class UserTokenProvider extends TokenProvider {
           [AuthenticationConfigOptions.NoAuthentication]: true,
           [AuthenticationConfigOptions.IsUserRefreshTokenRequest]: true,
         },
-      ).then(async response => {
-        this.currentGetAccessTokenPromise = null;
+      ).then(
+        async response => {
+          this.currentGetAccessTokenPromise = null;
 
-        const responseTokenData = new TokenData(response);
+          const responseTokenData = new TokenData(response);
 
-        if (!responseTokenData.userId && this.userId) {
-          responseTokenData.userId = this.userId;
-        }
+          if (!responseTokenData.userId && this.userId) {
+            responseTokenData.userId = this.userId;
+          }
 
-        await this.setTokenData(responseTokenData);
+          await this.setTokenData(responseTokenData);
 
-        return this.tokenData.accessToken;
-      });
+          return this.tokenData.accessToken;
+        },
+        error => {
+          // Clear current get access token promise
+          this.currentGetAccessTokenPromise = null;
+
+          return Promise.reject(error);
+        },
+      );
 
       return this.currentGetAccessTokenPromise;
     }

--- a/packages/client/src/helpers/client/interceptors/authentication/token-providers/__tests__/GuestTokenProvider.test.js
+++ b/packages/client/src/helpers/client/interceptors/authentication/token-providers/__tests__/GuestTokenProvider.test.js
@@ -1,0 +1,80 @@
+import GuestTokenProvider from '../GuestTokenProvider';
+
+jest.useFakeTimers();
+
+describe('GuestTokenProvider', () => {
+  describe('setTokenContext', () => {
+    it('should not set token data if the new token context is equal to the current token context', () => {
+      const requester = jest.fn();
+      const tokenContext = { contextProp1: 'dummy', contextProp2: 'dummy' };
+      const instance = new GuestTokenProvider(requester);
+      const setTokenDataSpy = jest.spyOn(instance, 'setTokenData');
+
+      instance.setTokenContext(tokenContext);
+
+      expect(setTokenDataSpy).toHaveBeenCalledWith(null);
+
+      jest.clearAllMocks();
+
+      // Clone the object to test a deep comparison instead of a reference one
+      const tokenContextClone = { ...tokenContext };
+
+      instance.setTokenContext(tokenContextClone);
+
+      expect(setTokenDataSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAccessToken', () => {
+    it('should not set token data if the token context has changed between requests', async () => {
+      const requester = jest.fn(() => {
+        return new Promise(resolve => {
+          // Resolve after a timeout to give a change to setTokenContext to be ran
+          // while the request is not finished.
+          setTimeout(() => {
+            resolve({ accessToken: 'dummy_access_token', expiresIn: 12000 });
+          }, 1000);
+        });
+      });
+
+      const instance = new GuestTokenProvider(requester);
+      const setTokenDataSpy = jest.spyOn(instance, 'setTokenData');
+      const getAccessTokenPromise = instance.getAccessToken(false);
+
+      instance.setTokenContext({ contextProp1: 'dummy' });
+
+      // Clear all mocks because the call to setTokenContext will call setTokenData
+      jest.clearAllMocks();
+
+      // Force the setTimeout to run, so that the promise can be resolved
+      jest.runAllTimers();
+
+      await getAccessTokenPromise;
+
+      expect(setTokenDataSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getCachedAccessToken', () => {
+    it('should return the access token from cache if available', async () => {
+      const accessToken = 'dummy_access_token';
+
+      const instance = new GuestTokenProvider(
+        jest.fn(() => Promise.resolve({ accessToken })),
+      );
+
+      expect(instance.getCachedAccessToken()).toBeUndefined();
+
+      const receivedAccessToken = await instance.getAccessToken(false);
+
+      expect(receivedAccessToken).toEqual(accessToken);
+
+      const getAccessTokenSpy = jest.spyOn(instance, 'getAccessToken');
+      const cachedAccessToken = instance.getCachedAccessToken();
+
+      expect(cachedAccessToken).toEqual(accessToken);
+
+      expect(getAccessTokenSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/client/src/helpers/client/interceptors/authentication/token-providers/__tests__/TokenData.test.js
+++ b/packages/client/src/helpers/client/interceptors/authentication/token-providers/__tests__/TokenData.test.js
@@ -1,0 +1,7 @@
+import TokenData from '../TokenData';
+
+describe('TokenData', () => {
+  it('should throw if data is not set when creating a new instance', () => {
+    expect(() => new TokenData()).toThrow('');
+  });
+});

--- a/packages/client/src/helpers/client/interceptors/authentication/token-providers/__tests__/TokenProvider.test.js
+++ b/packages/client/src/helpers/client/interceptors/authentication/token-providers/__tests__/TokenProvider.test.js
@@ -1,0 +1,33 @@
+import TokenProvider from '../TokenProvider';
+
+class MyTokenProvider extends TokenProvider {}
+
+describe('TokenProvider', () => {
+  describe('virtual methods', () => {
+    it('should throw when a virtual method is not overriden by a derived class', () => {
+      const instance = new MyTokenProvider(jest.fn());
+
+      expect(() => instance.getSupportedTokenKind()).toThrow(
+        'Not implemented exception',
+      );
+
+      expect(() => instance.getAccessToken()).toThrow(
+        'Not implemented exception',
+      );
+    });
+  });
+
+  describe('canRetrieveTokens', () => {
+    it('should return false by default', () => {
+      expect(new TokenProvider().canRetrieveTokens()).toBe(false);
+    });
+  });
+
+  describe('setCanSaveTokenData', () => {
+    it('should throw if parameter passed is not a boolean', () => {
+      expect(() => new TokenProvider().setCanSaveTokenData({})).toThrow(
+        "Called 'setCanSaveTokenData' with a value that is not a boolean: [object Object]",
+      );
+    });
+  });
+});

--- a/packages/react/src/authentication/contexts/UserProfileProvider.js
+++ b/packages/react/src/authentication/contexts/UserProfileProvider.js
@@ -77,6 +77,7 @@ const reducer = (state, action) => {
  * @param {boolean} [props.fetchProfileOnTokenChanges=false] - Boolean to indicate if the provider should try to keep the user profile data in sync with the active token data.
  * @param {boolean} [props.onProfileChange] - Callback that runs after the profile changes.
  *
+ * @returns {React.ReactElement} An element that wraps the children with the UserProfileContext.Provider element.
  */
 const UserProfileProvider = ({
   children,
@@ -100,6 +101,7 @@ const UserProfileProvider = ({
       const userData = await getUser({
         [AuthenticationConfigOptions.UsedAccessTokenCallback]:
           setAccessTokenRef,
+        [AuthenticationConfigOptions.IsGetUserProfileRequest]: true,
       });
 
       const tokenManagerCurrentActiveToken =
@@ -113,12 +115,6 @@ const UserProfileProvider = ({
       if (tokenManagerCurrentActiveToken !== usedAccessTokenRef.current) {
         throw new ProfileChangedError();
       }
-
-      // HACK: While the guestTokens/tokens endpoints do not return
-      // the userId, we need to use the response from the getUser
-      // client to associate a userId with a previously obtained token.
-      // When these endpoints include this data, we can safely remove this call.
-      await tokenManager.setUserInfo(userData);
 
       dispatch({
         type: ActionTypes.GetUserSucceeded,
@@ -186,6 +182,7 @@ const UserProfileProvider = ({
     activeTokenData,
     fetchProfileOnTokenChanges,
     loadProfile,
+    onProfileChange,
     tokenManager,
     userProfileState,
   ]);

--- a/packages/react/src/authentication/hooks/__tests__/useAuthentication.test.js
+++ b/packages/react/src/authentication/hooks/__tests__/useAuthentication.test.js
@@ -2,11 +2,6 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { ActionTypes } from '../useUserAuthState';
 import { cleanup } from '@testing-library/react';
 import {
-  deleteTokens,
-  postGuestTokens,
-  postTokens,
-} from '@farfetch/blackout-client/authentication';
-import {
   LoginWithoutDataError,
   NotLoggedInError,
   PendingUserOperationError,
@@ -21,28 +16,9 @@ import AxiosAuthenticationTokenManager, {
 import client, {
   configApiBlackAndWhite,
 } from '@farfetch/blackout-client/helpers/client';
+import moxios from 'moxios';
 import React from 'react';
 import useAuthentication from '../useAuthentication';
-
-const mockUserTokenData = {
-  accessToken: 'dummy_access_token',
-  refreshToken: 'dummy_refresh_token',
-  expiresIn: '12000',
-};
-
-const mockGuestUserTokenData = {
-  accessToken: 'dummy_access_token',
-  expiresIn: '12000',
-};
-
-jest.mock('@farfetch/blackout-client/authentication', () => {
-  return {
-    ...jest.requireActual('@farfetch/blackout-client/authentication'),
-    postGuestTokens: jest.fn(() => Promise.resolve(mockGuestUserTokenData)),
-    postTokens: jest.fn(() => Promise.resolve(mockUserTokenData)),
-    deleteTokens: jest.fn(() => Promise.resolve(true)),
-  };
-});
 
 const defaultHeaders = {
   'Accept-Language': 'en-GB',
@@ -64,9 +40,16 @@ const wrapper = ({ children, baseURL, callbacks, headers, storage }) => (
 
 jest.useFakeTimers();
 
-afterEach(cleanup);
+beforeEach(() => {
+  moxios.install(client);
+});
 
-describe('useUserAuthState', () => {
+afterEach(() => {
+  moxios.uninstall(client);
+  cleanup();
+});
+
+describe('useAuthentication', () => {
   it('should return the correct values', async () => {
     const { result, waitForNextUpdate } = renderHook(
       () => useAuthentication(),
@@ -210,6 +193,24 @@ describe('useUserAuthState', () => {
   });
 
   it("should update the value of 'isLoggedIn' value whenever user login status changed", async () => {
+    const accessToken = 'dummy_access_token';
+
+    moxios.stubRequest('/authentication/v1/tokens', {
+      method: 'post',
+      response: {
+        accessToken,
+        expiresIn: '12000',
+        refreshToken: 'dummy_refresh_token',
+      },
+      status: 200,
+    });
+
+    moxios.stubRequest(`/authentication/v1/tokens/${accessToken}`, {
+      method: 'delete',
+      response: {},
+      status: 200,
+    });
+
     const { result, waitForNextUpdate } = renderHook(
       () => useAuthentication(),
       {
@@ -223,7 +224,7 @@ describe('useUserAuthState', () => {
 
     await act(async () => {
       await result.current.login({
-        rememberMe: false,
+        rememberMe: true,
         username: 'user',
         password: 'pass',
       });
@@ -241,20 +242,22 @@ describe('useUserAuthState', () => {
   });
 
   it('should throw an error if login is called before it is terminated', async () => {
+    moxios.stubRequest('/authentication/v1/tokens', {
+      method: 'post',
+      response: {
+        accessToken: 'dummy_access_token',
+        expiresIn: '12000',
+        refreshToken: 'dummy_refresh_token',
+      },
+      status: 200,
+    });
+
     const { result, waitForNextUpdate } = renderHook(
       () => useAuthentication(),
       {
         wrapper,
       },
     );
-
-    postTokens.mockImplementationOnce(() => {
-      return new Promise(resolve => {
-        setTimeout(() => {
-          resolve(mockUserTokenData);
-        }, 10000);
-      });
-    });
 
     await waitForNextUpdate();
 
@@ -265,8 +268,6 @@ describe('useUserAuthState', () => {
     expect(result.current.isLoading).toBe(true);
 
     expect(result.current.login({})).rejects.toThrow(PendingUserOperationError);
-
-    jest.runTimersToTime();
 
     await loginPromise;
 
@@ -299,8 +300,20 @@ describe('useUserAuthState', () => {
   });
 
   it('should set tokens context before fetching the access token', async () => {
-    const mockGuestUserEmail = 'user@email.com';
-    const mockGuestUserSecretCode = 'A1B2C3';
+    moxios.stubRequest('/authentication/v1/guestTokens', {
+      method: 'post',
+      response: {
+        accessToken: 'dummy_access_token',
+        expiresIn: '12000',
+      },
+      status: 200,
+    });
+
+    const mockGuestUserClaimsParameter = {
+      guestUserEmail: 'user@email.com',
+      guestUserSecret: 'A1B2C3',
+    };
+
     const { result, waitForNextUpdate } = renderHook(
       () => useAuthentication(),
       {
@@ -313,21 +326,26 @@ describe('useUserAuthState', () => {
     expect(result.current.activeTokenData).toBeTruthy();
     expect(result.current.activeTokenData.kind).toBe(TokenKinds.Guest);
 
+    const getAccessTokenSpy = jest.spyOn(
+      result.current.tokenManager,
+      'getAccessToken',
+    );
+
+    jest.clearAllMocks();
+
     await act(async () => {
-      await result.current.setGuestUserClaims({
-        guestUserEmail: mockGuestUserEmail,
-        guestUserSecret: mockGuestUserSecretCode,
-      });
+      await result.current.setGuestUserClaims(mockGuestUserClaimsParameter);
     });
 
-    expect(postGuestTokens).toBeCalledWith(
-      {
-        guestUserEmail: 'user@email.com',
-        guestUserId: null,
-        guestUserSecret: 'A1B2C3',
-      },
-      { __isGuestUserAccessTokenRequest: true, __noAuthentication: true },
-    );
+    expect(getAccessTokenSpy).toHaveBeenCalledTimes(1);
+
+    const request = moxios.requests.mostRecent();
+    const requestDataParsed = JSON.parse(request.config.data);
+
+    expect(requestDataParsed).toEqual({
+      ...mockGuestUserClaimsParameter,
+      guestUserId: null,
+    });
   });
 
   it('should throw an error if logout is called but the current user is not logged in', async () => {
@@ -361,10 +379,14 @@ describe('useUserAuthState', () => {
     // Make the login endpoint return invalid data
     // to test when the user token data does not contain
     // an access token case.
-    postTokens.mockImplementationOnce(() => ({
-      ...mockUserTokenData,
-      accessToken: null,
-    }));
+    moxios.stubRequest('/authentication/v1/tokens', {
+      status: 200,
+      response: {
+        refreshToken: 'dummy_refresh_token',
+        expiresIn: '12000',
+        accessToken: null,
+      },
+    });
 
     await act(async () => result.current.login({}));
 
@@ -386,6 +408,18 @@ describe('useUserAuthState', () => {
   });
 
   it("should _NOT_ throw an error if logout request fails but the error is of the kind 'user token is not found'", async () => {
+    const accessToken = 'dummy_access_token';
+
+    moxios.stubRequest('/authentication/v1/tokens', {
+      method: 'post',
+      status: 200,
+      response: {
+        accessToken,
+        expiresIn: '12000',
+        refreshToken: 'dummy_refresh_token',
+      },
+    });
+
     const { result, waitForNextUpdate } = renderHook(
       () => useAuthentication(),
       {
@@ -406,12 +440,11 @@ describe('useUserAuthState', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.isLoggedIn).toBe(true);
 
-    deleteTokens.mockImplementationOnce(() =>
-      Promise.reject({
-        status: 400,
-        code: '17',
-      }),
-    );
+    moxios.stubRequest(`/authentication/v1/tokens/${accessToken}`, {
+      method: 'delete',
+      status: 400,
+      code: '17',
+    });
 
     await act(async () => {
       await result.current.logout();
@@ -426,11 +459,15 @@ describe('useUserAuthState', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.isLoggedIn).toBe(true);
 
-    deleteTokens.mockImplementationOnce(() =>
-      Promise.reject({
-        status: 404,
-      }),
-    );
+    // Need to reinstall moxios so that we can mock a new response for delete request again.
+    // By the way, the method stubOnce was already tried and did not work.
+    moxios.uninstall(client);
+    moxios.install(client);
+
+    moxios.stubRequest(`/authentication/v1/tokens/${accessToken}`, {
+      method: 'delete',
+      status: 404,
+    });
 
     await act(async () => {
       await result.current.logout();
@@ -441,6 +478,18 @@ describe('useUserAuthState', () => {
   });
 
   it("should throw an error if logout fails for other reason than 'user token is not found'", async () => {
+    const accessToken = 'dummy_access_token';
+
+    moxios.stubRequest('/authentication/v1/tokens', {
+      method: 'post',
+      status: 200,
+      response: {
+        accessToken,
+        expiresIn: '12000',
+        refreshToken: 'dummy_refresh_token',
+      },
+    });
+
     const { result, waitForNextUpdate } = renderHook(
       () => useAuthentication(),
       {
@@ -457,10 +506,15 @@ describe('useUserAuthState', () => {
     expect(result.current.activeTokenData.kind).toBe(TokenKinds.User);
     expect(result.current.isLoading).toBe(false);
 
-    const mockError = new Error('mock error');
+    const errorResponseStatus = 500;
 
-    deleteTokens.mockImplementationOnce(() => {
-      throw mockError;
+    const mockError = new Error(
+      `Request failed with status code ${errorResponseStatus}`,
+    );
+
+    moxios.stubRequest(`/authentication/v1/tokens/${accessToken}`, {
+      method: 'delete',
+      status: errorResponseStatus,
     });
 
     try {
@@ -468,7 +522,7 @@ describe('useUserAuthState', () => {
         await result.current.logout();
       });
     } catch (e) {
-      expect(e).toBe(mockError);
+      expect(e).toStrictEqual(mockError);
     }
 
     expect(result.current.errorData).toEqual({

--- a/packages/react/src/authentication/hooks/__tests__/useUserProfile.test.js
+++ b/packages/react/src/authentication/hooks/__tests__/useUserProfile.test.js
@@ -113,7 +113,7 @@ describe('useUserProfile', () => {
     expect(getUser).toHaveBeenCalledTimes(1);
   });
 
-  it('should throw an error if getProfile fails', async () => {
+  it('should throw an error if getUser fails', async () => {
     const expectedError = new Error('dummy error');
 
     getUser.mockImplementationOnce(config => {


### PR DESCRIPTION
## Description

- Fixes the bug that happens when the guest user has expired
but the authentication provider continues to use the expired
guest user id when obtaining new guest tokens.

- Fixes a bug that the get access token promise was not
being set to null when the request to get access token fails
in both GuestTokenProvider and UserTokenProvider.

- Refactored the logic to change current token provider to live
inside AxiosAuthenticationTokenManager instead of being
spread out in UserProfileProvider.

- Increase test coverage.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
