### PR TITLE
fix(react): add `from` to PRODUCT_CLICKED event mapping in GA4

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/eventMapping.js
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.js
@@ -391,6 +391,7 @@ const getSelectContentParametersFromEvent = eventProperties => ({
  * @returns {object} Properties formatted for the GA4's select item.
  */
 const getProductClickedParametersFromEvent = eventProperties => ({
+  from: eventProperties.from,
   items: getProductItemsFromEvent(eventProperties),
   item_list_id: eventProperties.listId,
   item_list_name: eventProperties.list,

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
@@ -351,6 +351,7 @@ Array [
     "event",
     "select_item",
     Object {
+      "from": "PLP",
       "item_list_id": "/en-pt/shopping/woman",
       "item_list_name": "Woman shopping",
       "items": Array [


### PR DESCRIPTION
## Description

This adds the missing `from` parameter to the mapping
for PRODUCT_CLICKED event in GA4.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
