### PR TITLE
feat(redux): provide loyalty actions with a client

### DIFF
--- a/packages/redux/src/loyalty/actions/__tests__/createProgramMembership.test.js
+++ b/packages/redux/src/loyalty/actions/__tests__/createProgramMembership.test.js
@@ -4,9 +4,15 @@ import {
   programId,
 } from 'tests/__fixtures__/loyalty/loyalty.fixtures';
 import { mockStore } from '../../../../tests';
+import { postProgramMembership } from '@farfetch/blackout-client/loyalty';
 import createProgramMembership from '../createProgramMembership';
 import find from 'lodash/find';
 import reducer, { actionTypes } from '../..';
+
+jest.mock('@farfetch/blackout-client/loyalty', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/loyalty'),
+  postProgramMembership: jest.fn(),
+}));
 
 const rewardsMockStore = (state = {}) =>
   mockStore({ rewards: reducer() }, state);
@@ -17,8 +23,6 @@ let store;
 beforeEach(jest.clearAllMocks);
 
 describe('createProgramMembership() action creator', () => {
-  const postProgramMembership = jest.fn();
-  const action = createProgramMembership(postProgramMembership);
   const { id: membershipId, ...data } = mockResponseProgramMembership;
 
   beforeEach(() => {
@@ -39,7 +43,7 @@ describe('createProgramMembership() action creator', () => {
     expect.assertions(4);
 
     try {
-      await store.dispatch(action(programId, data));
+      await store.dispatch(createProgramMembership(programId, data));
     } catch (error) {
       expect(error).toBe(expectedError);
       expect(postProgramMembership).toHaveBeenCalledTimes(1);
@@ -62,7 +66,7 @@ describe('createProgramMembership() action creator', () => {
 
   it('should create the correct actions for when the create program membership procedure is successful', async () => {
     postProgramMembership.mockResolvedValueOnce(mockResponseProgramMembership);
-    await store.dispatch(action(programId, data));
+    await store.dispatch(createProgramMembership(programId, data));
 
     const actionResults = store.getActions();
 

--- a/packages/redux/src/loyalty/actions/__tests__/createProgramMembershipConvert.test.js
+++ b/packages/redux/src/loyalty/actions/__tests__/createProgramMembershipConvert.test.js
@@ -5,9 +5,15 @@ import {
   programId,
 } from 'tests/__fixtures__/loyalty/loyalty.fixtures';
 import { mockStore } from '../../../../tests';
+import { postProgramMembershipConvert } from '@farfetch/blackout-client/loyalty';
 import createProgramMembershipConvert from '../createProgramMembershipConvert';
 import find from 'lodash/find';
 import reducer, { actionTypes } from '../..';
+
+jest.mock('@farfetch/blackout-client/loyalty', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/loyalty'),
+  postProgramMembershipConvert: jest.fn(),
+}));
 
 const rewardsMockStore = (state = {}) =>
   mockStore({ rewards: reducer() }, state);
@@ -18,9 +24,6 @@ let store;
 beforeEach(jest.clearAllMocks);
 
 describe('createProgramMembershipConvert() action creator', () => {
-  const postProgramMembershipConvert = jest.fn();
-  const action = createProgramMembershipConvert(postProgramMembershipConvert);
-
   beforeEach(() => {
     store = rewardsMockStore();
   });
@@ -32,7 +35,9 @@ describe('createProgramMembershipConvert() action creator', () => {
     expect.assertions(4);
 
     try {
-      await store.dispatch(action(programId, membershipId));
+      await store.dispatch(
+        createProgramMembershipConvert(programId, membershipId),
+      );
     } catch (error) {
       expect(error).toBe(expectedError);
       expect(postProgramMembershipConvert).toHaveBeenCalledTimes(1);
@@ -59,7 +64,9 @@ describe('createProgramMembershipConvert() action creator', () => {
     postProgramMembershipConvert.mockResolvedValueOnce(
       mockResponseProgramMembershipConvert,
     );
-    await store.dispatch(action(programId, membershipId));
+    await store.dispatch(
+      createProgramMembershipConvert(programId, membershipId),
+    );
 
     const actionResults = store.getActions();
 

--- a/packages/redux/src/loyalty/actions/__tests__/createProgramMembershipReplacement.test.js
+++ b/packages/redux/src/loyalty/actions/__tests__/createProgramMembershipReplacement.test.js
@@ -5,9 +5,15 @@ import {
   programId,
 } from 'tests/__fixtures__/loyalty/loyalty.fixtures';
 import { mockStore } from '../../../../tests';
+import { postProgramMembershipReplacement } from '@farfetch/blackout-client/loyalty';
 import createProgramMembershipReplacement from '../createProgramMembershipReplacement';
 import find from 'lodash/find';
 import reducer, { actionTypes } from '../..';
+
+jest.mock('@farfetch/blackout-client/loyalty', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/loyalty'),
+  postProgramMembershipReplacement: jest.fn(),
+}));
 
 const rewardsMockStore = (state = {}) =>
   mockStore({ rewards: reducer() }, state);
@@ -18,10 +24,6 @@ let store;
 beforeEach(jest.clearAllMocks);
 
 describe('createProgramMembershipReplacement() action creator', () => {
-  const postProgramMembershipReplacement = jest.fn();
-  const action = createProgramMembershipReplacement(
-    postProgramMembershipReplacement,
-  );
   const data = { reason: 'string' };
 
   beforeEach(() => {
@@ -44,7 +46,9 @@ describe('createProgramMembershipReplacement() action creator', () => {
     expect.assertions(4);
 
     try {
-      await store.dispatch(action(programId, membershipId, data));
+      await store.dispatch(
+        createProgramMembershipReplacement(programId, membershipId, data),
+      );
     } catch (error) {
       expect(error).toBe(expectedError);
       expect(postProgramMembershipReplacement).toHaveBeenCalledTimes(1);
@@ -72,7 +76,9 @@ describe('createProgramMembershipReplacement() action creator', () => {
     postProgramMembershipReplacement.mockResolvedValueOnce(
       mockResponseProgramMembershipReplacement,
     );
-    await store.dispatch(action(programId, membershipId, data));
+    await store.dispatch(
+      createProgramMembershipReplacement(programId, membershipId, data),
+    );
 
     const actionResults = store.getActions();
 

--- a/packages/redux/src/loyalty/actions/__tests__/fetchProgramMembershipStatements.test.js
+++ b/packages/redux/src/loyalty/actions/__tests__/fetchProgramMembershipStatements.test.js
@@ -5,10 +5,16 @@ import {
   mockResponseProgramMembershipStatements,
   programId,
 } from 'tests/__fixtures__/loyalty/loyalty.fixtures';
+import { getProgramMembershipStatements } from '@farfetch/blackout-client/loyalty';
 import { mockStore } from '../../../../tests';
 import fetchProgramMembershipStatements from '../fetchProgramMembershipStatements';
 import find from 'lodash/find';
 import reducer, { actionTypes } from '../..';
+
+jest.mock('@farfetch/blackout-client/loyalty', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/loyalty'),
+  getProgramMembershipStatements: jest.fn(),
+}));
 
 const rewardsMockStore = (state = {}) =>
   mockStore({ rewards: reducer() }, state);
@@ -20,10 +26,6 @@ let store;
 beforeEach(jest.clearAllMocks);
 
 describe('fetchProgramMembershipStatements() action creator', () => {
-  const getProgramMembershipStatements = jest.fn();
-  const action = fetchProgramMembershipStatements(
-    getProgramMembershipStatements,
-  );
   const query = {};
 
   beforeEach(() => {
@@ -39,7 +41,9 @@ describe('fetchProgramMembershipStatements() action creator', () => {
     expect.assertions(4);
 
     try {
-      await store.dispatch(action(programId, membershipId));
+      await store.dispatch(
+        fetchProgramMembershipStatements(programId, membershipId),
+      );
     } catch (error) {
       expect(error).toBe(expectedError);
       expect(getProgramMembershipStatements).toHaveBeenCalledTimes(1);
@@ -67,7 +71,9 @@ describe('fetchProgramMembershipStatements() action creator', () => {
     getProgramMembershipStatements.mockResolvedValueOnce(
       mockResponseProgramMembershipStatements,
     );
-    await store.dispatch(action(programId, membershipId));
+    await store.dispatch(
+      fetchProgramMembershipStatements(programId, membershipId),
+    );
 
     const actionResults = store.getActions();
 

--- a/packages/redux/src/loyalty/actions/__tests__/fetchProgramUsersMembership.test.js
+++ b/packages/redux/src/loyalty/actions/__tests__/fetchProgramUsersMembership.test.js
@@ -4,10 +4,16 @@ import {
   mockResponseProgramUsersMembership,
   programId,
 } from 'tests/__fixtures__/loyalty/loyalty.fixtures';
+import { getProgramUsersMembership } from '@farfetch/blackout-client/loyalty';
 import { mockStore } from '../../../../tests';
 import fetchProgramUsersMembership from '../fetchProgramUsersMembership';
 import find from 'lodash/find';
 import reducer, { actionTypes } from '../..';
+
+jest.mock('@farfetch/blackout-client/loyalty', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/loyalty'),
+  getProgramUsersMembership: jest.fn(),
+}));
 
 const rewardsMockStore = (state = {}) =>
   mockStore({ rewards: reducer() }, state);
@@ -19,8 +25,6 @@ let store;
 beforeEach(jest.clearAllMocks);
 
 describe('fetchProgramUsersMembership() action creator', () => {
-  const getProgramUsersMembership = jest.fn();
-  const action = fetchProgramUsersMembership(getProgramUsersMembership);
   beforeEach(() => {
     store = rewardsMockStore();
   });
@@ -32,7 +36,7 @@ describe('fetchProgramUsersMembership() action creator', () => {
     expect.assertions(4);
 
     try {
-      await store.dispatch(action(programId));
+      await store.dispatch(fetchProgramUsersMembership(programId));
     } catch (error) {
       expect(error).toBe(expectedError);
       expect(getProgramUsersMembership).toHaveBeenCalledTimes(1);
@@ -58,7 +62,7 @@ describe('fetchProgramUsersMembership() action creator', () => {
     getProgramUsersMembership.mockResolvedValueOnce(
       mockResponseProgramUsersMembership,
     );
-    await store.dispatch(action(programId));
+    await store.dispatch(fetchProgramUsersMembership(programId));
 
     const actionResults = store.getActions();
 

--- a/packages/redux/src/loyalty/actions/__tests__/fetchPrograms.test.js
+++ b/packages/redux/src/loyalty/actions/__tests__/fetchPrograms.test.js
@@ -1,8 +1,14 @@
 import * as normalizr from 'normalizr';
+import { getPrograms } from '@farfetch/blackout-client/loyalty';
 import { mockStore } from '../../../../tests';
 import fetchPrograms from '../fetchPrograms';
 import find from 'lodash/find';
 import reducer, { actionTypes } from '../..';
+
+jest.mock('@farfetch/blackout-client/loyalty', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/loyalty'),
+  getPrograms: jest.fn(),
+}));
 
 const rewardsMockStore = (state = {}) =>
   mockStore({ rewards: reducer() }, state);
@@ -29,9 +35,6 @@ describe('fetchPrograms() action creator', () => {
     result: [programId],
   };
 
-  const getPrograms = jest.fn();
-  const action = fetchPrograms(getPrograms);
-
   beforeEach(() => {
     jest.clearAllMocks();
     store = rewardsMockStore();
@@ -44,7 +47,7 @@ describe('fetchPrograms() action creator', () => {
     expect.assertions(4);
 
     try {
-      await store.dispatch(action());
+      await store.dispatch(fetchPrograms());
     } catch (error) {
       expect(error).toBe(expectedError);
       expect(getPrograms).toHaveBeenCalledTimes(1);
@@ -63,7 +66,7 @@ describe('fetchPrograms() action creator', () => {
 
   it('should create the correct actions for when the fetch programs procedure is successful', async () => {
     getPrograms.mockResolvedValueOnce(mockResponsePrograms);
-    await store.dispatch(action());
+    await store.dispatch(fetchPrograms());
 
     const actionResults = store.getActions();
 

--- a/packages/redux/src/loyalty/actions/createProgramMembership.js
+++ b/packages/redux/src/loyalty/actions/createProgramMembership.js
@@ -1,63 +1,13 @@
-import {
-  CREATE_PROGRAM_MEMBERSHIP_FAILURE,
-  CREATE_PROGRAM_MEMBERSHIP_REQUEST,
-  CREATE_PROGRAM_MEMBERSHIP_SUCCESS,
-} from '../actionTypes';
-import { normalize } from 'normalizr';
-import membershipSchema from '../../entities/schemas/membership';
-
-/**
- * @typedef {object} CreateMembershipData
- * @property {string} id - Membership identifier.
- * @property {string} externalId - External identifier.
- * @property {number} userId - User identifier.
- * @property {number} rewardPoints - Reward Points.
- * @property {number} cashBalance - Cash balance.
- * @property {('Unverified'|'Activated'|'Invalid'|'Canceled')} status - Membership status.
- */
-
-/**
- * @callback CreateProgramMembershipThunkFactory
- * @param {string} programId - Program identifier.
- * @param {CreateMembershipData} data - Membership to be created.
- * @param {object} [config] - Custom configurations to send to the client
- * instance (axios).
- *
- * @returns {Function} Thunk to be dispatched to the redux store.
- */
+import { createProgramMembershipFactory } from './factories';
+import { postProgramMembership } from '@farfetch/blackout-client/loyalty';
 
 /**
  * Create program membership.
  *
- * @function createProgramMembership
  * @memberof module:loyalty/actions
  *
- * @param {Function} postProgramMembership - Post program membership client.
+ * @name createProgramMembership
  *
- * @returns {CreateProgramMembershipThunkFactory} Thunk factory.
+ * @type {CreateProgramMembershipThunkFactory}
  */
-export default postProgramMembership =>
-  (programId, data, config) =>
-  async dispatch => {
-    dispatch({
-      type: CREATE_PROGRAM_MEMBERSHIP_REQUEST,
-    });
-
-    try {
-      const result = await postProgramMembership(programId, data, config);
-
-      dispatch({
-        payload: normalize(result, membershipSchema),
-        type: CREATE_PROGRAM_MEMBERSHIP_SUCCESS,
-      });
-
-      return result;
-    } catch (error) {
-      dispatch({
-        payload: { error },
-        type: CREATE_PROGRAM_MEMBERSHIP_FAILURE,
-      });
-
-      throw error;
-    }
-  };
+export default createProgramMembershipFactory(postProgramMembership);

--- a/packages/redux/src/loyalty/actions/createProgramMembershipConvert.js
+++ b/packages/redux/src/loyalty/actions/createProgramMembershipConvert.js
@@ -1,58 +1,15 @@
-import {
-  CREATE_PROGRAM_MEMBERSHIP_CONVERT_FAILURE,
-  CREATE_PROGRAM_MEMBERSHIP_CONVERT_REQUEST,
-  CREATE_PROGRAM_MEMBERSHIP_CONVERT_SUCCESS,
-} from '../actionTypes';
-import { normalize } from 'normalizr';
-import convertSchema from '../../entities/schemas/convert';
-
-/**
- * @callback CreateProgramMembershipConvertThunkFactory
- * @param {string} programId - Program identifier.
- * @param {string} membershipId - Membership identifier.
- * @param {object} [config] - Custom configurations to send to the client
- * instance (axios).
- *
- * @returns {Function} Thunk to be dispatched to the redux store.
- */
+import { createProgramMembershipConvertFactory } from './factories';
+import { postProgramMembershipConvert } from '@farfetch/blackout-client/loyalty';
 
 /**
  * Create program membership convert.
  *
- * @function createProgramMembershipConvert
  * @memberof module:loyalty/actions
  *
- * @param {Function} postProgramMembershipConvert - Post program membership
- * convert client.
+ * @name createProgramMembershipConvert
  *
- * @returns {CreateProgramMembershipConvertThunkFactory} Thunk factory.
+ * @type {CreateProgramMembershipConvertThunkFactory}
  */
-export default postProgramMembershipConvert =>
-  (programId, membershipId, config) =>
-  async dispatch => {
-    dispatch({
-      type: CREATE_PROGRAM_MEMBERSHIP_CONVERT_REQUEST,
-    });
-
-    try {
-      const result = await postProgramMembershipConvert(
-        programId,
-        membershipId,
-        config,
-      );
-
-      dispatch({
-        payload: normalize(result, convertSchema),
-        type: CREATE_PROGRAM_MEMBERSHIP_CONVERT_SUCCESS,
-      });
-
-      return result;
-    } catch (error) {
-      dispatch({
-        payload: { error },
-        type: CREATE_PROGRAM_MEMBERSHIP_CONVERT_FAILURE,
-      });
-
-      throw error;
-    }
-  };
+export default createProgramMembershipConvertFactory(
+  postProgramMembershipConvert,
+);

--- a/packages/redux/src/loyalty/actions/createProgramMembershipReplacement.js
+++ b/packages/redux/src/loyalty/actions/createProgramMembershipReplacement.js
@@ -1,65 +1,15 @@
-import {
-  CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_FAILURE,
-  CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_REQUEST,
-  CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_SUCCESS,
-} from '../actionTypes';
-import { normalize } from 'normalizr';
-import replacementSchema from '../../entities/schemas/replacement';
-
-/**
- * @typedef {object} CreateProgramMembershipReplacementData
- * @property {string} reason - Reason of replacement.
- */
-
-/**
- * @callback CreateProgramMembershipReplacementThunkFactory
- * @param {string} programId - Program identifier.
- * @param {string} membershipId - Membership identifier.
- * @param {CreateProgramMembershipReplacementData} data - Replacement to be created.
- * @param {object} [config] - Custom configurations to send to the client
- * instance (axios).
- *
- * @returns {Function} Thunk to be dispatched to the redux store.
- */
+import { createProgramMembershipReplacementFactory } from './factories';
+import { postProgramMembershipReplacement } from '@farfetch/blackout-client/loyalty';
 
 /**
  * Request a new membership id by replacement.
  *
- * @function createProgramMembershipReplacement
  * @memberof module:loyalty/actions
  *
- * @param {Function} postProgramMembershipReplacement - Post program membership
- * replacement client.
+ * @name createProgramMembershipReplacement
  *
- * @returns {CreateProgramMembershipReplacementThunkFactory} Thunk factory.
+ * @type {CreateProgramMembershipReplacementThunkFactory}
  */
-export default postProgramMembershipReplacement =>
-  (programId, membershipId, data, config) =>
-  async dispatch => {
-    dispatch({
-      type: CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_REQUEST,
-    });
-
-    try {
-      const result = await postProgramMembershipReplacement(
-        programId,
-        membershipId,
-        data,
-        config,
-      );
-
-      dispatch({
-        payload: normalize(result, replacementSchema),
-        type: CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_SUCCESS,
-      });
-
-      return result;
-    } catch (error) {
-      dispatch({
-        payload: { error },
-        type: CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_FAILURE,
-      });
-
-      throw error;
-    }
-  };
+export default createProgramMembershipReplacementFactory(
+  postProgramMembershipReplacement,
+);

--- a/packages/redux/src/loyalty/actions/factories/createProgramMembershipConvertFactory.js
+++ b/packages/redux/src/loyalty/actions/factories/createProgramMembershipConvertFactory.js
@@ -1,0 +1,58 @@
+import {
+  CREATE_PROGRAM_MEMBERSHIP_CONVERT_FAILURE,
+  CREATE_PROGRAM_MEMBERSHIP_CONVERT_REQUEST,
+  CREATE_PROGRAM_MEMBERSHIP_CONVERT_SUCCESS,
+} from '../../actionTypes';
+import { normalize } from 'normalizr';
+import convertSchema from '../../../entities/schemas/convert';
+
+/**
+ * @callback CreateProgramMembershipConvertThunkFactory
+ * @param {string} programId - Program identifier.
+ * @param {string} membershipId - Membership identifier.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Create program membership convert.
+ *
+ * @function createProgramMembershipConvertFactory
+ * @memberof module:loyalty/actions/factories
+ *
+ * @param {Function} postProgramMembershipConvert - Post program membership
+ * convert client.
+ *
+ * @returns {CreateProgramMembershipConvertThunkFactory} Thunk factory.
+ */
+export default postProgramMembershipConvert =>
+  (programId, membershipId, config) =>
+  async dispatch => {
+    dispatch({
+      type: CREATE_PROGRAM_MEMBERSHIP_CONVERT_REQUEST,
+    });
+
+    try {
+      const result = await postProgramMembershipConvert(
+        programId,
+        membershipId,
+        config,
+      );
+
+      dispatch({
+        payload: normalize(result, convertSchema),
+        type: CREATE_PROGRAM_MEMBERSHIP_CONVERT_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: CREATE_PROGRAM_MEMBERSHIP_CONVERT_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/redux/src/loyalty/actions/factories/createProgramMembershipFactory.js
+++ b/packages/redux/src/loyalty/actions/factories/createProgramMembershipFactory.js
@@ -1,0 +1,63 @@
+import {
+  CREATE_PROGRAM_MEMBERSHIP_FAILURE,
+  CREATE_PROGRAM_MEMBERSHIP_REQUEST,
+  CREATE_PROGRAM_MEMBERSHIP_SUCCESS,
+} from '../../actionTypes';
+import { normalize } from 'normalizr';
+import membershipSchema from '../../../entities/schemas/membership';
+
+/**
+ * @typedef {object} CreateMembershipData
+ * @property {string} id - Membership identifier.
+ * @property {string} externalId - External identifier.
+ * @property {number} userId - User identifier.
+ * @property {number} rewardPoints - Reward Points.
+ * @property {number} cashBalance - Cash balance.
+ * @property {('Unverified'|'Activated'|'Invalid'|'Canceled')} status - Membership status.
+ */
+
+/**
+ * @callback CreateProgramMembershipThunkFactory
+ * @param {string} programId - Program identifier.
+ * @param {CreateMembershipData} data - Membership to be created.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Create program membership.
+ *
+ * @function createProgramMembershipFactory
+ * @memberof module:loyalty/actions/factories
+ *
+ * @param {Function} postProgramMembership - Post program membership client.
+ *
+ * @returns {CreateProgramMembershipThunkFactory} Thunk factory.
+ */
+export default postProgramMembership =>
+  (programId, data, config) =>
+  async dispatch => {
+    dispatch({
+      type: CREATE_PROGRAM_MEMBERSHIP_REQUEST,
+    });
+
+    try {
+      const result = await postProgramMembership(programId, data, config);
+
+      dispatch({
+        payload: normalize(result, membershipSchema),
+        type: CREATE_PROGRAM_MEMBERSHIP_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: CREATE_PROGRAM_MEMBERSHIP_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/redux/src/loyalty/actions/factories/createProgramMembershipReplacementFactory.js
+++ b/packages/redux/src/loyalty/actions/factories/createProgramMembershipReplacementFactory.js
@@ -1,0 +1,65 @@
+import {
+  CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_FAILURE,
+  CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_REQUEST,
+  CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_SUCCESS,
+} from '../../actionTypes';
+import { normalize } from 'normalizr';
+import replacementSchema from '../../../entities/schemas/replacement';
+
+/**
+ * @typedef {object} CreateProgramMembershipReplacementData
+ * @property {string} reason - Reason of replacement.
+ */
+
+/**
+ * @callback CreateProgramMembershipReplacementThunkFactory
+ * @param {string} programId - Program identifier.
+ * @param {string} membershipId - Membership identifier.
+ * @param {CreateProgramMembershipReplacementData} data - Replacement to be created.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Request a new membership id by replacement.
+ *
+ * @function createProgramMembershipReplacementFactory
+ * @memberof module:loyalty/actions/factories
+ *
+ * @param {Function} postProgramMembershipReplacement - Post program membership
+ * replacement client.
+ *
+ * @returns {CreateProgramMembershipReplacementThunkFactory} Thunk factory.
+ */
+export default postProgramMembershipReplacement =>
+  (programId, membershipId, data, config) =>
+  async dispatch => {
+    dispatch({
+      type: CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_REQUEST,
+    });
+
+    try {
+      const result = await postProgramMembershipReplacement(
+        programId,
+        membershipId,
+        data,
+        config,
+      );
+
+      dispatch({
+        payload: normalize(result, replacementSchema),
+        type: CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/redux/src/loyalty/actions/factories/fetchProgramMembershipStatementsFactory.js
+++ b/packages/redux/src/loyalty/actions/factories/fetchProgramMembershipStatementsFactory.js
@@ -1,0 +1,74 @@
+import {
+  FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_FAILURE,
+  FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_REQUEST,
+  FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_SUCCESS,
+} from '../../actionTypes';
+import { normalize } from 'normalizr';
+import statementSchema from '../../../entities/schemas/statement';
+
+/**
+ * @typedef {object} FetchProgramMembershipStatementsQuery
+ * @property {string} Category - Gets/Sets the Category Add or Convert
+ * statement.Possible Values: Purchase, Misc, Transfer, Bonus, Partner, Convert.
+ * @property {string} InitialDate- Gets/Sets the InitialDate (Ex. 2017-07-20).
+ * @property {string} FinalDate - Gets or sets the FinalDate (Ex. 2017-07-21).
+ * @property {object} PageFilter - Page filter parameters.
+ * @property {string} PageFilter.PageIndex - Gets or sets the
+ * PageIndex (The default is 1).
+ * @property {string} PageFilter.PageSize - Gets or sets the
+ * PageSize (The default is 60).
+ */
+
+/**
+ * @callback FetchProgramMembershipStatementsThunkFactory
+ * @param {string} programId - Program identifier.
+ * @param {string} membershipId - Memberhip identifier.
+ * @param {FetchProgramMembershipStatementsQuery} query - Data to retrieve
+ * memberships statements.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Load program membership statements.
+ *
+ * @function fetchProgramMembershipStatementsFactory
+ * @memberof module:loyalty/actions/factories
+ *
+ * @param {Function} getProgramMembershipStatements - Get program membership
+ * statements client.
+ *
+ * @returns {FetchProgramMembershipStatementsThunkFactory} Thunk factory.
+ */
+export default getProgramMembershipStatements =>
+  (programId, membershipId, query = {}, config) =>
+  async dispatch => {
+    dispatch({
+      type: FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_REQUEST,
+    });
+
+    try {
+      const result = await getProgramMembershipStatements(
+        programId,
+        membershipId,
+        query,
+        config,
+      );
+
+      dispatch({
+        payload: normalize(result, [statementSchema]),
+        type: FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/redux/src/loyalty/actions/factories/fetchProgramUsersMembershipFactory.js
+++ b/packages/redux/src/loyalty/actions/factories/fetchProgramUsersMembershipFactory.js
@@ -1,0 +1,53 @@
+import {
+  FETCH_PROGRAM_USERS_MEMBERSHIP_FAILURE,
+  FETCH_PROGRAM_USERS_MEMBERSHIP_REQUEST,
+  FETCH_PROGRAM_USERS_MEMBERSHIP_SUCCESS,
+} from '../../actionTypes';
+import { normalize } from 'normalizr';
+import membershipSchema from '../../../entities/schemas/membership';
+
+/**
+ * @callback FetchProgramUsersMembershipThunkFactory
+ * @param {string} programId - Program identifier.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Load program membership statements.
+ *
+ * @function fetchProgramUsersMembershipFactory
+ * @memberof module:loyalty/actions/factories
+ *
+ * @param {Function} getProgramUsersMembership - Get program users membership
+ *  client.
+ *
+ * @returns {FetchProgramUsersMembershipThunkFactory} Thunk factory.
+ */
+export default getProgramUsersMembership =>
+  (programId, config) =>
+  async dispatch => {
+    dispatch({
+      type: FETCH_PROGRAM_USERS_MEMBERSHIP_REQUEST,
+    });
+
+    try {
+      const result = await getProgramUsersMembership(programId, config);
+
+      dispatch({
+        payload: normalize(result, membershipSchema),
+        type: FETCH_PROGRAM_USERS_MEMBERSHIP_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: FETCH_PROGRAM_USERS_MEMBERSHIP_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/redux/src/loyalty/actions/factories/fetchProgramsFactory.js
+++ b/packages/redux/src/loyalty/actions/factories/fetchProgramsFactory.js
@@ -1,0 +1,49 @@
+import {
+  FETCH_PROGRAMS_FAILURE,
+  FETCH_PROGRAMS_REQUEST,
+  FETCH_PROGRAMS_SUCCESS,
+} from '../../actionTypes';
+import { normalize } from 'normalizr';
+import programSchema from '../../../entities/schemas/program';
+
+/**
+ * @callback FetchProgramUsersThunkFactory
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Load programs.
+ *
+ * @function fetchProgramsFactory
+ * @memberof module:loyalty/actions/factories
+ *
+ * @param {Function} getPrograms - Get programs client.
+ *
+ * @returns {FetchProgramUsersThunkFactory} Thunk factory.
+ */
+export default getPrograms => config => async dispatch => {
+  dispatch({
+    type: FETCH_PROGRAMS_REQUEST,
+  });
+
+  try {
+    const result = await getPrograms(config);
+
+    dispatch({
+      payload: normalize(result, [programSchema]),
+      type: FETCH_PROGRAMS_SUCCESS,
+    });
+
+    return result;
+  } catch (error) {
+    dispatch({
+      payload: { error },
+      type: FETCH_PROGRAMS_FAILURE,
+    });
+
+    throw error;
+  }
+};

--- a/packages/redux/src/loyalty/actions/factories/index.js
+++ b/packages/redux/src/loyalty/actions/factories/index.js
@@ -1,0 +1,14 @@
+/**
+ * Loyalty actions factories.
+ *
+ * @module loyalty/actions/factories
+ * @category Products
+ * @subcategory Actions Factories
+ */
+
+export { default as createProgramMembershipConvertFactory } from './createProgramMembershipConvertFactory';
+export { default as createProgramMembershipFactory } from './createProgramMembershipFactory';
+export { default as createProgramMembershipReplacementFactory } from './createProgramMembershipReplacementFactory';
+export { default as fetchProgramMembershipStatementsFactory } from './fetchProgramMembershipStatementsFactory';
+export { default as fetchProgramsFactory } from './fetchProgramsFactory';
+export { default as fetchProgramUsersMembershipFactory } from './fetchProgramUsersMembershipFactory';

--- a/packages/redux/src/loyalty/actions/fetchProgramMembershipStatements.js
+++ b/packages/redux/src/loyalty/actions/fetchProgramMembershipStatements.js
@@ -1,74 +1,15 @@
-import {
-  FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_FAILURE,
-  FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_REQUEST,
-  FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_SUCCESS,
-} from '../actionTypes';
-import { normalize } from 'normalizr';
-import statementSchema from '../../entities/schemas/statement';
-
-/**
- * @typedef {object} FetchProgramMembershipStatementsQuery
- * @property {string} Category - Gets/Sets the Category Add or Convert
- * statement.Possible Values: Purchase, Misc, Transfer, Bonus, Partner, Convert.
- * @property {string} InitialDate- Gets/Sets the InitialDate (Ex. 2017-07-20).
- * @property {string} FinalDate - Gets or sets the FinalDate (Ex. 2017-07-21).
- * @property {object} PageFilter - Page filter parameters.
- * @property {string} PageFilter.PageIndex - Gets or sets the
- * PageIndex (The default is 1).
- * @property {string} PageFilter.PageSize - Gets or sets the
- * PageSize (The default is 60).
- */
-
-/**
- * @callback FetchProgramMembershipStatementsThunkFactory
- * @param {string} programId - Program identifier.
- * @param {string} membershipId - Memberhip identifier.
- * @param {FetchProgramMembershipStatementsQuery} query - Data to retrieve
- * memberships statements.
- * @param {object} [config] - Custom configurations to send to the client
- * instance (axios).
- *
- * @returns {Function} Thunk to be dispatched to the redux store.
- */
+import { fetchProgramMembershipStatementsFactory } from './factories';
+import { getProgramMembershipStatements } from '@farfetch/blackout-client/loyalty';
 
 /**
  * Load program membership statements.
  *
- * @function fetchProgramMembershipStatements
  * @memberof module:loyalty/actions
  *
- * @param {Function} getProgramMembershipStatements - Get program membership
- * statements client.
+ * @name fetchProgramMembershipStatements
  *
- * @returns {FetchProgramMembershipStatementsThunkFactory} Thunk factory.
+ * @type {FetchProgramMembershipStatementsThunkFactory}
  */
-export default getProgramMembershipStatements =>
-  (programId, membershipId, query = {}, config) =>
-  async dispatch => {
-    dispatch({
-      type: FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_REQUEST,
-    });
-
-    try {
-      const result = await getProgramMembershipStatements(
-        programId,
-        membershipId,
-        query,
-        config,
-      );
-
-      dispatch({
-        payload: normalize(result, [statementSchema]),
-        type: FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_SUCCESS,
-      });
-
-      return result;
-    } catch (error) {
-      dispatch({
-        payload: { error },
-        type: FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_FAILURE,
-      });
-
-      throw error;
-    }
-  };
+export default fetchProgramMembershipStatementsFactory(
+  getProgramMembershipStatements,
+);

--- a/packages/redux/src/loyalty/actions/fetchProgramUsersMembership.js
+++ b/packages/redux/src/loyalty/actions/fetchProgramUsersMembership.js
@@ -1,53 +1,13 @@
-import {
-  FETCH_PROGRAM_USERS_MEMBERSHIP_FAILURE,
-  FETCH_PROGRAM_USERS_MEMBERSHIP_REQUEST,
-  FETCH_PROGRAM_USERS_MEMBERSHIP_SUCCESS,
-} from '../actionTypes';
-import { normalize } from 'normalizr';
-import membershipSchema from '../../entities/schemas/membership';
-
-/**
- * @callback FetchProgramUsersMembershipThunkFactory
- * @param {string} programId - Program identifier.
- * @param {object} [config] - Custom configurations to send to the client
- * instance (axios).
- *
- * @returns {Function} Thunk to be dispatched to the redux store.
- */
+import { fetchProgramUsersMembershipFactory } from './factories';
+import { getProgramUsersMembership } from '@farfetch/blackout-client/loyalty';
 
 /**
  * Load program membership statements.
  *
- * @function fetchProgramUsersMembership
  * @memberof module:loyalty/actions
  *
- * @param {Function} getProgramUsersMembership - Get program users membership
- *  client.
+ * @name fetchProgramUsersMembership
  *
- * @returns {FetchProgramUsersMembershipThunkFactory} Thunk factory.
+ * @type {FetchProgramUsersMembershipThunkFactory}
  */
-export default getProgramUsersMembership =>
-  (programId, config) =>
-  async dispatch => {
-    dispatch({
-      type: FETCH_PROGRAM_USERS_MEMBERSHIP_REQUEST,
-    });
-
-    try {
-      const result = await getProgramUsersMembership(programId, config);
-
-      dispatch({
-        payload: normalize(result, membershipSchema),
-        type: FETCH_PROGRAM_USERS_MEMBERSHIP_SUCCESS,
-      });
-
-      return result;
-    } catch (error) {
-      dispatch({
-        payload: { error },
-        type: FETCH_PROGRAM_USERS_MEMBERSHIP_FAILURE,
-      });
-
-      throw error;
-    }
-  };
+export default fetchProgramUsersMembershipFactory(getProgramUsersMembership);

--- a/packages/redux/src/loyalty/actions/fetchPrograms.js
+++ b/packages/redux/src/loyalty/actions/fetchPrograms.js
@@ -1,49 +1,13 @@
-import {
-  FETCH_PROGRAMS_FAILURE,
-  FETCH_PROGRAMS_REQUEST,
-  FETCH_PROGRAMS_SUCCESS,
-} from '../actionTypes';
-import { normalize } from 'normalizr';
-import programSchema from '../../entities/schemas/program';
-
-/**
- * @callback FetchProgramUsersThunkFactory
- * @param {object} [config] - Custom configurations to send to the client
- * instance (axios).
- *
- * @returns {Function} Thunk to be dispatched to the redux store.
- */
+import { fetchProgramsFactory } from './factories';
+import { getPrograms } from '@farfetch/blackout-client/loyalty';
 
 /**
  * Load programs.
  *
- * @function fetchPrograms
  * @memberof module:loyalty/actions
  *
- * @param {Function} getPrograms - Get programs client.
+ * @name fetchPrograms
  *
- * @returns {FetchProgramUsersThunkFactory} Thunk factory.
+ * @type {FetchProgramUsersThunkFactory}
  */
-export default getPrograms => config => async dispatch => {
-  dispatch({
-    type: FETCH_PROGRAMS_REQUEST,
-  });
-
-  try {
-    const result = await getPrograms(config);
-
-    dispatch({
-      payload: normalize(result, [programSchema]),
-      type: FETCH_PROGRAMS_SUCCESS,
-    });
-
-    return result;
-  } catch (error) {
-    dispatch({
-      payload: { error },
-      type: FETCH_PROGRAMS_FAILURE,
-    });
-
-    throw error;
-  }
-};
+export default fetchProgramsFactory(getPrograms);


### PR DESCRIPTION
## Description

This creates the factories for the `loyalty` actions, and provides the respective actions with the client embedded.

BREAKING CHANGE

- The action creators `createProgramMembership`, `createProgramMembershipConvert`, 
`createProgramMembershipReplacement`, `fetchProgramMembershipStatements`, `fetchPrograms`
`fetchProgramUsersMembership`,  were renamed and now come pre-configured with the 
corresponding client from @blackout-client, so you do not need to configure 
these action creators anymore if you use the default @blackout-client client provided.

```js
// Previously
import {
  fetchPrograms,
  createProgramMembership,
  createProgramMembershipReplacement,
  createProgramMembershipConvert,
  fetchProgramMembershipStatements,
  fetchProgramUsersMembership,
} from '@blackout-redux/loyalty';
import {
  getPrograms,
  postProgramMembership,
  postProgramMembershipReplacement,
  postProgramMembershipConvert,
  getProgramMembershipStatements,
  getProgramUsersMembership,
} from '@blackout-client/loyalty';

const mapDispatchToProps = {
  getPrograms: fetchPrograms(getPrograms),
  createProgramMembership: createProgramMembership(postProgramMembership),
  (...)
};

// Change to:
import {
  fetchPrograms,
  createProgramMembership,
  (...)
} from '@blackout-redux/loyalty';

const mapDispatchToProps = {
  getPrograms: fetchPrograms,
  createProgramMembership: createProgramMembership,
  (...)
};
```

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
