### PR TITLE
fix(redux): remove circular dependency from recently viewed

### DIFF
--- a/packages/redux/src/recentlyViewed/actions/factories/fetchRecentlyViewedProductsFactory.js
+++ b/packages/redux/src/recentlyViewed/actions/factories/fetchRecentlyViewedProductsFactory.js
@@ -1,5 +1,5 @@
 import * as actionTypes from '../../actionTypes';
-import { areRecentlyViewedProductsFetched } from '../../';
+import { areRecentlyViewedProductsFetched } from '../../selectors';
 
 /* eslint-disable jsdoc/no-undefined-types */
 


### PR DESCRIPTION
## Description

This just removes a circular dependency from `fetchRecentlyViewedProductsFactory`.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
