### PR TITLE
chore(redux): remove `id` property from `products.details` reducer

### DIFF
--- a/packages/redux/src/products/reducer/__tests__/details.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/details.test.ts
@@ -3,12 +3,10 @@ import { mockProductId, mockSetId } from 'tests/__fixtures__/products';
 import reducer, {
   entitiesMapper,
   getError,
-  getId,
   getIsHydrated,
   getIsLoading,
   INITIAL_STATE,
 } from '../details';
-import type { ProductEntity } from '../../../entities/types';
 
 const mockAction = { type: 'foo' };
 const meta = { productId: mockProductId };
@@ -65,47 +63,10 @@ describe('details redux reducer', () => {
       const state = {
         error: { [mockProductId]: error },
         isLoading: {},
-        id: mockProductId,
         isHydrated: {},
       };
 
       expect(reducer(state, mockAction).error).toEqual(state.error);
-    });
-  });
-
-  describe('id() reducer', () => {
-    it('should return the initial state', () => {
-      const state = reducer(INITIAL_STATE, mockAction).id;
-
-      expect(state).toBe(initialState.id);
-    });
-
-    it('should handle FETCH_PRODUCT_DETAILS_SUCCESS action type', () => {
-      const state = reducer(undefined, {
-        meta,
-        payload: {
-          entities: {
-            products: {
-              [mockProductId]: { id: mockProductId } as ProductEntity,
-            },
-          },
-          result: 'foo',
-        },
-        type: actionTypes.FETCH_PRODUCT_DETAILS_SUCCESS,
-      });
-
-      expect(state.id).toBe(mockProductId);
-    });
-
-    it('should handle other actions by returning the previous state', () => {
-      const state = {
-        id: mockProductId,
-        error: {},
-        isLoading: {},
-        isHydrated: {},
-      };
-
-      expect(reducer(state, mockAction).id).toBe(mockProductId);
     });
   });
 
@@ -130,7 +91,6 @@ describe('details redux reducer', () => {
       const state = {
         isHydrated: { [mockProductId]: false },
         isLoading: {},
-        id: mockProductId,
         error: {},
       };
       expect(reducer(state, mockAction).isHydrated).toEqual(state.isHydrated);
@@ -188,7 +148,6 @@ describe('details redux reducer', () => {
       const state = {
         isHydrated: {},
         isLoading: { [mockProductId]: false },
-        id: mockProductId,
         error: {},
       };
       expect(reducer(state, mockAction).isLoading).toEqual(state.isLoading);
@@ -234,14 +193,6 @@ describe('details redux reducer', () => {
         const state = { ...initialState, error };
 
         expect(getError(state)).toBe(error);
-      });
-    });
-
-    describe('getId()', () => {
-      it('should return the `id` property from a given state', () => {
-        const state = { ...initialState, id: mockProductId };
-
-        expect(getId(state)).toBe(mockProductId);
       });
     });
 

--- a/packages/redux/src/products/reducer/details.ts
+++ b/packages/redux/src/products/reducer/details.ts
@@ -10,7 +10,6 @@ import type {
   FetchProductDetailsAction,
   FetchProductDetailsFailureAction,
   FetchProductDetailsRequestAction,
-  FetchProductDetailsSuccessAction,
   ProductsDetailsState,
   ResetProductDetailsStateAction,
 } from '../types';
@@ -18,7 +17,6 @@ import type { StoreState } from '../../types';
 
 export const INITIAL_STATE: ProductsDetailsState = {
   error: {},
-  id: null,
   isHydrated: {},
   isLoading: {},
 };
@@ -41,16 +39,6 @@ const error = (
     default:
       return state;
   }
-};
-
-const id = (
-  state = INITIAL_STATE.id,
-  action: FetchProductDetailsSuccessAction,
-) => {
-  if (action.type === actionTypes.FETCH_PRODUCT_DETAILS_SUCCESS) {
-    return action.meta.productId;
-  }
-  return state;
 };
 
 const isHydrated = (
@@ -97,9 +85,6 @@ export const entitiesMapper = {
 export const getError = (
   state: ProductsDetailsState,
 ): ProductsDetailsState['error'] => state.error;
-export const getId = (
-  state: ProductsDetailsState,
-): ProductsDetailsState['id'] => state.id;
 export const getIsHydrated = (
   state: ProductsDetailsState,
 ): ProductsDetailsState['isHydrated'] => state.isHydrated;
@@ -109,7 +94,6 @@ export const getIsLoading = (
 
 const reducers = combineReducers({
   error,
-  id,
   isHydrated,
   isLoading,
 });

--- a/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/index.test.ts.snap
@@ -75,7 +75,6 @@ Object {
   "products": Object {
     "details": Object {
       "error": Object {},
-      "id": null,
       "isHydrated": Object {},
       "isLoading": Object {},
     },
@@ -260,7 +259,6 @@ Object {
   "products": Object {
     "details": Object {
       "error": Object {},
-      "id": 11766695,
       "isHydrated": Object {
         "11766695": true,
       },

--- a/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/products.test.ts.snap
+++ b/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/products.test.ts.snap
@@ -4,7 +4,6 @@ exports[`products serverInitialState() should initialize server state for a non 
 Object {
   "details": Object {
     "error": Object {},
-    "id": null,
     "isHydrated": Object {},
     "isLoading": Object {},
   },
@@ -19,7 +18,6 @@ exports[`products serverInitialState() should initialize server state for produc
 Object {
   "details": Object {
     "error": Object {},
-    "id": 11766695,
     "isHydrated": Object {
       "11766695": true,
     },

--- a/packages/redux/src/products/serverInitialState/products.ts
+++ b/packages/redux/src/products/serverInitialState/products.ts
@@ -94,7 +94,6 @@ const serverInitialState = ({
   return {
     details: {
       error: {},
-      id,
       isHydrated: {
         [id]: true,
       },

--- a/packages/redux/src/products/types/state.types.ts
+++ b/packages/redux/src/products/types/state.types.ts
@@ -15,7 +15,6 @@ export type ProductsColorGroupingState = CombinedState<{
 
 export type ProductsDetailsState = CombinedState<{
   error: Record<ProductEntity['id'], Error | undefined>;
-  id: number | null;
   isHydrated: Record<ProductEntity['id'], boolean | never>;
   isLoading: Record<ProductEntity['id'], boolean | undefined>;
 }>;

--- a/tests/__fixtures__/products/state.fixtures.ts
+++ b/tests/__fixtures__/products/state.fixtures.ts
@@ -37,7 +37,6 @@ export const mockDetailsState = {
       [mockProductId]: 'Error - Not loaded.',
       456: null,
     },
-    id: mockProductId,
     isHydrated: {
       [mockProductId]: false,
       456: false,


### PR DESCRIPTION
## Description

This removes the `id` property from the `products.details` reducer since we fetch a lot of products and keeping the id of the last one fetched doesn’t look useful.

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
