### PR TITLE
feat: add `useWishlistSets` hook

### DIFF
--- a/packages/client/src/wishlists/types/wishlistSet.types.ts
+++ b/packages/client/src/wishlists/types/wishlistSet.types.ts
@@ -1,14 +1,17 @@
 import type { WishlistItem } from './wishlistItem.types';
 
+export type WishlistSetItem = {
+  createdByStaffMemberId?: string | null;
+  dateCreated: string | null;
+  wishlistItemId: WishlistItem['id'];
+  quantity?: WishlistItem['quantity'];
+};
+
 export type WishlistSet = {
   createdByStaffMemberId?: string | null;
   dateCreated: string | null;
   description?: string;
   name: string;
   setId: string;
-  wishlistSetItems: Array<{
-    createdByStaffMemberId?: string | null;
-    dateCreated: string | null;
-    wishlistItemId: WishlistItem['id'];
-  }>;
+  wishlistSetItems: Array<WishlistSetItem>;
 };

--- a/packages/react/src/wishlists/hooks/__tests__/useWishlistSets.test.tsx
+++ b/packages/react/src/wishlists/hooks/__tests__/useWishlistSets.test.tsx
@@ -1,0 +1,134 @@
+import { cleanup } from '@testing-library/react';
+import { mockStore } from '../../../../tests/helpers';
+import {
+  mockWishlistSetId,
+  mockWishlistState,
+} from 'tests/__fixtures__/wishlists';
+import { Provider } from 'react-redux';
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import useWishlistSets from '../useWishlistSets';
+
+jest.mock('@farfetch/blackout-redux/wishlists', () => ({
+  ...jest.requireActual('@farfetch/blackout-redux/wishlists'),
+  addWishlistSet: jest.fn(() => ({ type: 'add' })),
+  fetchWishlistSets: jest.fn(() => ({ type: 'fetch' })),
+  resetWishlistSets: jest.fn(() => ({ type: 'reset' })),
+  resetWishlistSetsState: jest.fn(() => ({ type: 'resetState' })),
+}));
+
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+const getRenderedHook = (state = mockWishlistState) => {
+  const {
+    result: { current },
+  } = renderHook(() => useWishlistSets(), {
+    wrapper: props => <Provider store={mockStore(state)} {...props} />,
+  });
+
+  return current;
+};
+
+describe('useWishlistSets', () => {
+  beforeEach(jest.clearAllMocks);
+  afterEach(cleanup);
+
+  it('should return values correctly with initial state', () => {
+    const current = getRenderedHook();
+
+    expect(current).toStrictEqual({
+      addWishlistSet: expect.any(Function),
+      allWishlistSetsErrors: expect.any(Array),
+      areLoading: expect.any(Boolean),
+      error: undefined,
+      fetchWishlistSets: expect.any(Function),
+      isAnyWishlistSetLoading: expect.any(Boolean),
+      isAnyWishlistSetWithError: expect.any(Boolean),
+      resetWishlistSets: expect.any(Function),
+      resetWishlistSetsState: expect.any(Function),
+      wishlistSets: expect.any(Array),
+    });
+  });
+
+  it('should render in error state', () => {
+    const mockError = { message: 'This is an error message' };
+    const { error } = getRenderedHook({
+      ...mockWishlistState,
+      wishlist: {
+        ...mockWishlistState.wishlist,
+        sets: {
+          ...mockWishlistState.wishlist.sets,
+          error: mockError,
+        },
+      },
+    });
+
+    expect(error).toEqual(mockError);
+  });
+
+  it('should render with any set in error state', () => {
+    const mockError = { message: 'This is an error message' };
+    const { allWishlistSetsErrors } = getRenderedHook({
+      ...mockWishlistState,
+      wishlist: {
+        ...mockWishlistState.wishlist,
+        sets: {
+          ...mockWishlistState.wishlist.sets,
+          set: {
+            ...mockWishlistState.wishlist.sets.set,
+            error: {
+              [mockWishlistSetId]: mockError,
+            },
+          },
+        },
+      },
+    });
+
+    expect(allWishlistSetsErrors).toEqual([
+      {
+        error: mockError,
+        id: mockWishlistSetId,
+        name: mockWishlistState.entities.wishlistSets[mockWishlistSetId].name,
+      },
+    ]);
+  });
+
+  describe('actions', () => {
+    it('should call `addWishlistSet` action', () => {
+      const { addWishlistSet } = getRenderedHook();
+
+      addWishlistSet({ name: 'test' });
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'add' });
+    });
+
+    it('should call `fetchWishlistSets` action', () => {
+      const { fetchWishlistSets } = getRenderedHook();
+
+      fetchWishlistSets();
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'fetch' });
+    });
+
+    it('should call `resetWishlistSets` action', () => {
+      const { resetWishlistSets } = getRenderedHook();
+
+      resetWishlistSets();
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'reset' });
+    });
+
+    it('should call `resetWishlistSetsState` action', () => {
+      const { resetWishlistSetsState } = getRenderedHook();
+
+      resetWishlistSetsState(['error']);
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'resetState' });
+    });
+  });
+});

--- a/packages/react/src/wishlists/hooks/index.ts
+++ b/packages/react/src/wishlists/hooks/index.ts
@@ -7,3 +7,4 @@
  */
 
 export { default as useWishlist } from './useWishlist';
+export { default as useWishlistSets } from './useWishlistSets';

--- a/packages/react/src/wishlists/hooks/types/index.ts
+++ b/packages/react/src/wishlists/hooks/types/index.ts
@@ -1,1 +1,2 @@
 export * from './useWishlist';
+export * from './useWishlistSets';

--- a/packages/react/src/wishlists/hooks/types/useWishlistSets.ts
+++ b/packages/react/src/wishlists/hooks/types/useWishlistSets.ts
@@ -1,0 +1,24 @@
+import type {
+  PostWishlistSetData,
+  WishlistSets,
+} from '@farfetch/blackout-client/wishlists/types';
+import type { SetsState } from '@farfetch/blackout-redux/wishlists/types';
+import type {
+  WishlistSetsErrors,
+  WishlistSetsHydrated,
+} from '@farfetch/blackout-redux/wishlists/selectors/types';
+
+export type UseWishlistSets = () => {
+  addWishlistSet: (
+    data: PostWishlistSetData,
+  ) => Promise<WishlistSets | undefined>;
+  allWishlistSetsErrors: WishlistSetsErrors | undefined;
+  areLoading: SetsState['isLoading'];
+  error: SetsState['error'] | undefined;
+  fetchWishlistSets: () => Promise<WishlistSets | undefined>;
+  isAnyWishlistSetLoading: boolean;
+  isAnyWishlistSetWithError: boolean;
+  resetWishlistSets: () => void;
+  resetWishlistSetsState: (fieldsToReset?: string[]) => void;
+  wishlistSets: WishlistSetsHydrated;
+};

--- a/packages/react/src/wishlists/hooks/useWishlistSets.ts
+++ b/packages/react/src/wishlists/hooks/useWishlistSets.ts
@@ -1,0 +1,111 @@
+/**
+ * Hook to provide data for the business logic attached to the wishlist sets.
+ *
+ * @module useWishlistSets
+ * @category Wishlist Sets
+ * @subcategory Hooks
+ */
+import {
+  addWishlistSet as addWishlistSetAction,
+  areWishlistSetsLoading,
+  areWishlistSetsWithAnyError,
+  fetchWishlistSets as fetchWishlistSetsAction,
+  getAllWishlistSetsErrors,
+  getWishlistSets,
+  getWishlistSetsError,
+  isAnyWishlistSetLoading as isAnyWishlistSetLoadingSelector,
+  resetWishlistSets as resetWishlistSetsAction,
+  resetWishlistSetsState as resetWishlistSetsStateAction,
+} from '@farfetch/blackout-redux/wishlists';
+import { useAction } from '../../helpers';
+import { useSelector } from 'react-redux';
+import type { UseWishlistSets } from './types';
+
+/**
+ * Provides Redux actions and state access for dealing with
+ * wishlist sets business logic.
+ *
+ * @memberof module:wishlists/hooks
+ *
+ * @returns {object} All the handlers, state, actions and relevant data needed
+ * to manage any wishlist sets operation.
+ */
+const useWishlistSets: UseWishlistSets = () => {
+  // Selectors
+  const allWishlistSetsErrors = useSelector(getAllWishlistSetsErrors);
+  const areLoading = useSelector(areWishlistSetsLoading);
+  const error = useSelector(getWishlistSetsError);
+  const isAnyWishlistSetLoading = useSelector(isAnyWishlistSetLoadingSelector);
+  const isAnyWishlistSetWithError = useSelector(areWishlistSetsWithAnyError);
+  const wishlistSets = useSelector(getWishlistSets);
+  // Actions
+  const addWishlistSet = useAction(addWishlistSetAction);
+  const fetchWishlistSets = useAction(fetchWishlistSetsAction);
+  const resetWishlistSets = useAction(resetWishlistSetsAction);
+  const resetWishlistSetsState = useAction(resetWishlistSetsStateAction);
+
+  return {
+    /**
+     * Adds a wishlist set.
+     *
+     * @type {Function}
+     */
+    addWishlistSet,
+    /**
+     * List of error states for the wishlist sets.
+     *
+     * @type {Array|undefined}
+     */
+    allWishlistSetsErrors,
+    /**
+     * Whether the wishlist sets are loading.
+     *
+     * @type {boolean}
+     */
+    areLoading,
+    /**
+     * Error state of the fetched wishlist sets.
+     *
+     * @type {object|undefined}
+     */
+    error,
+    /**
+     * Fetches the wishlist sets.
+     *
+     * @type {Function}
+     */
+    fetchWishlistSets,
+    /**
+     * Whether any of the wishlist sets is loading.
+     *
+     * @type {boolean}
+     */
+    isAnyWishlistSetLoading,
+    /**
+     * Whether any of the wishlist sets is has an error.
+     *
+     * @type {boolean}
+     */
+    isAnyWishlistSetWithError,
+    /**
+     * Resets the wishlist sets.
+     *
+     * @type {Function}
+     */
+    resetWishlistSets,
+    /**
+     * Resets the wishlist sets state.
+     *
+     * @type {Function}
+     */
+    resetWishlistSetsState,
+    /**
+     * Fetched wishlist sets data.
+     *
+     * @type {object}
+     */
+    wishlistSets,
+  };
+};
+
+export default useWishlistSets;

--- a/packages/redux/src/contents/actions/__tests__/fetchCommercePages.test.ts
+++ b/packages/redux/src/contents/actions/__tests__/fetchCommercePages.test.ts
@@ -89,7 +89,6 @@ describe('fetchCommercePages() action creator', () => {
     );
 
     const actionResults = store.getActions();
-    console.log('Payload:', actionResults[1].payload);
 
     expect(normalizeSpy).toHaveBeenCalledTimes(1);
     expect(getCommercePages).toHaveBeenCalledTimes(1);

--- a/packages/redux/src/wishlists/selectors/types/index.ts
+++ b/packages/redux/src/wishlists/selectors/types/index.ts
@@ -1,0 +1,1 @@
+export * from './wishlistsSets.types';

--- a/packages/redux/src/wishlists/selectors/types/wishlistsSets.types.ts
+++ b/packages/redux/src/wishlists/selectors/types/wishlistsSets.types.ts
@@ -1,0 +1,25 @@
+import type { Error } from '@farfetch/blackout-client/types';
+import type { ProductEntity, WishlistSetEntity } from '../../../entities/types';
+import type {
+  WishlistItem,
+  WishlistSetItem,
+} from '@farfetch/blackout-client/wishlists/types';
+
+export type WishlistSetsErrors = Array<{
+  id: string;
+  name?: string;
+  error: Error;
+}>;
+
+export type WishlistSetHydrated = WishlistSetEntity & {
+  wishlistSetItems:
+    | Array<
+        WishlistSetItem &
+          WishlistItem & {
+            product?: ProductEntity;
+          }
+      >
+    | undefined;
+};
+
+export type WishlistSetsHydrated = Array<WishlistSetHydrated> | undefined;

--- a/packages/redux/src/wishlists/selectors/wishlistsSets.ts
+++ b/packages/redux/src/wishlists/selectors/wishlistsSets.ts
@@ -6,6 +6,11 @@ import type { SetsState } from '../types';
 import type { StoreState } from '../../types';
 import type { WishlistSet } from '@farfetch/blackout-client/wishlists/types';
 import type { WishlistSetEntity } from '../../entities/types';
+import type {
+  WishlistSetHydrated,
+  WishlistSetsErrors,
+  WishlistSetsHydrated,
+} from './types/wishlistsSets.types';
 
 /**
  * Retrieves the error state of the current user's wishlist sets.
@@ -173,7 +178,7 @@ export const getWishlistSet = createSelector(
     return {
       ...wishlistSet,
       wishlistSetItems,
-    };
+    } as WishlistSetHydrated;
   },
 );
 
@@ -185,7 +190,7 @@ export const getWishlistSet = createSelector(
  *
  * @param {object} state - Application state.
  *
- * @returns {Array} List of wishlist sets.
+ * @returns {Array | undefined} List of wishlist sets.
  *
  * @example
  * import { getWishlistSets } from '@farfetch/blackout-redux/wishlists';
@@ -197,7 +202,9 @@ export const getWishlistSet = createSelector(
 export const getWishlistSets = createSelector(
   [getWishlistSetsIds, state => state],
   (wishlistSetsIds, state) =>
-    wishlistSetsIds?.map(setId => getWishlistSet(state, setId)),
+    wishlistSetsIds?.map(setId =>
+      getWishlistSet(state, setId),
+    ) as WishlistSetsHydrated,
 );
 
 /**
@@ -359,13 +366,7 @@ export const getAllWishlistSetsErrors = createSelector(
     state => getEntities(state, 'wishlistSets'),
   ],
   (wishlistSetsIds, wishlistSetsErrors, wishlistSets) => {
-    type Errors = Array<{
-      id: string;
-      name?: string;
-      error: Error;
-    }>;
-
-    const errors: Errors = [];
+    const errors: WishlistSetsErrors = [];
 
     wishlistSetsIds?.forEach(id => {
       const error = wishlistSetsErrors[id];


### PR DESCRIPTION
## Description

This adds a `useWishlistSets` hook that aggregates all relevant logic to use on wishlist sets.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
