### PR TITLE
chore: improvements to workflows

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,15 @@
+# Always validate all commits, and ignore the PR title
+commitsOnly: true
+
+# Require at least one commit to be valid
+# this is only relevant when using commitsOnly: true or titleAndCommits: true,
+# which validate all commits by default
+anyCommit: false
+
+# Allow use of Merge commits (eg on github: "Merge branch 'master' into feature/ride-unicorns")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowMergeCommits: true
+
+# Allow use of Revert commits (eg on github: "Revert "feat: ride unicorns"")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowRevertCommits: true

--- a/.github/workflows/PullRequestLabeler.yml
+++ b/.github/workflows/PullRequestLabeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  - pull_request_target
 
 jobs:
   triage:
@@ -10,3 +10,19 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true
+
+  conventional-commits-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@v1
+        with:
+          type_labels: | 
+            {
+              "breaking": ":rotating_light: BREAKING CHANGE",
+              "feat": "type: feature",
+              "fix": "type: bug",
+              "docs": "type: documentation",
+              "perf": "type: enhancement",
+              "refactor": "type: enhancement",
+              "test": "type: enhancement"
+            }


### PR DESCRIPTION
## Description

- This adds another job to the PullRequestLabeler workflow that adds a type
label to the PR automatically by checking the title of the PR if it uses the conventional
commits standard.

- This also adds a semantic.yml configuration file to configure the
github app "Semantic Pull Requests" to check if all commits of a PR
contain a title that follows the conventional commits standard.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
