### PR TITLE
chore: add support for typescript in test files

### DIFF
--- a/configs/typescript/tsconfig.basic.json
+++ b/configs/typescript/tsconfig.basic.json
@@ -1,23 +1,16 @@
 {
   "compilerOptions": {
-    "target": "ES2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
-    "module": "ES2020" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "lib": [
-      "esnext",
-      "dom"
-    ] /* Specify library files to be included in the compilation. */,
-    "jsx": "preserve" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
-    "isolatedModules": true /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */,
-    "strict": true /* Enable all strict type-checking options. */,
-    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    "noUncheckedIndexedAccess": true /* Will add undefined to any un-declared field in the type. */,
-    "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-    "resolveJsonModule": true /* Enable importing .json files." */,
-    "importsNotUsedAsValues": "error" /* Specify emit/checking behavior for imports that are only used for types */,
-    "typeRoots": [
-      "../node_modules/@types",
-      "../types"
-    ] /* List of folders to include type definitions from. */
+    "target": "ES2015",
+    "module": "ES2020",
+    "lib": ["esnext", "dom"],
+    "jsx": "preserve",
+    "isolatedModules": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "noUncheckedIndexedAccess": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "importsNotUsedAsValues": "error"
   }
 }

--- a/configs/typescript/tsconfig.package-build.json
+++ b/configs/typescript/tsconfig.package-build.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declaration": true /* Output d.ts files */
+    "declaration": true
   },
   "extends": "./tsconfig.basic.json"
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -50,7 +50,6 @@ module.exports = {
     '^@farfetch/blackout-client(.*)$': '<rootDir>/packages/client/src$1',
     '^@farfetch/blackout-redux(.*)$': '<rootDir>/packages/redux/src$1',
     '^jestSetup$': '<rootDir>/jestSetup',
-    '^redux/tests(.*)$': '<rootDir>/packages/redux/tests$1',
     '^tests(.*)$': '<rootDir>/tests$1',
   },
   // Add custom reporters to Jest

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "clean": "bash scripts/clean.sh",
     "docs": "lerna exec --concurrency 1 --no-bail --stream -- jsdoc -c '$LERNA_ROOT_PATH'/jsdoc.json",
-    "types": "lerna exec --concurrency 1 --no-bail --stream -- tsc -p .",
+    "types": "lerna exec --concurrency 1 --no-bail --stream -- tsc -p tsconfig.build.json",
     "lint": "npx eslint . --ext .js,.ts",
     "postinstall": "patch-package",
     "format": "prettier --write '**/*.{js,ts,json,md}'",

--- a/packages/analytics/tsconfig.build.json
+++ b/packages/analytics/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/__tests__/*", "**/__fixtures__/*"],
+  "include": ["src", "../../types"]
+}

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -1,15 +1,8 @@
 {
+  "extends": "../../configs/typescript/tsconfig.package-build.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist" /* Output dir to d.ts core files */
-  },
-  "exclude": [
-    "./node_modules",
-    "./docs",
-    "./tests",
-    "**/__tests__/*",
-    "**/__fixtures__/*"
-  ],
-  "extends": "../../configs/typescript/tsconfig.package-build.json",
-  "include": ["src", "../../types"]
+    "outDir": "./dist",
+    "typeRoots": ["../../node_modules/@types", "../../types"]
+  }
 }

--- a/packages/client/tsconfig.build.json
+++ b/packages/client/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/__tests__/*", "**/__fixtures__/*"],
+  "include": ["src", "../../types"]
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,15 +1,8 @@
 {
+  "extends": "../../configs/typescript/tsconfig.package-build.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist" /* Output dir to d.ts core files */
-  },
-  "exclude": [
-    "./node_modules",
-    "./docs",
-    "./tests",
-    "**/__tests__/*",
-    "**/__fixtures__/*"
-  ],
-  "extends": "../../configs/typescript/tsconfig.package-build.json",
-  "include": ["src", "../../types"]
+    "outDir": "./dist",
+    "typeRoots": ["../../node_modules/@types", "../../types"]
+  }
 }

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/__tests__/*", "**/__fixtures__/*"],
+  "include": ["src", "../../types"]
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,8 +1,9 @@
 {
+  "extends": "../../configs/typescript/tsconfig.package-build.json",
   "compilerOptions": {
     "baseUrl": "../..",
     "rootDir": "src",
-    "outDir": "./dist" /* Output dir to d.ts core files */,
+    "outDir": "./dist",
     "lib": ["esnext", "DOM"],
     "paths": {
       "@farfetch/blackout-client/*": [
@@ -11,14 +12,7 @@
       "@farfetch/blackout-redux/*": [
         "node_modules/@farfetch/blackout-redux/src/*"
       ]
-    }
-  },
-  "exclude": [
-    "./node_modules",
-    "./docs",
-    "**/__tests__/*",
-    "**/__fixtures__/*"
-  ],
-  "extends": "../../configs/typescript/tsconfig.package-build.json",
-  "include": ["src", "../../types"]
+    },
+    "typeRoots": ["../../node_modules/@types", "../../types"]
+  }
 }

--- a/packages/redux/src/analytics/middlewares/__tests__/bag.test.js
+++ b/packages/redux/src/analytics/middlewares/__tests__/bag.test.js
@@ -9,7 +9,7 @@ import {
   mockBrandId,
   mockCategoryId,
   mockStore,
-} from 'redux/tests';
+} from '../../../../tests';
 import { logger } from '@farfetch/blackout-analytics/utils';
 import Analytics, { eventTypes } from '@farfetch/blackout-analytics';
 import merge from 'lodash/merge';

--- a/packages/redux/src/analytics/middlewares/__tests__/wishlist.test.js
+++ b/packages/redux/src/analytics/middlewares/__tests__/wishlist.test.js
@@ -9,7 +9,7 @@ import {
   mockWishlistItemId,
   mockWishlistProductId,
   mockWishlistSetId,
-} from 'redux/tests';
+} from '../../../../tests';
 import { logger } from '@farfetch/blackout-analytics/utils';
 import { wishlistMiddleware } from '../../';
 import Analytics, {

--- a/packages/redux/src/forms/actions/__tests__/fetchFormSchema.test.ts
+++ b/packages/redux/src/forms/actions/__tests__/fetchFormSchema.test.ts
@@ -6,7 +6,7 @@ import {
 } from 'tests/__fixtures__/forms';
 import { getFormSchema } from '@farfetch/blackout-client/forms';
 import { INITIAL_STATE } from '../../reducer';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
 
 const formsMockStore = (state = {}) =>

--- a/packages/redux/src/forms/actions/__tests__/resetFormSchema.test.ts
+++ b/packages/redux/src/forms/actions/__tests__/resetFormSchema.test.ts
@@ -1,5 +1,5 @@
 import { actionTypes } from '../../';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import { resetFormSchema } from '../';
 
 let store;

--- a/packages/redux/src/forms/actions/__tests__/submitFormData.test.ts
+++ b/packages/redux/src/forms/actions/__tests__/submitFormData.test.ts
@@ -4,7 +4,7 @@ import {
   postFormDataPayload,
 } from 'tests/__fixtures__/forms';
 import { INITIAL_STATE } from '../../reducer';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import { postFormData } from '@farfetch/blackout-client/forms';
 import { submitFormData } from '..';
 import find from 'lodash/find';

--- a/packages/redux/src/recentlyViewed/actions/__tests__/fetchRecentlyViewedProducts.test.js
+++ b/packages/redux/src/recentlyViewed/actions/__tests__/fetchRecentlyViewedProducts.test.js
@@ -1,7 +1,7 @@
 import { expectedRemotePayload } from 'tests/__fixtures__/recentlyViewed/getRecentlyViewed';
 import { fetchRecentlyViewedProducts } from '../';
 import { getRecentlyViewedProducts } from '@farfetch/blackout-client/recentlyViewed';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
 import reducer, { actionTypes } from '../../';
 

--- a/packages/redux/src/recentlyViewed/actions/__tests__/removeRecentlyViewedProduct.test.js
+++ b/packages/redux/src/recentlyViewed/actions/__tests__/removeRecentlyViewedProduct.test.js
@@ -1,5 +1,5 @@
 import { deleteRecentlyViewedProduct } from '@farfetch/blackout-client/recentlyViewed';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import { removeRecentlyViewedProduct } from '..';
 import reducer, { actionTypes } from '../..';
 

--- a/packages/redux/src/recentlyViewed/actions/__tests__/saveRecentlyViewedProduct.test.js
+++ b/packages/redux/src/recentlyViewed/actions/__tests__/saveRecentlyViewedProduct.test.js
@@ -1,5 +1,5 @@
 import { expectedLocalPayload } from 'tests/__fixtures__/recentlyViewed/getRecentlyViewed';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import { saveRecentlyViewedProduct } from '../';
 import reducer, { actionTypes } from '../../';
 

--- a/packages/redux/src/recommendations/__tests__/reducer.test.js
+++ b/packages/redux/src/recommendations/__tests__/reducer.test.js
@@ -1,4 +1,4 @@
-import { mockRecommendationsStrategy } from 'redux/tests/__fixtures__/initialReduxState';
+import { mockRecommendationsStrategy } from '../../../tests/__fixtures__/initialReduxState';
 import reducer, { actionTypes } from '..';
 
 let initialState;

--- a/packages/redux/src/recommendations/__tests__/selectors.test.js
+++ b/packages/redux/src/recommendations/__tests__/selectors.test.js
@@ -1,8 +1,8 @@
 import * as fromRecommendations from '../reducer';
 import * as selectors from '../selectors';
-import { initialReduxState } from 'redux/tests';
+import { initialReduxState } from '../../../tests';
 import { merge } from 'lodash';
-import { mockRecommendationsStrategy } from 'redux/tests/__fixtures__/initialReduxState';
+import { mockRecommendationsStrategy } from '../../../tests/__fixtures__/initialReduxState';
 
 describe('Recommendations redux selectors', () => {
   const mockState = initialReduxState;

--- a/packages/redux/src/recommendations/actions/__tests__/fetchProductRecommendations.test.js
+++ b/packages/redux/src/recommendations/actions/__tests__/fetchProductRecommendations.test.js
@@ -6,7 +6,7 @@ import {
   mockProductId,
   mockRecommendationsStrategy,
   mockStore,
-} from 'redux/tests';
+} from '../../../../tests';
 import find from 'lodash/find';
 import reducer, { actionTypes } from '../..';
 

--- a/packages/redux/src/subscriptions/actions/__tests__/clearAllUnsubscribeRecipientFromTopicRequests.test.js
+++ b/packages/redux/src/subscriptions/actions/__tests__/clearAllUnsubscribeRecipientFromTopicRequests.test.js
@@ -1,5 +1,5 @@
 import { actionTypes } from '../..';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import clearAllUnsubscribeRecipientFromTopicRequests from '../clearAllUnsubscribeRecipientFromTopicRequests';
 
 let store;

--- a/packages/redux/src/subscriptions/actions/__tests__/clearUnsubscribeRecipientFromTopicRequest.test.js
+++ b/packages/redux/src/subscriptions/actions/__tests__/clearUnsubscribeRecipientFromTopicRequest.test.js
@@ -1,5 +1,5 @@
 import { actionTypes } from '../..';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import clearUnsubscribeRecipientFromTopicRequest from '../clearUnsubscribeRecipientFromTopicRequest';
 
 let store;

--- a/packages/redux/src/subscriptions/actions/__tests__/fetchSubscriptionPackages.test.js
+++ b/packages/redux/src/subscriptions/actions/__tests__/fetchSubscriptionPackages.test.js
@@ -5,7 +5,7 @@ import {
   mockQuery,
   mockResponse,
 } from 'tests/__fixtures__/subscriptions/getSubscriptionPackages.fixtures';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
 import reducer from '../../reducer';
 

--- a/packages/redux/src/subscriptions/actions/__tests__/fetchUserSubscriptions.test.js
+++ b/packages/redux/src/subscriptions/actions/__tests__/fetchUserSubscriptions.test.js
@@ -4,7 +4,7 @@ import {
   mockQuery,
   mockResponse,
 } from 'tests/__fixtures__/subscriptions/getSubscriptions.fixtures';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
 import reducer, { actionTypes } from '../..';
 

--- a/packages/redux/src/subscriptions/actions/__tests__/resetSubscriptions.test.js
+++ b/packages/redux/src/subscriptions/actions/__tests__/resetSubscriptions.test.js
@@ -1,5 +1,5 @@
 import { actionTypes } from '../..';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import { resetSubscriptions } from '..';
 
 let store;

--- a/packages/redux/src/subscriptions/actions/__tests__/updateUserSubscriptions.test.js
+++ b/packages/redux/src/subscriptions/actions/__tests__/updateUserSubscriptions.test.js
@@ -3,7 +3,7 @@ import {
   mockData,
   mockResponse,
 } from 'tests/__fixtures__/subscriptions/putSubscriptions.fixtures';
-import { mockStore } from 'redux/tests';
+import { mockStore } from '../../../../tests';
 import { putSubscriptions } from '@farfetch/blackout-client/subscriptions';
 import { updateUserSubscriptions } from '..';
 import find from 'lodash/find';

--- a/packages/redux/src/subscriptions/reducer/__tests__/index.test.js
+++ b/packages/redux/src/subscriptions/reducer/__tests__/index.test.js
@@ -1,6 +1,6 @@
 import * as actionTypes from '../../actionTypes';
 import * as authenticationActionTypes from '../../../authentication/actionTypes';
-import { initialReduxState } from 'redux/tests';
+import { initialReduxState } from '../../../../tests';
 import merge from 'lodash/merge';
 import reducer, { entitiesMapper, INITIAL_STATE } from '..';
 

--- a/packages/redux/tsconfig.build.json
+++ b/packages/redux/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/__tests__/*", "**/__fixtures__/*"],
+  "include": ["src", "../../types"]
+}

--- a/packages/redux/tsconfig.json
+++ b/packages/redux/tsconfig.json
@@ -1,21 +1,14 @@
 {
+  "extends": "../../configs/typescript/tsconfig.package-build.json",
   "compilerOptions": {
     "baseUrl": "../..",
     "rootDir": "src",
-    "outDir": "./dist" /* Output dir to d.ts core files */,
+    "outDir": "./dist",
     "paths": {
       "@farfetch/blackout-client/*": [
         "node_modules/@farfetch/blackout-client/src/*"
       ]
-    }
-  },
-  "exclude": [
-    "./node_modules",
-    "./docs",
-    "./tests",
-    "**/__tests__/*",
-    "**/__fixtures__/*"
-  ],
-  "extends": "../../configs/typescript/tsconfig.package-build.json",
-  "include": ["src", "../../types"]
+    },
+    "typeRoots": ["../../node_modules/@types", "../../types"]
+  }
 }


### PR DESCRIPTION
## Description

- This adds support for using typescript in test files
while keeping the tests from transpiling when using yarn types command.
- Removed 'redux/tests' alias to be consistent with the other packages.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
