### PR TITLE
fix: `useBag` hook types

### DIFF
--- a/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
@@ -1,5 +1,9 @@
 import { cleanup } from '@testing-library/react';
-import { mockLoadingState, mockState } from 'tests/__fixtures__/bags';
+import {
+  mockInitialState,
+  mockLoadingState,
+  mockState,
+} from 'tests/__fixtures__/bags';
 import { mockStore } from '../../../../tests/helpers';
 import { Provider } from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
@@ -39,10 +43,10 @@ describe('useBag', () => {
 
     expect(current).toStrictEqual({
       bag: expect.any(Object),
-      bagId: expect.any(String),
       error: expect.any(Object),
       fetchBag: expect.any(Function),
-      hasItems: expect.any(Boolean),
+      id: expect.any(String),
+      isEmpty: expect.any(Boolean),
       isLoading: expect.any(Boolean),
       isWithAnyError: expect.any(Boolean),
       items: expect.any(Array),
@@ -62,10 +66,10 @@ describe('useBag', () => {
     expect(isLoading).toBe(true);
   });
 
-  it('should return hasItems as true if it has items', () => {
-    const { hasItems } = getRenderedHook();
+  it('should return isEmpty as true if it does not have items', () => {
+    const { isEmpty } = getRenderedHook({ ...mockState, ...mockInitialState });
 
-    expect(hasItems).toBe(true);
+    expect(isEmpty).toBe(true);
   });
 
   describe('actions', () => {

--- a/packages/react/src/bags/hooks/types/useBag.ts
+++ b/packages/react/src/bags/hooks/types/useBag.ts
@@ -1,18 +1,18 @@
+import type { Bag } from '@farfetch/blackout-client/src/bags/types';
 import type { BagItemHydrated } from '@farfetch/blackout-redux/src/entities/types';
-import type { Error } from '@farfetch/blackout-client/types';
-import type { NormalizedBag } from '@farfetch/blackout-redux/src/bags/types';
+import type { State } from '@farfetch/blackout-redux/src/bags/types';
 
 export type UseBag = () => {
-  bag: NormalizedBag | null;
-  bagId: NormalizedBag['id'] | null;
-  error: Error | null | undefined;
-  fetchBag: () => Promise<NormalizedBag>;
-  hasItems: boolean | undefined;
-  isLoading: boolean | undefined;
+  bag: State['result'];
+  error: State['error'] | undefined;
+  fetchBag: () => Promise<Bag>;
+  id: State['id'];
+  isEmpty: boolean | undefined;
+  isLoading: State['isLoading'];
   isWithAnyError: boolean | undefined;
   items: BagItemHydrated[];
   itemsIds: BagItemHydrated['id'][] | null;
   itemsUnavailable: BagItemHydrated[] | undefined;
   resetBag: () => void;
-  resetBagState: () => void;
+  resetBagState: (fieldsToReset?: string[]) => void;
 };

--- a/packages/react/src/bags/hooks/useBag.ts
+++ b/packages/react/src/bags/hooks/useBag.ts
@@ -34,14 +34,14 @@ import type { UseBag } from './types';
 const useBag: UseBag = () => {
   // Selectors
   const bag = useSelector(getBag);
-  const bagId = useSelector(getBagId);
   const error = useSelector(getBagError);
   const isBagLoading = useSelector(isBagLoadingSelector);
+  const id = useSelector(getBagId);
   const isWithAnyError = useSelector(isBagWithAnyError);
   const items = useSelector(getBagItems);
   const itemsIds = useSelector(getBagItemsIds);
   const itemsUnavailable = useSelector(getBagItemsUnavailable);
-  const hasItems = items?.length > 0;
+  const isEmpty = items?.length === 0;
   const isLoading = (!bag && !error) || isBagLoading;
   // Actions
   const fetchBag = useAction(fetchBagAction);
@@ -55,12 +55,7 @@ const useBag: UseBag = () => {
      * @type {object}
      */
     bag,
-    /**
-     * Bag identifier.
-     *
-     * @type {string}
-     */
-    bagId,
+
     /**
      * Bag error.
      *
@@ -74,15 +69,21 @@ const useBag: UseBag = () => {
      */
     fetchBag,
     /**
-     * Whether the bag has any items.
+     * Whether the bag is empty (doesn't have items).
      *
      * @type {boolean}
      */
-    hasItems,
+    id,
     /**
      * Whether the bag is loading.
      *
      * @type {boolean}
+     */
+    isEmpty,
+    /**
+     * Bag identifier.
+     *
+     * @type {string}
      */
     isLoading,
     /**

--- a/packages/redux/src/bags/actions/fetchBag.ts
+++ b/packages/redux/src/bags/actions/fetchBag.ts
@@ -2,7 +2,7 @@ import { fetchBagFactory } from './factories';
 import { getBag } from '@farfetch/blackout-client/bags';
 
 /**
- * Fetches a bag item with the given id.
+ * Fetches the bag.
  *
  * @memberof module:bags/actions
  *


### PR DESCRIPTION
## Description

This fixes some types on the useBag hook. It also changes some of its returned values, such as `isEmpty` instead of `hasItems` and `id` instead of `bagId`.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
