### PR TITLE
fix(core|react): allow `useBagItem`'s to work without `productAggregator`

### DIFF
--- a/packages/core/src/bags/hooks/useBagItem.js
+++ b/packages/core/src/bags/hooks/useBagItem.js
@@ -51,7 +51,7 @@ export function useBagItem(
   // Function that provides all tenant logic to deal with add,
   // update or add the next merchant available.
   const addOrUpdateItem = async ({
-    productAggregatorId = bagItem.productAggregator.id,
+    productAggregatorId = bagItem.productAggregator?.id,
     quantity = bagItem.quantity,
     size = productSize,
     ...otherParams

--- a/packages/core/src/bags/redux/utils/__tests__/createBagItemHash.test.js
+++ b/packages/core/src/bags/redux/utils/__tests__/createBagItemHash.test.js
@@ -1,5 +1,5 @@
 import { createBagItemHash } from '../';
-import { mockBagItem } from 'tests/__fixtures__/bags';
+import { mockBagItem, mockProductAggregatorId } from 'tests/__fixtures__/bags';
 import omit from 'lodash/omit';
 
 describe('createBagItemHash()', () => {
@@ -49,20 +49,31 @@ describe('createBagItemHash()', () => {
     });
 
     it('should create a valid hash when `customAttributes` are provided', () => {
-      expect(createBagItemHash(omit(mockBagItem, ['productAggregator']))).toBe(
+      expect(createBagItemHash(mockBagItem)).toBe(
         `${baseHashPattern}!${mockBagItem.customAttributes}`,
       );
     });
 
     it('should create a valid hash when a `productAggregatorId` is provided', () => {
-      expect(createBagItemHash(omit(mockBagItem, ['customAttributes']))).toBe(
-        `${baseHashPattern}!${mockBagItem.productAggregator.id}`,
+      const mockBagItemWithProductAggregator = {
+        ...mockBagItem,
+        productAggregator: {
+          bundleSlug: '/slug',
+          id: mockProductAggregatorId,
+        },
+      };
+      expect(
+        createBagItemHash(
+          omit(mockBagItemWithProductAggregator, ['customAttributes']),
+        ),
+      ).toBe(
+        `${baseHashPattern}!${mockBagItemWithProductAggregator.productAggregator.id}`,
       );
     });
 
     it('should create a valid hash from a valid bag item', () => {
       expect(createBagItemHash(mockBagItem)).toBe(
-        `${baseHashPattern}!${mockBagItem.customAttributes}!${mockBagItem.productAggregator.id}`,
+        `${baseHashPattern}!${mockBagItem.customAttributes}`,
       );
     });
   });

--- a/packages/react/src/bags/hooks/useBagItem.js
+++ b/packages/react/src/bags/hooks/useBagItem.js
@@ -83,7 +83,7 @@ export default bagItemId => {
   const handleAddOrUpdateItem = async ({
     customAttributes = bagItem.customAttributes,
     product = bagItem.product,
-    productAggregatorId = bagItem.productAggregator.id,
+    productAggregatorId = bagItem.productAggregator?.id,
     quantity = bagItem.quantity,
     size = productSize,
     ...otherParams

--- a/tests/__fixtures__/bags/bagItem.fixtures.js
+++ b/tests/__fixtures__/bags/bagItem.fixtures.js
@@ -29,10 +29,7 @@ export const mockBagItem = {
   sizeId: 23,
   isAvailable: true,
   product: mockProduct,
-  productAggregator: {
-    bundleSlug: '/slug',
-    id: mockProductAggregatorId,
-  },
+  productAggregator: null,
 };
 
 export const mockBagItemEntity = {


### PR DESCRIPTION
## Description

This fixes the incorrect access to the id property of `productAggregator`, which may be null.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
