### PR TITLE
feat(redux): reset returns data on logout

### DIFF
--- a/packages/redux/src/entities/__tests__/__snapshots__/reducer.test.js.snap
+++ b/packages/redux/src/entities/__tests__/__snapshots__/reducer.test.js.snap
@@ -59,6 +59,7 @@ Object {
     "@farfetch/blackout-client/FETCH_PICKUP_CAPABILITIES_SUCCESS": [Function],
     "@farfetch/blackout-client/RESET_RETURN": [Function],
     "@farfetch/blackout-client/UPDATE_RETURN_SUCCESS": [Function],
+    "@farfetch/blackout-redux/LOGOUT_SUCCESS": [Function],
   },
   "subscriptions": Object {
     "@farfetch/blackout-redux/LOGOUT_SUCCESS": [Function],

--- a/packages/redux/src/returns/__tests__/reducer.test.js
+++ b/packages/redux/src/returns/__tests__/reducer.test.js
@@ -1,5 +1,6 @@
 import * as fromReducer from '../reducer';
 import { getInitialState } from '../../../tests';
+import { LOGOUT_SUCCESS } from '@farfetch/blackout-redux/authentication/actionTypes';
 import reducer, { actionTypes, entitiesMapper } from '..';
 
 let initialState;
@@ -23,6 +24,7 @@ describe('returns reducer', () => {
       actionTypes.FETCH_RETURN_REQUEST,
       actionTypes.UPDATE_RETURN_REQUEST,
       actionTypes.FETCH_REFERENCES_REQUEST,
+      LOGOUT_SUCCESS,
     ])('should handle %s action type', actionType => {
       expect(
         reducer(
@@ -205,6 +207,15 @@ describe('returns reducer', () => {
         entitiesMapper[actionTypes.RESET_RETURN](state, {
           meta: { resetEntities: false },
           type: actionTypes.RESET_RETURN,
+        }),
+      ).toEqual(state);
+    });
+
+    it('should handle LOGOUT_SUCCESS', () => {
+      expect(
+        entitiesMapper[LOGOUT_SUCCESS](state, {
+          meta: { resetEntities: false },
+          type: LOGOUT_SUCCESS,
         }),
       ).toEqual(state);
     });

--- a/packages/redux/src/returns/reducer.js
+++ b/packages/redux/src/returns/reducer.js
@@ -6,6 +6,7 @@
 
 import * as actionTypes from './actionTypes';
 import { combineReducers } from 'redux';
+import { LOGOUT_SUCCESS } from '../authentication/actionTypes';
 import { reducerFactory } from '../helpers';
 
 const INITIAL_STATE = {
@@ -42,6 +43,7 @@ const error = (state = INITIAL_STATE.error, action = {}) => {
     case actionTypes.UPDATE_RETURN_REQUEST:
     case actionTypes.FETCH_REFERENCES_REQUEST:
     case actionTypes.RESET_RETURN:
+    case LOGOUT_SUCCESS:
       return INITIAL_STATE.error;
     default:
       return state;
@@ -55,6 +57,7 @@ const id = (state = INITIAL_STATE.id, action = {}) => {
     case actionTypes.FETCH_RETURNS_FROM_ORDER_SUCCESS:
       return action.payload.result;
     case actionTypes.RESET_RETURN:
+    case LOGOUT_SUCCESS:
       return INITIAL_STATE.id;
     default:
       return state;
@@ -83,6 +86,7 @@ const isLoading = (state = INITIAL_STATE.isLoading, action = {}) => {
     case actionTypes.FETCH_REFERENCES_SUCCESS:
     case actionTypes.FETCH_REFERENCES_FAILURE:
     case actionTypes.RESET_RETURN:
+    case LOGOUT_SUCCESS:
       return INITIAL_STATE.isLoading;
     default:
       return state;
@@ -113,6 +117,20 @@ export const entitiesMapper = {
   [actionTypes.UPDATE_RETURN_SUCCESS]: (state, action) =>
     returnsEntityMapper(state, action),
   [actionTypes.RESET_RETURN]: (state, action) => {
+    const {
+      meta: { resetEntities },
+    } = action;
+    const { returns, returnItems, ...rest } = state;
+
+    if (resetEntities) {
+      return {
+        ...rest,
+      };
+    }
+
+    return state;
+  },
+  [LOGOUT_SUCCESS]: (state, action) => {
     const {
       meta: { resetEntities },
     } = action;


### PR DESCRIPTION
## Description

This resets the returns data (state and entities) when the user proceeds with a logout action.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
