### PR TITLE
feat: add selector to get all product sizes with remaining quantity

### DIFF
--- a/packages/redux/src/products/selectors/__tests__/details.test.ts
+++ b/packages/redux/src/products/selectors/__tests__/details.test.ts
@@ -250,6 +250,53 @@ describe('Product', () => {
     });
   });
 
+  describe('getAllProductSizesRemainingQuantity()', () => {
+    let spyGetProduct;
+    let spyGetBagItems;
+
+    beforeEach(() => {
+      spyGetProduct = jest.spyOn(fromProductEntities, 'getProduct');
+      spyGetBagItems = jest.spyOn(fromBags, 'getBagItems');
+    });
+
+    afterEach(() => {
+      spyGetProduct.mockRestore();
+      spyGetBagItems.mockRestore();
+    });
+
+    it('should return the updated product sizes', () => {
+      const bagItem = mockProductsState.entities.bagItems[102];
+      const product = mockProductsState.entities.products[mockProductId];
+      const size = product.sizes.find(({ id }) => id === bagItem.size.id);
+      const globalQuantity = bagItem.size.globalQuantity;
+      const bagQuantity = bagItem.quantity;
+      const expectedResult = globalQuantity - bagQuantity;
+
+      expect(
+        selectors.getAllProductSizesRemainingQuantity(
+          mockProductsState,
+          mockProductId,
+        ),
+      ).toEqual(
+        expect.arrayContaining([
+          {
+            ...size,
+            globalQuantity: expectedResult,
+          },
+        ]),
+      );
+    });
+
+    it("should return an empty array when the product or its sizes don't exist", () => {
+      expect(
+        selectors.getAllProductSizesRemainingQuantity(
+          mockProductsState,
+          'not-a-product-id-for-sure',
+        ),
+      ).toEqual([]);
+    });
+  });
+
   describe('getProductGroupedEntries()', () => {
     it('should get the color grouping', () => {
       const expectedResult = {

--- a/tests/__fixtures__/products/state.fixtures.ts
+++ b/tests/__fixtures__/products/state.fixtures.ts
@@ -157,7 +157,7 @@ export const mockProductsState = {
         size: {
           scale: 117,
           id: 6,
-          name: '40',
+          name: '41',
           scaleDescription: 'Jeans (waist)',
           scaleAbbreviation: 'WAIST',
           globalQuantity: 44,


### PR DESCRIPTION
## Description

This creates a selector that returns all product sizes with an updated remaining quantity,
calculated according to the items already in bag.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->


<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
