### PR TITLE
feat(core): implement new return endpoints

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,7 @@
 ---
-name: "Bug"
+name: 'Bug'
 about: Report a detailed bug or problem.
-labels: "type: bug"
+labels: 'type: bug'
 ---
 
 ## Expected behavior

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,7 @@
 ---
-name: "Feature"
+name: 'Feature'
 about: Request a feature or a different way of doing something.
-labels: "type: feature"
+labels: 'type: feature'
 ---
 
 ## Is your proposal related to a problem?

--- a/packages/core/src/returns/client/__fixtures__/getPickupCapabilities.fixtures.js
+++ b/packages/core/src/returns/client/__fixtures__/getPickupCapabilities.fixtures.js
@@ -1,30 +1,63 @@
-import get from 'lodash/get';
 import join from 'proper-url-join';
 import moxios from 'moxios';
 
 export default {
-  success: params => {
-    moxios.stubRequest(
-      join('/api/legacy/v1/returns', params.id, 'pickupcapabilities', {
-        query: get(params, 'query'),
-      }),
-      {
-        method: 'get',
-        response: get(params, 'response'),
-        status: 200,
-      },
-    );
+  accsvc: {
+    success: params => {
+      moxios.stubRequest(
+        join(
+          '/api/account/v1/returns',
+          params.id,
+          'pickupcapabilities/',
+          params.pickupDay,
+        ),
+        {
+          method: 'get',
+          response: params.response,
+          status: 200,
+        },
+      );
+    },
+    failure: params => {
+      moxios.stubRequest(
+        join(
+          '/api/account/v1/returns',
+          params.id,
+          'pickupcapabilities/',
+          params.pickupDay,
+        ),
+        {
+          method: 'get',
+          response: 'stub error',
+          status: 404,
+        },
+      );
+    },
   },
-  failure: params => {
-    moxios.stubRequest(
-      join('/api/legacy/v1/returns', params.id, 'pickupcapabilities', {
-        query: get(params, 'query'),
-      }),
-      {
-        method: 'get',
-        response: 'stub error',
-        status: 404,
-      },
-    );
+  legacy: {
+    success: params => {
+      moxios.stubRequest(
+        join('/api/legacy/v1/returns', params.id, 'pickupcapabilities/', {
+          query: params.query,
+        }),
+        {
+          method: 'get',
+          response: params.response,
+          status: 200,
+        },
+      );
+    },
+    failure: params => {
+      moxios.stubRequest(
+        join('/api/legacy/v1/returns', params.id, 'pickupcapabilities/', {
+          query: params.query,
+        }),
+        {
+          method: 'get',
+          response: 'stub error',
+          status: 404,
+        },
+      );
+    },
   },
 };

--- a/packages/core/src/returns/client/__fixtures__/getReferences.fixtures.js
+++ b/packages/core/src/returns/client/__fixtures__/getReferences.fixtures.js
@@ -1,24 +1,23 @@
-import get from 'lodash/get';
 import join from 'proper-url-join';
 import moxios from 'moxios';
 
 export default {
   success: params => {
     moxios.stubRequest(
-      join('/api/legacy/v1/returns', params.id, 'references', params.name, {
-        query: get(params, 'query'),
+      join('/api/account/v1/returns', params.id, 'references', params.name, {
+        query: params.query,
       }),
       {
         method: 'get',
-        response: get(params, 'response'),
+        response: params.response,
         status: 200,
       },
     );
   },
   failure: params => {
     moxios.stubRequest(
-      join('/api/legacy/v1/returns', params.id, 'references', params.name, {
-        query: get(params, 'query'),
+      join('/api/account/v1/returns', params.id, 'references', params.name, {
+        query: params.query,
       }),
       {
         method: 'get',

--- a/packages/core/src/returns/client/__fixtures__/getReturn.fixtures.js
+++ b/packages/core/src/returns/client/__fixtures__/getReturn.fixtures.js
@@ -5,7 +5,7 @@ import moxios from 'moxios';
 export default {
   success: params => {
     moxios.stubRequest(
-      join('/api/legacy/v1/returns', params.id, {
+      join('/api/account/v1/returns', params.id, {
         query: get(params, 'query'),
       }),
       {
@@ -17,7 +17,7 @@ export default {
   },
   failure: params => {
     moxios.stubRequest(
-      join('/api/legacy/v1/returns', params.id, {
+      join('/api/account/v1/returns', params.id, {
         query: get(params, 'query'),
       }),
       {

--- a/packages/core/src/returns/client/__fixtures__/patchReturn.fixtures.js
+++ b/packages/core/src/returns/client/__fixtures__/patchReturn.fixtures.js
@@ -5,7 +5,7 @@ import moxios from 'moxios';
 export default {
   success: params => {
     moxios.stubRequest(
-      join('/api/legacy/v1/returns', params.id, {
+      join('/api/account/v1/returns', params.id, {
         query: get(params, 'query'),
       }),
       {
@@ -17,7 +17,7 @@ export default {
   },
   failure: params => {
     moxios.stubRequest(
-      join('/api/legacy/v1/returns', params.id, {
+      join('/api/account/v1/returns', params.id, {
         query: get(params, 'query'),
       }),
       {

--- a/packages/core/src/returns/client/__fixtures__/postReturn.fixtures.js
+++ b/packages/core/src/returns/client/__fixtures__/postReturn.fixtures.js
@@ -5,7 +5,7 @@ import moxios from 'moxios';
 export default {
   success: params => {
     moxios.stubRequest(
-      join('/api/legacy/v1/returns', {
+      join('/api/account/v1/returns', {
         query: get(params, 'query'),
       }),
       {
@@ -17,7 +17,7 @@ export default {
   },
   failure: params => {
     moxios.stubRequest(
-      join('/api/legacy/v1/returns', {
+      join('/api/account/v1/returns', {
         query: get(params, 'query'),
       }),
       {

--- a/packages/core/src/returns/client/__tests__/__snapshots__/getPickupCapabilities.test.js.snap
+++ b/packages/core/src/returns/client/__tests__/__snapshots__/getPickupCapabilities.test.js.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getPickupCapabilities should receive a client request error 1`] = `
+exports[`getPickupCapabilities Account SVC should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;
+
+exports[`getPickupCapabilities Legacy should receive a client request error 1`] = `
 Object {
   "code": -1,
   "message": "stub error",

--- a/packages/core/src/returns/client/__tests__/getPickupCapabilities.test.js
+++ b/packages/core/src/returns/client/__tests__/getPickupCapabilities.test.js
@@ -6,9 +6,7 @@ import moxios from 'moxios';
 
 describe('getPickupCapabilities', () => {
   const spy = jest.spyOn(client, 'get');
-  const id = '123456';
   const expectedConfig = undefined;
-  const query = { guestUserEmail: 'test@email.com' };
 
   beforeEach(() => {
     moxios.install(client);
@@ -17,31 +15,67 @@ describe('getPickupCapabilities', () => {
 
   afterEach(() => moxios.uninstall(client));
 
-  it('should handle a client request successfully', async () => {
-    const response = {};
+  describe('Account SVC', () => {
+    const id = 123456;
+    const query = { pickupDay: '2020-04-20' };
 
-    fixture.success({
-      id,
-      response,
-      query,
+    it('should handle a client request successfully', async () => {
+      const response = {};
+
+      fixture.accsvc.success({
+        id,
+        pickupDay: query.pickupDay,
+        response,
+      });
+
+      expect.assertions(2);
+      await expect(getPickupCapabilities(id, query)).resolves.toStrictEqual(
+        response,
+      );
+      expect(spy).toHaveBeenCalledWith(
+        join(`/account/v1/returns/${id}/pickupcapabilities/${query.pickupDay}`),
+        expectedConfig,
+      );
     });
 
-    expect.assertions(2);
-    await expect(getPickupCapabilities(id, query)).resolves.toBe(response);
-    expect(spy).toHaveBeenCalledWith(
-      join(`/legacy/v1/returns/${id}/pickupcapabilities`, { query }),
-      expectedConfig,
-    );
+    it('should receive a client request error', async () => {
+      fixture.accsvc.failure({ id, pickupDay: query.pickupDay });
+
+      expect.assertions(2);
+      await expect(getPickupCapabilities(id, query)).rejects.toMatchSnapshot();
+      expect(spy).toHaveBeenCalledWith(
+        join(`/account/v1/returns/${id}/pickupcapabilities/${query.pickupDay}`),
+        expectedConfig,
+      );
+    });
   });
 
-  it('should receive a client request error', async () => {
-    fixture.failure({ id, query });
+  describe('Legacy', () => {
+    const query = { pickupDay: 1519211809934 };
+    const id = '123456';
 
-    expect.assertions(2);
-    await expect(getPickupCapabilities(id, query)).rejects.toMatchSnapshot();
-    expect(spy).toHaveBeenCalledWith(
-      join(`/legacy/v1/returns/${id}/pickupcapabilities`, { query }),
-      expectedConfig,
-    );
+    it('should handle a client request successfully', async () => {
+      const response = {};
+
+      fixture.legacy.success({ id, query, response });
+
+      expect.assertions(2);
+      await expect(getPickupCapabilities(id, query)).resolves.toBe(response);
+      expect(spy).toHaveBeenCalledWith(
+        join('/legacy/v1/returns', id, 'pickupcapabilities', { query }),
+        expectedConfig,
+      );
+    });
+
+    it('should receive a client request error', async () => {
+      fixture.legacy.failure({ id, query });
+
+      expect.assertions(2);
+      await expect(getPickupCapabilities(id, query)).rejects.toMatchSnapshot();
+      expect(spy).toHaveBeenCalledWith(
+        join('/legacy/v1/returns', id, 'pickupcapabilities', { query }),
+        expectedConfig,
+      );
+    });
   });
 });

--- a/packages/core/src/returns/client/__tests__/getReferences.test.js
+++ b/packages/core/src/returns/client/__tests__/getReferences.test.js
@@ -31,7 +31,7 @@ describe('getReferences', () => {
     expect.assertions(2);
     await expect(getReferences(id, name, query)).resolves.toBe(response);
     expect(spy).toHaveBeenCalledWith(
-      join(`/legacy/v1/returns/${id}/references/${name}`, { query }),
+      join(`/account/v1/returns/${id}/references/${name}`, { query }),
       expectedConfig,
     );
   });
@@ -42,7 +42,7 @@ describe('getReferences', () => {
     expect.assertions(2);
     await expect(getReferences(id, name, query)).rejects.toMatchSnapshot();
     expect(spy).toHaveBeenCalledWith(
-      join(`/legacy/v1/returns/${id}/references/${name}`, { query }),
+      join(`/account/v1/returns/${id}/references/${name}`, { query }),
       expectedConfig,
     );
   });

--- a/packages/core/src/returns/client/__tests__/getReturn.test.js
+++ b/packages/core/src/returns/client/__tests__/getReturn.test.js
@@ -25,7 +25,7 @@ describe('getReturn', () => {
     expect.assertions(2);
     await expect(getReturn(id, query)).resolves.toBe(response);
     expect(spy).toHaveBeenCalledWith(
-      join(`/legacy/v1/returns/${id}`, { query }),
+      join(`/account/v1/returns/${id}`, { query }),
       expectedConfig,
     );
   });
@@ -36,7 +36,7 @@ describe('getReturn', () => {
     expect.assertions(2);
     await expect(getReturn(id, query)).rejects.toMatchSnapshot();
     expect(spy).toHaveBeenCalledWith(
-      join(`/legacy/v1/returns/${id}`, { query }),
+      join(`/account/v1/returns/${id}`, { query }),
       expectedConfig,
     );
   });

--- a/packages/core/src/returns/client/__tests__/patchReturn.test.js
+++ b/packages/core/src/returns/client/__tests__/patchReturn.test.js
@@ -26,7 +26,7 @@ describe('patchReturn', () => {
     expect.assertions(2);
     await expect(patchReturn(id, data, query)).resolves.toBe(response);
     expect(spy).toHaveBeenCalledWith(
-      join(`/legacy/v1/returns/${id}`, { query }),
+      join(`/account/v1/returns/${id}`, { query }),
       data,
       expectedConfig,
     );
@@ -38,7 +38,7 @@ describe('patchReturn', () => {
     expect.assertions(2);
     await expect(patchReturn(id, data, query)).rejects.toMatchSnapshot();
     expect(spy).toHaveBeenCalledWith(
-      join(`/legacy/v1/returns/${id}`, { query }),
+      join(`/account/v1/returns/${id}`, { query }),
       data,
       expectedConfig,
     );

--- a/packages/core/src/returns/client/__tests__/postReturn.test.js
+++ b/packages/core/src/returns/client/__tests__/postReturn.test.js
@@ -25,7 +25,7 @@ describe('postReturn()', () => {
     expect.assertions(2);
     await expect(postReturn(data, query)).resolves.toBe(response);
     expect(spy).toHaveBeenCalledWith(
-      join('/legacy/v1/returns/', { query }),
+      join('/account/v1/returns/', { query }),
       data,
       expectedConfig,
     );
@@ -37,7 +37,7 @@ describe('postReturn()', () => {
     expect.assertions(2);
     await expect(postReturn(data, query)).rejects.toMatchSnapshot();
     expect(spy).toHaveBeenCalledWith(
-      join('/legacy/v1/returns/', { query }),
+      join('/account/v1/returns/', { query }),
       data,
       expectedConfig,
     );

--- a/packages/core/src/returns/client/getPickupCapabilities.js
+++ b/packages/core/src/returns/client/getPickupCapabilities.js
@@ -20,21 +20,34 @@ import join from 'proper-url-join';
  * @function getPickupCapabilities
  * @memberof module:returns/client
  *
- * @param {string} id - Return identifier.
- * @param {GetPickupCapabilitiesQuery} query - Query parameters.
+ * @param {number} id - Return identifier.
+ * @param {GetPickupCapabilitiesQuery} pickupDay - Query parameters.
  * @param {object} [config] - Custom configurations to send to the client
  * instance (axios).
  *
  * @returns {Promise} Promise that will resolve when the call to
  * the endpoint finishes.
  */
-export default (id, query, config) =>
-  client
-    .get(
-      join('/legacy/v1/returns', id, 'pickupcapabilities', { query }),
-      config,
-    )
+export default (id, pickupDay, config) => {
+  const returnId = id.toString();
+  const isQuery = typeof pickupDay.pickupDay !== 'string';
+
+  const args = isQuery
+    ? [
+        join('/legacy/v1/returns', id, 'pickupcapabilities', {
+          query: pickupDay,
+        }),
+        config,
+      ]
+    : [
+        join('/account/v1/returns', returnId, 'pickupcapabilities', pickupDay),
+        config,
+      ];
+
+  return client
+    .get(...args)
     .then(response => response.data)
     .catch(error => {
       throw adaptError(error);
     });
+};

--- a/packages/core/src/returns/client/getReferences.js
+++ b/packages/core/src/returns/client/getReferences.js
@@ -31,7 +31,7 @@ import join from 'proper-url-join';
  */
 export default (id, name, query, config) =>
   client
-    .get(join('/legacy/v1/returns', id, 'references', name, { query }), config)
+    .get(join('/account/v1/returns', id, 'references', name, { query }), config)
     .then(response => response.data)
     .catch(error => {
       throw adaptError(error);

--- a/packages/core/src/returns/client/getReturn.js
+++ b/packages/core/src/returns/client/getReturn.js
@@ -29,7 +29,7 @@ import join from 'proper-url-join';
  */
 export default (id, query, config) =>
   client
-    .get(join('/legacy/v1/returns', id, { query }), config)
+    .get(join('/account/v1/returns', id, { query }), config)
     .then(response => response.data)
     .catch(error => {
       throw adaptError(error);

--- a/packages/core/src/returns/client/patchReturn.js
+++ b/packages/core/src/returns/client/patchReturn.js
@@ -42,7 +42,7 @@ import join from 'proper-url-join';
  */
 export default (id, data, query, config) =>
   client
-    .patch(join('/legacy/v1/returns', id, { query }), data, config)
+    .patch(join('/account/v1/returns', id, { query }), data, config)
     .then(response => response.data)
     .catch(error => {
       throw adaptError(error);

--- a/packages/core/src/returns/client/postReturn.js
+++ b/packages/core/src/returns/client/postReturn.js
@@ -36,7 +36,7 @@ import join from 'proper-url-join';
  */
 export default (data, query, config) =>
   client
-    .post(join('/legacy/v1/returns', { query }), data, config)
+    .post(join('/account/v1/returns', { query }), data, config)
     .then(response => response.data)
     .catch(error => {
       throw adaptError(error);

--- a/packages/core/src/returns/redux/actions/__tests__/doGetPickupCapabilities.test.js
+++ b/packages/core/src/returns/redux/actions/__tests__/doGetPickupCapabilities.test.js
@@ -8,22 +8,13 @@ const returnsMockStore = (state = {}) =>
   mockStore({ returns: reducer() }, state);
 
 describe('doGetPickupCapabilities action creator', () => {
-  const pickupDay = 154992960000;
-  const queryParams = {
-    pickupDay,
-    guestOrderId: '12345',
-    guestUserEmail: 'test@test.com',
-  };
+  const pickupDay = '1974-11-29';
   const expectedConfig = undefined;
   let store;
 
   const getPickupCapabilities = jest.fn();
   const action = doGetPickupCapabilities(getPickupCapabilities);
   const returnId = 5926969;
-  const expectedQueryParams = {
-    ...queryParams,
-    pickupDay: '1974-11-29',
-  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -37,13 +28,13 @@ describe('doGetPickupCapabilities action creator', () => {
     expect.assertions(4);
 
     try {
-      await store.dispatch(action(returnId, pickupDay, queryParams));
+      await store.dispatch(action(returnId, pickupDay));
     } catch (error) {
       expect(error).toBe(expectedError);
       expect(getPickupCapabilities).toHaveBeenCalledTimes(1);
       expect(getPickupCapabilities).toHaveBeenCalledWith(
         returnId,
-        expectedQueryParams,
+        pickupDay,
         expectedConfig,
       );
       expect(store.getActions()).toEqual(
@@ -100,14 +91,14 @@ describe('doGetPickupCapabilities action creator', () => {
     getPickupCapabilities.mockResolvedValueOnce(
       responses.getPickupCapabilities.success,
     );
-    await store.dispatch(action(returnId, pickupDay, queryParams));
+    await store.dispatch(action(returnId, pickupDay));
 
     const actionResults = store.getActions();
 
     expect(getPickupCapabilities).toHaveBeenCalledTimes(1);
     expect(getPickupCapabilities).toHaveBeenCalledWith(
       returnId,
-      expectedQueryParams,
+      pickupDay,
       expectedConfig,
     );
     expect(actionResults).toMatchObject([

--- a/packages/core/src/returns/redux/actions/doGetPickupCapabilities.js
+++ b/packages/core/src/returns/redux/actions/doGetPickupCapabilities.js
@@ -4,7 +4,6 @@ import {
   GET_PICKUP_CAPABILITIES_REQUEST,
   GET_PICKUP_CAPABILITIES_SUCCESS,
 } from '../actionTypes';
-import parsePickupDate from '../../../helpers/parsePickupDate';
 
 /**
  * @typedef {object} GetPickupCapabilitiesQuery
@@ -17,10 +16,8 @@ import parsePickupDate from '../../../helpers/parsePickupDate';
 
 /**
  * @callback GetPickupCapabilitiesThunkFactory
- * @param {string} id - Return identifier.
- * @param {number} pickupDay - Deprecated: Timestamp for the day of pickup.
- * This parameter will no longer be available in the next major version (2.x.x).
- * @param {GetPickupCapabilitiesQuery} [query] - Query parameters for the pickup capabilities.
+ * @param {number} id - Return identifier.
+ * @param {string} pickupDay - Day of the pickup. Format: YYYY-MM-DD.
  * @param {object} [config] - Custom configurations to send to the client
  * instance (axios).
  *
@@ -38,13 +35,8 @@ import parsePickupDate from '../../../helpers/parsePickupDate';
  * @returns {GetPickupCapabilitiesThunkFactory} Thunk factory.
  */
 export default getPickupCapabilities =>
-  (id, pickupDay, query = {}, config) =>
+  (id, pickupDay, config) =>
   async dispatch => {
-    const queryParams = {
-      ...query,
-      pickupDay: parsePickupDate(query.pickupDay ? query.pickupDay : pickupDay),
-    };
-
     dispatch({
       type: GET_PICKUP_CAPABILITIES_REQUEST,
     });
@@ -55,7 +47,7 @@ export default getPickupCapabilities =>
         availableStartHours,
         availableTimeSlots,
         pickupDate,
-      } = await getPickupCapabilities(id, queryParams, config);
+      } = await getPickupCapabilities(id, pickupDay, config);
 
       dispatch({
         meta: { id },


### PR DESCRIPTION
## Description

- Implement new return endpoints. Changed from /legacy/v1/returns to /account/v1/returns
- Changed pickupCapabilities endpoint. No longer needs a query, only needs the pickupDay in the format YYYY-MM-DD

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
