### PR TITLE
feat(client|redux): add `promotionEvaluations` endpoint

### DIFF
--- a/packages/client/src/promotionEvaluations/__fixtures__/getPromotionEvaluationItems.fixtures.ts
+++ b/packages/client/src/promotionEvaluations/__fixtures__/getPromotionEvaluationItems.fixtures.ts
@@ -1,0 +1,35 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+import type { PromotionEvaluationId, PromotionEvaluationItem } from '../types';
+
+export default {
+  success: (params: {
+    promotionEvaluationId: PromotionEvaluationId;
+    response: Array<PromotionEvaluationItem>;
+  }): void => {
+    moxios.stubRequest(
+      join(
+        '/api/commerce/v1/promotionEvaluations',
+        params.promotionEvaluationId,
+        'promotionEvaluationItems',
+      ),
+      {
+        response: params.response,
+        status: 200,
+      },
+    );
+  },
+  failure: (params: { promotionEvaluationId: PromotionEvaluationId }): void => {
+    moxios.stubRequest(
+      join(
+        '/api/commerce/v1/promotionEvaluations',
+        params.promotionEvaluationId,
+        'promotionEvaluationItems',
+      ),
+      {
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/client/src/promotionEvaluations/__tests__/__snapshots__/getPromotionEvaluationItems.test.ts.snap
+++ b/packages/client/src/promotionEvaluations/__tests__/__snapshots__/getPromotionEvaluationItems.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPromotionEvaluationItems() should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/client/src/promotionEvaluations/__tests__/getPromotionEvaluationItems.test.ts
+++ b/packages/client/src/promotionEvaluations/__tests__/getPromotionEvaluationItems.test.ts
@@ -1,0 +1,51 @@
+import { getPromotionEvaluationItems } from '..';
+import {
+  mockPromotionEvaluationId,
+  mockPromotionEvaluationsItemsResponse,
+} from 'tests/__fixtures__/promotionEvaluations';
+import client from '../../helpers/client';
+import fixtures from '../__fixtures__/getPromotionEvaluationItems.fixtures';
+import moxios from 'moxios';
+
+describe('getPromotionEvaluationItems()', () => {
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+  const spy = jest.spyOn(client, 'get');
+
+  it('should handle a client request successfully', async () => {
+    const response = mockPromotionEvaluationsItemsResponse;
+
+    fixtures.success({
+      promotionEvaluationId: mockPromotionEvaluationId,
+      response,
+    });
+
+    await expect(
+      getPromotionEvaluationItems(mockPromotionEvaluationId),
+    ).resolves.toBe(response);
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/promotionEvaluations/${mockPromotionEvaluationId}/promotionEvaluationItems`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure({
+      promotionEvaluationId: mockPromotionEvaluationId,
+    });
+
+    await expect(
+      getPromotionEvaluationItems(mockPromotionEvaluationId),
+    ).rejects.toMatchSnapshot();
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/promotionEvaluations/${mockPromotionEvaluationId}/promotionEvaluationItems`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/client/src/promotionEvaluations/getPromotionEvaluationItems.ts
+++ b/packages/client/src/promotionEvaluations/getPromotionEvaluationItems.ts
@@ -1,0 +1,35 @@
+import client, { adaptError } from '../helpers/client';
+import join from 'proper-url-join';
+import type { GetPromotionEvaluationItems } from './types';
+
+/**
+ * Method responsible for getting the promotion evaluation items of an evaluation.
+ *
+ * @memberof module:promotionEvaluations/client
+ *
+ * @param {string} promotionEvaluationId - Promotion evaluation identifier.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Promise} Promise that will be resolved when the call to the
+ * endpoint finishes.
+ */
+const getPromotionEvaluationItems: GetPromotionEvaluationItems = (
+  promotionEvaluationId,
+  config,
+) =>
+  client
+    .get(
+      join(
+        '/commerce/v1/promotionEvaluations',
+        promotionEvaluationId,
+        'promotionEvaluationItems',
+      ),
+      config,
+    )
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });
+
+export default getPromotionEvaluationItems;

--- a/packages/client/src/promotionEvaluations/index.ts
+++ b/packages/client/src/promotionEvaluations/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Promotion evaluations clients.
+ *
+ * @module promotionEvaluations/client
+ * @category Promotion evaluations
+ * @subcategory Clients
+ */
+
+export { default as getPromotionEvaluationItems } from './getPromotionEvaluationItems';

--- a/packages/client/src/promotionEvaluations/types/getPromotionEvaluationItems.types.ts
+++ b/packages/client/src/promotionEvaluations/types/getPromotionEvaluationItems.types.ts
@@ -1,0 +1,9 @@
+import type {
+  PromotionEvaluationId,
+  PromotionEvaluationItem,
+} from './promotionEvaluationItems.types';
+
+export type GetPromotionEvaluationItems = (
+  promotionEvaluationId: PromotionEvaluationId,
+  config?: Record<string, unknown>,
+) => Promise<Array<PromotionEvaluationItem>>;

--- a/packages/client/src/promotionEvaluations/types/index.ts
+++ b/packages/client/src/promotionEvaluations/types/index.ts
@@ -1,0 +1,2 @@
+export * from './getPromotionEvaluationItems.types';
+export * from './promotionEvaluationItems.types';

--- a/packages/client/src/promotionEvaluations/types/promotionEvaluationItems.types.ts
+++ b/packages/client/src/promotionEvaluations/types/promotionEvaluationItems.types.ts
@@ -1,0 +1,22 @@
+export type PromotionEvaluationId = string;
+
+export type PromotionEvaluationItem = {
+  id: string;
+  eligiblePromotions: Array<{
+    promocode: string;
+    displayName: string;
+    eligibleOffers: Array<{
+      type: number;
+      offerMoneyOff: {
+        discount: number;
+        currencyCode: string;
+        formattedDiscount: string;
+      };
+      offerPercentOff: {
+        discount: number;
+        currencyCode: string;
+        formattedDiscount: string;
+      };
+    }>;
+  }>;
+};

--- a/packages/redux/src/promotionEvaluations/__tests__/reducer.test.ts
+++ b/packages/redux/src/promotionEvaluations/__tests__/reducer.test.ts
@@ -1,0 +1,175 @@
+import * as fromReducer from '../reducer';
+import {
+  mockPromotionEvaluationId,
+  mockPromotionEvaluationsItemsResponse,
+} from 'tests/__fixtures__/promotionEvaluations';
+import reducer, { actionTypes } from '..';
+
+let initialState;
+const mockAction = { type: 'foo' };
+
+describe('promotionEvaluations redux reducer', () => {
+  beforeEach(() => {
+    initialState = reducer(fromReducer.INITIAL_STATE, mockAction);
+  });
+
+  describe('error() reducer', () => {
+    it('should return the initial state', () => {
+      const state = reducer(fromReducer.INITIAL_STATE, mockAction).error;
+
+      expect(state).toEqual(initialState.error);
+      expect(state).toEqual(null);
+    });
+
+    it('should handle FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST action type', () => {
+      expect(
+        reducer(undefined, {
+          type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST,
+          meta: { promotionEvaluationId: mockPromotionEvaluationId },
+        }).error,
+      ).toBeNull();
+    });
+
+    it('should handle FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE action type', () => {
+      const expectedResult = 'foo';
+
+      expect(
+        reducer(undefined, {
+          type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE,
+          payload: {
+            error: expectedResult,
+          },
+          meta: { promotionEvaluationId: mockPromotionEvaluationId },
+        }).error,
+      ).toEqual(expectedResult);
+    });
+  });
+
+  describe('isLoading() reducer', () => {
+    it('should return the initial state', () => {
+      const state = reducer(fromReducer.INITIAL_STATE, mockAction).isLoading;
+
+      expect(state).toEqual(initialState.isLoading);
+      expect(state).toEqual(false);
+    });
+
+    it('should handle FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST action type', () => {
+      expect(
+        reducer(undefined, {
+          type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST,
+          meta: { promotionEvaluationId: mockPromotionEvaluationId },
+        }).isLoading,
+      ).toEqual(true);
+    });
+
+    it('should handle FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS action type', () => {
+      expect(
+        reducer(undefined, {
+          type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS,
+          payload: {
+            result: {},
+          },
+          meta: { promotionEvaluationId: mockPromotionEvaluationId },
+        }).isLoading,
+      ).toEqual(false);
+    });
+
+    it('should handle FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE action type', () => {
+      expect(
+        reducer(undefined, {
+          type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE,
+          payload: {
+            error: {},
+          },
+          meta: { promotionEvaluationId: mockPromotionEvaluationId },
+        }).isLoading,
+      ).toEqual(false);
+    });
+
+    it('should handle other actions by returning the previous state', () => {
+      const state = { ...initialState, isLoading: false };
+
+      expect(reducer(state, mockAction).isLoading).toEqual(state.isLoading);
+    });
+  });
+
+  describe('result() reducer', () => {
+    it('should return the initial state', () => {
+      const state = reducer(fromReducer.INITIAL_STATE, mockAction).result;
+
+      expect(state).toEqual(initialState.result);
+    });
+
+    it('should handle FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS', () => {
+      const state = reducer(undefined, {
+        type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS,
+        payload: { result: mockPromotionEvaluationsItemsResponse },
+        meta: { promotionEvaluationId: mockPromotionEvaluationId },
+      });
+
+      expect(state.result).toEqual(mockPromotionEvaluationsItemsResponse);
+    });
+
+    it('should handle other actions by returning the previous state', () => {
+      const state = {
+        ...initialState,
+        result: { foo: 'bar' },
+      };
+
+      expect(reducer(state, mockAction).result).toEqual(state.result);
+    });
+  });
+
+  describe('id() reducer', () => {
+    it('should return the initial state', () => {
+      const state = reducer(fromReducer.INITIAL_STATE, mockAction).id;
+
+      expect(state).toEqual(initialState.id);
+    });
+
+    it('should handle FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS', () => {
+      const state = reducer(undefined, {
+        type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS,
+        payload: { result: mockPromotionEvaluationsItemsResponse },
+        meta: { promotionEvaluationId: mockPromotionEvaluationId },
+      });
+
+      expect(state.id).toEqual(mockPromotionEvaluationId);
+    });
+
+    it('should handle other actions by returning the previous state', () => {
+      const state = {
+        ...initialState,
+        id: 'bar',
+      };
+
+      expect(reducer(state, mockAction).id).toEqual(state.id);
+    });
+  });
+
+  describe('getError() selector', () => {
+    it('should return the `error` property from a given state', () => {
+      expect(fromReducer.getError(initialState)).toBe(initialState.error);
+    });
+  });
+
+  describe('getIsLoading() selector', () => {
+    it('should return the `isLoading` property from a given state', () => {
+      expect(fromReducer.getIsLoading(initialState)).toEqual(
+        initialState.isLoading,
+      );
+    });
+  });
+
+  describe('getResult() selector', () => {
+    it('should return the result property from a given state', () => {
+      expect(fromReducer.getResult(initialState)).toEqual(initialState.result);
+    });
+  });
+
+  describe('getId() selector', () => {
+    it('should return the id property from a given state', () => {
+      expect(fromReducer.getId(initialState)).toEqual(initialState.id);
+    });
+  });
+});

--- a/packages/redux/src/promotionEvaluations/__tests__/selectors.test.ts
+++ b/packages/redux/src/promotionEvaluations/__tests__/selectors.test.ts
@@ -1,0 +1,64 @@
+import * as fromPromotionEvaluations from '../reducer';
+import * as selectors from '../selectors';
+import {
+  mockErrorState,
+  mockLoadingState,
+  mockPromotionEvaluationId,
+  mockPromotionEvaluationItemId,
+  mockPromotionEvaluationsItemsResponse,
+  mockState,
+} from 'tests/__fixtures__/promotionEvaluations';
+
+describe('promotionEvaluations redux selectors', () => {
+  beforeEach(jest.clearAllMocks);
+
+  describe('arePromotionEvaluationItemsLoading()', () => {
+    it('should get the promotion evaluations items loading status', () => {
+      const spy = jest.spyOn(fromPromotionEvaluations, 'getIsLoading');
+
+      expect(
+        selectors.arePromotionEvaluationItemsLoading(mockLoadingState),
+      ).toBe(mockLoadingState.promotionEvaluations.isLoading);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getPromotionEvaluationsItemsError()', () => {
+    it('should get the promotion evaluations items error', () => {
+      const expectedResult = mockErrorState.promotionEvaluations.error;
+      const spy = jest.spyOn(fromPromotionEvaluations, 'getError');
+
+      expect(
+        selectors.getPromotionEvaluationItemsError(mockErrorState),
+      ).toEqual(expectedResult);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getPromotionEvaluationItems()', () => {
+    it('should return an array with the result stored', () => {
+      const result = selectors.getPromotionEvaluationItems(mockState);
+
+      expect(result).toEqual(mockPromotionEvaluationsItemsResponse);
+    });
+  });
+
+  describe('getPromotionEvaluationItemById()', () => {
+    it('should return an object with the promotion evaluation item id', () => {
+      const result = selectors.getPromotionEvaluationItemById(
+        mockState,
+        mockPromotionEvaluationItemId,
+      );
+
+      expect(result).toEqual(mockPromotionEvaluationsItemsResponse[0]);
+    });
+  });
+
+  describe('getPromotionEvaluationId()', () => {
+    it('should return a string with the promotion evaluation id', () => {
+      const result = selectors.getPromotionEvaluationId(mockState);
+
+      expect(result).toEqual(mockPromotionEvaluationId);
+    });
+  });
+});

--- a/packages/redux/src/promotionEvaluations/actionTypes.ts
+++ b/packages/redux/src/promotionEvaluations/actionTypes.ts
@@ -1,0 +1,15 @@
+/**
+ * @module promotionEvaluations/actionTypes
+ * @category Promotion evaluations
+ * @subcategory Action types
+ */
+
+/** Action type dispatched when the fetch promotion evaluation items request fails. */
+export const FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE =
+  '@farfetch/blackout-redux/FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE';
+/** Action type dispatched when the fetch promotion evaluation items request starts. */
+export const FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST =
+  '@farfetch/blackout-redux/FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST';
+/** Action type dispatched when the fetch promotion evaluation items request succeeds. */
+export const FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS =
+  '@farfetch/blackout-redux/FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS';

--- a/packages/redux/src/promotionEvaluations/actions/__tests__/fetchPromotionEvaluationItems.test.ts
+++ b/packages/redux/src/promotionEvaluations/actions/__tests__/fetchPromotionEvaluationItems.test.ts
@@ -1,0 +1,95 @@
+import { actionTypes } from '../..';
+import { fetchPromotionEvaluationItems } from '..';
+import { getPromotionEvaluationItems } from '@farfetch/blackout-client/promotionEvaluations';
+import { INITIAL_STATE } from '../../reducer';
+import {
+  mockPromotionEvaluationId,
+  mockPromotionEvaluationsItemsResponse,
+} from 'tests/__fixtures__/promotionEvaluations';
+import { mockStore } from '../../../../tests';
+
+jest.mock('@farfetch/blackout-client/promotionEvaluations', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/promotionEvaluations'),
+  getPromotionEvaluationItems: jest.fn(),
+}));
+
+const promotionEvaluationsMockStore = (state = {}) =>
+  mockStore({ promotionEvaluations: INITIAL_STATE }, state);
+const expectedConfig = undefined;
+let store;
+
+describe('fetchPromotionEvaluationItems() action creator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = promotionEvaluationsMockStore();
+  });
+
+  it('should create the correct actions for when the fetch promotion evaluation items procedure fails', async () => {
+    const expectedError = new Error('Fetch promotion evaluation items error');
+
+    getPromotionEvaluationItems.mockRejectedValueOnce(expectedError);
+
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(
+        fetchPromotionEvaluationItems(mockPromotionEvaluationId),
+      );
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(getPromotionEvaluationItems).toHaveBeenCalledTimes(1);
+      expect(getPromotionEvaluationItems).toHaveBeenCalledWith(
+        mockPromotionEvaluationId,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual([
+        {
+          meta: {
+            promotionEvaluationId: mockPromotionEvaluationId,
+          },
+          type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST,
+        },
+        {
+          meta: {
+            promotionEvaluationId: mockPromotionEvaluationId,
+          },
+          payload: { error: expectedError },
+          type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE,
+        },
+      ]);
+    }
+  });
+
+  it('should create the correct actions for when the fetch promotion evaluation items procedure is successful', async () => {
+    getPromotionEvaluationItems.mockResolvedValueOnce(
+      mockPromotionEvaluationsItemsResponse,
+    );
+
+    expect.assertions(3);
+
+    await store.dispatch(
+      fetchPromotionEvaluationItems(mockPromotionEvaluationId),
+    );
+
+    expect(getPromotionEvaluationItems).toHaveBeenCalledTimes(1);
+    expect(getPromotionEvaluationItems).toHaveBeenCalledWith(
+      mockPromotionEvaluationId,
+      expectedConfig,
+    );
+    expect(store.getActions()).toEqual([
+      {
+        meta: {
+          promotionEvaluationId: mockPromotionEvaluationId,
+        },
+        type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST,
+      },
+      {
+        meta: {
+          promotionEvaluationId: mockPromotionEvaluationId,
+        },
+        payload: { result: mockPromotionEvaluationsItemsResponse },
+        type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS,
+      },
+    ]);
+  });
+});

--- a/packages/redux/src/promotionEvaluations/actions/factories/fetchPromotionEvaluationItemsFactory.ts
+++ b/packages/redux/src/promotionEvaluations/actions/factories/fetchPromotionEvaluationItemsFactory.ts
@@ -1,0 +1,72 @@
+import {
+  FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE,
+  FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST,
+  FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS,
+} from '../../actionTypes';
+import type { Dispatch } from 'redux';
+import type { FetchPromotionEvaluationItemsAction } from '../../types';
+import type {
+  GetPromotionEvaluationItems,
+  PromotionEvaluationId,
+  PromotionEvaluationItem,
+} from '@farfetch/blackout-client/promotionEvaluations/types';
+
+/**
+ * @callback FetchPromotionEvaluationItemsThunkFactory
+ *
+ * @param {string} promotionEvaluationId - Promotion evaluation identifier.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Creates a thunk factory configured with the specified client to fetch
+ * promotion evaluation items for a given promotion evaluation id.
+ *
+ * @memberof module:promotionEvaluations/actions/factories
+ *
+ * @param {Function} getPromotionEvaluationItems - Get promotion evaluation items client.
+ *
+ * @returns {FetchPromotionEvaluationItemsThunkFactory} Thunk factory.
+ */
+const fetchPromotionEvaluationItemsFactory =
+  (getPromotionEvaluationItems: GetPromotionEvaluationItems) =>
+  (
+    promotionEvaluationId: PromotionEvaluationId,
+    config?: Record<string, unknown>,
+  ) =>
+  async (
+    dispatch: Dispatch<FetchPromotionEvaluationItemsAction>,
+  ): Promise<Array<PromotionEvaluationItem>> => {
+    dispatch({
+      meta: { promotionEvaluationId },
+      type: FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST,
+    });
+
+    try {
+      const result = await getPromotionEvaluationItems(
+        promotionEvaluationId,
+        config,
+      );
+
+      dispatch({
+        meta: { promotionEvaluationId },
+        payload: { result },
+        type: FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        meta: { promotionEvaluationId },
+        payload: { error },
+        type: FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE,
+      });
+
+      throw error;
+    }
+  };
+
+export default fetchPromotionEvaluationItemsFactory;

--- a/packages/redux/src/promotionEvaluations/actions/factories/index.ts
+++ b/packages/redux/src/promotionEvaluations/actions/factories/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Promotion Evaluations actions factories.
+ *
+ * @module promotionEvaluations/actions/factories
+ * @category Promotion Evaluations
+ * @subcategory Actions
+ */
+
+export { default as fetchPromotionEvaluationItemsFactory } from './fetchPromotionEvaluationItemsFactory';

--- a/packages/redux/src/promotionEvaluations/actions/fetchPromotionEvaluationItems.ts
+++ b/packages/redux/src/promotionEvaluations/actions/fetchPromotionEvaluationItems.ts
@@ -1,0 +1,16 @@
+import { fetchPromotionEvaluationItemsFactory } from './factories';
+import { getPromotionEvaluationItems } from '@farfetch/blackout-client/promotionEvaluations';
+
+/**
+ * Fetches promotion evaluation items given a promotion evaluation id.
+ *
+ * @memberof module:promotionEvaluations/actions
+ *
+ * @function fetchPromotionEvaluationItemsFactory
+ *
+ * @type {FetchPromotionEvaluationItemsThunkFactory}
+ */
+
+export default fetchPromotionEvaluationItemsFactory(
+  getPromotionEvaluationItems,
+);

--- a/packages/redux/src/promotionEvaluations/actions/index.ts
+++ b/packages/redux/src/promotionEvaluations/actions/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Promotion evaluations actions.
+ *
+ * @module promotionEvaluations/actions
+ * @category Promotion evaluations
+ * @subcategory Actions
+ */
+
+export { default as fetchPromotionEvaluationItems } from './fetchPromotionEvaluationItems';

--- a/packages/redux/src/promotionEvaluations/index.ts
+++ b/packages/redux/src/promotionEvaluations/index.ts
@@ -1,0 +1,9 @@
+import * as actionTypes from './actionTypes';
+import reducer from './reducer';
+
+export * from './actions';
+export * from './selectors';
+
+export { actionTypes };
+
+export default reducer;

--- a/packages/redux/src/promotionEvaluations/reducer.ts
+++ b/packages/redux/src/promotionEvaluations/reducer.ts
@@ -1,0 +1,85 @@
+/**
+ * @module promotionEvaluations/reducer
+ * @category Promotion Evaluations
+ * @subcategory Reducer
+ */
+import * as actionTypes from './actionTypes';
+import { AnyAction, combineReducers } from 'redux';
+import type {
+  FetchPromotionEvaluationItemsAction,
+  FetchPromotionEvaluationItemsSuccessAction,
+  State,
+} from './types';
+
+export const INITIAL_STATE: State = {
+  id: null,
+  error: null,
+  isLoading: false,
+  result: null,
+};
+
+const error = (
+  state = INITIAL_STATE.error,
+  action: FetchPromotionEvaluationItemsAction,
+) => {
+  switch (action.type) {
+    case actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST:
+      return INITIAL_STATE.error;
+    case actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE:
+      return action.payload.error;
+    default:
+      return state;
+  }
+};
+
+const isLoading = (
+  state = INITIAL_STATE.isLoading,
+  action: FetchPromotionEvaluationItemsAction,
+) => {
+  switch (action.type) {
+    case actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST:
+      return true;
+    case actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS:
+    case actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE:
+      return INITIAL_STATE.isLoading;
+    default:
+      return state;
+  }
+};
+
+const result = (
+  state = INITIAL_STATE.result,
+  action: FetchPromotionEvaluationItemsSuccessAction | AnyAction,
+) => {
+  switch (action.type) {
+    case actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS:
+      return action.payload.result;
+    default:
+      return state;
+  }
+};
+
+const id = (
+  state = INITIAL_STATE.id,
+  action: FetchPromotionEvaluationItemsSuccessAction | AnyAction,
+) => {
+  switch (action.type) {
+    case actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS:
+      return action.meta.promotionEvaluationId;
+    default:
+      return state;
+  }
+};
+
+export const getError = (state: State): State['error'] => state.error;
+export const getIsLoading = (state: State): State['isLoading'] =>
+  state.isLoading;
+export const getResult = (state: State): State['result'] => state.result;
+export const getId = (state: State): State['id'] => state.id;
+
+export default combineReducers({
+  error,
+  id,
+  isLoading,
+  result,
+});

--- a/packages/redux/src/promotionEvaluations/selectors.ts
+++ b/packages/redux/src/promotionEvaluations/selectors.ts
@@ -1,0 +1,118 @@
+/**
+ * @module promotionEvaluations/selectors
+ * @category Promotion Evaluations
+ * @subcategory Selectors
+ */
+
+import { getError, getId, getIsLoading, getResult } from './reducer';
+import type {
+  PromotionEvaluationId,
+  PromotionEvaluationItem,
+} from '@farfetch/blackout-client/src/promotionEvaluations/types';
+import type { State } from './types';
+import type { StoreState } from '../types';
+
+/**
+ * Retrieves a list of all the promotion evaluations items available.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {Array} - List of promotion evaluations items.
+ *
+ * @example
+ * import { getPromotionEvaluationItems } from '@farfetch/blackout-redux/promotionEvaluations';
+ *
+ * const mapStateToProps = state => ({
+ *   promotionEvaluationsItems: getPromotionEvaluationItems(state)
+ * });
+ */
+export const getPromotionEvaluationItems = (
+  state: StoreState,
+): State['result'] => getResult(state.promotionEvaluations);
+
+/**
+ * Retrieves a promotion evaluation item given an id.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ * @param {string} id - Promotion evaluation item identifier to retrieve.
+ *
+ * @returns {object | undefined} - Promotion evaluations item.
+ *
+ * @example
+ * import { getPromotionEvaluationItemById } from '@farfetch/blackout-redux/promotionEvaluations';
+ *
+ * const mapStateToProps = (state, { id } ) => ({
+ *   promotionEvaluationsItem: getPromotionEvaluationItemById(state, id)
+ * });
+ */
+export const getPromotionEvaluationItemById = (
+  state: StoreState,
+  id: PromotionEvaluationId,
+): PromotionEvaluationItem | undefined => {
+  const promotionEvaluationsItems = getResult(state.promotionEvaluations);
+
+  return promotionEvaluationsItems?.find(item => item.id === id);
+};
+
+/**
+ * Retrieves the promotion evaluation id stored.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {string} - Promotion evaluation id.
+ *
+ * @example
+ * import { getPromotionEvaluationId } from '@farfetch/blackout-redux/promotionEvaluations';
+ *
+ * const mapStateToProps = state => ({
+ *   promotionEvaluationId: getPromotionEvaluationId(state)
+ * });
+ */
+export const getPromotionEvaluationId = (state: StoreState): State['id'] =>
+  getId(state.promotionEvaluations);
+
+/**
+ * Retrieves the error status of promotion evaluations items.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {object | null} Error information (`null` if there are no errors).
+ *
+ * @example
+ * import { getPromotionEvaluationItemsError } from '@farfetch/blackout-redux/promotionEvaluations';
+ *
+ * const mapStateToProps = state => ({
+ *   error: getPromotionEvaluationItemsError(state)
+ * });
+ */
+export const getPromotionEvaluationItemsError = (
+  state: StoreState,
+): State['error'] => getError(state.promotionEvaluations);
+
+/**
+ * Retrieves the loading state of promotion evaluations items.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {boolean} - Loading status of promotion evaluations items.
+ *
+ * @example
+ * import { arePromotionEvaluationItemsLoading } from '@farfetch/blackout-redux/promotionEvaluations';
+ *
+ * const mapStateToProps = state => ({
+ *   isLoading: arePromotionEvaluationItemsLoading(state)
+ * });
+ */
+export const arePromotionEvaluationItemsLoading = (
+  state: StoreState,
+): State['isLoading'] => getIsLoading(state.promotionEvaluations);

--- a/packages/redux/src/promotionEvaluations/types/action.types.ts
+++ b/packages/redux/src/promotionEvaluations/types/action.types.ts
@@ -1,0 +1,30 @@
+import type * as actionTypes from '../actionTypes';
+import type { Action } from 'redux';
+import type { Error } from '@farfetch/blackout-client/types';
+import type {
+  PromotionEvaluationId,
+  PromotionEvaluationItem,
+} from '@farfetch/blackout-client/promotionEvaluations/types';
+
+export interface FetchPromotionEvaluationItemsFailureAction extends Action {
+  meta: { promotionEvaluationId: PromotionEvaluationId };
+  type: typeof actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE;
+  payload: { error: Error };
+}
+export interface FetchPromotionEvaluationItemsRequestAction extends Action {
+  meta: { promotionEvaluationId: PromotionEvaluationId };
+  type: typeof actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST;
+}
+export interface FetchPromotionEvaluationItemsSuccessAction extends Action {
+  meta: { promotionEvaluationId: PromotionEvaluationId };
+  type: typeof actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS;
+  payload: {
+    result: Array<PromotionEvaluationItem>;
+  };
+}
+
+/** Actions dispatched when the fetch categories request is made. */
+export type FetchPromotionEvaluationItemsAction =
+  | FetchPromotionEvaluationItemsFailureAction
+  | FetchPromotionEvaluationItemsRequestAction
+  | FetchPromotionEvaluationItemsSuccessAction;

--- a/packages/redux/src/promotionEvaluations/types/index.ts
+++ b/packages/redux/src/promotionEvaluations/types/index.ts
@@ -1,0 +1,2 @@
+export * from './action.types';
+export * from './state.types';

--- a/packages/redux/src/promotionEvaluations/types/state.types.ts
+++ b/packages/redux/src/promotionEvaluations/types/state.types.ts
@@ -1,0 +1,10 @@
+import type { CombinedState } from 'redux';
+import type { Error } from '@farfetch/blackout-client/types';
+import type { PromotionEvaluationItem } from '@farfetch/blackout-client/promotionEvaluations/types';
+
+export type State = CombinedState<{
+  error: Error | null;
+  id: string | null;
+  isLoading: boolean;
+  result: Array<PromotionEvaluationItem> | null;
+}>;

--- a/packages/redux/src/types/StoreState.types.ts
+++ b/packages/redux/src/types/StoreState.types.ts
@@ -32,6 +32,7 @@ import type { MerchantLocation } from '@farfetch/blackout-client/merchantsLocati
 import type { State as MerchantsLocationsState } from '../merchantsLocations/types';
 import type { State as PaymentsState } from '../payments/types';
 import type { State as ProductsState } from '../products/types';
+import type { State as PromotionEvaluationsState } from '../promotionEvaluations/types';
 import type { State as SearchState } from '../search/types';
 import type { State as SizeGuidesState } from '../sizeGuides/types';
 import type { SizeScale } from '@farfetch/blackout-client/sizeScales/types';
@@ -84,6 +85,7 @@ export type StoreState = {
   merchantsLocations: MerchantsLocationsState;
   payments: PaymentsState;
   products: ProductsState;
+  promotionEvaluations: PromotionEvaluationsState;
   search: SearchState;
   sizeGuides: SizeGuidesState;
   sizeScales: SizeScalesState;

--- a/tests/__fixtures__/promotionEvaluations/index.ts
+++ b/tests/__fixtures__/promotionEvaluations/index.ts
@@ -1,0 +1,1 @@
+export * from './promotionEvaluations.fixtures';

--- a/tests/__fixtures__/promotionEvaluations/promotionEvaluations.fixtures.ts
+++ b/tests/__fixtures__/promotionEvaluations/promotionEvaluations.fixtures.ts
@@ -1,0 +1,63 @@
+export const mockPromotionEvaluationId = '123456';
+export const mockPromotionEvaluationItemId = '123456-7890';
+
+export const mockPromotionEvaluationsItemsResponse = [
+  {
+    id: mockPromotionEvaluationItemId,
+    eligiblePromotions: [
+      {
+        promocode: null,
+        displayName: 'Promotion test',
+        eligibleOffers: [
+          {
+            type: 1,
+            offerMoneyOff: {
+              discount: 50.0,
+              currencyCode: 'EUR',
+              formattedDiscount: '50 €',
+            },
+            offerPercentOff: null,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const mockInitialState = {
+  promotionEvaluations: {
+    id: null,
+    error: null,
+    isLoading: false,
+    result: null,
+  },
+};
+
+export const mockLoadingState = {
+  promotionEvaluations: {
+    id: null,
+    error: null,
+    isLoading: true,
+    result: null,
+  },
+};
+
+export const mockErrorState = {
+  promotionEvaluations: {
+    id: null,
+    error: {
+      message: 'Error message',
+    },
+    isLoading: false,
+    result: null,
+  },
+};
+
+export const mockState = {
+  promotionEvaluations: {
+    id: mockPromotionEvaluationId,
+    error: null,
+    isLoading: false,
+    result: mockPromotionEvaluationsItemsResponse,
+  },
+};


### PR DESCRIPTION
## Description

This adds the client and redux for the `promotionEvaluations` endpoint.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
