### PR TITLE
feat(redux): reset loyalty data on logout

### DIFF
--- a/packages/redux/src/loyalty/__tests__/reducer.test.ts
+++ b/packages/redux/src/loyalty/__tests__/reducer.test.ts
@@ -1,4 +1,5 @@
 import * as fromReducer from '../reducer';
+import { LOGOUT_SUCCESS } from '@farfetch/blackout-redux/authentication/actionTypes';
 import reducer, { actionTypes } from '..';
 
 let initialState;
@@ -19,6 +20,15 @@ describe('loyalty reducer', () => {
       const state = fromReducer.INITIAL_STATE[subArea];
 
       expect(state).toEqual(initialState[subArea]);
+    });
+
+    it('should return the initial state when is a LOGOUT_SUCCESS action', () => {
+      expect(
+        reducer(undefined, {
+          payload: {},
+          type: LOGOUT_SUCCESS,
+        }),
+      ).toEqual(initialState);
     });
   });
 

--- a/packages/redux/src/loyalty/reducer.ts
+++ b/packages/redux/src/loyalty/reducer.ts
@@ -7,6 +7,7 @@
 import * as actionTypes from './actionTypes';
 import { combineReducers } from 'redux';
 import { createReducerWithResult } from '../helpers';
+import { LOGOUT_SUCCESS } from '../authentication/actionTypes';
 import type * as T from './types';
 import type { ProgramMembership } from '@farfetch/blackout-client/src/loyalty/types';
 import type { ReducerSwitch, StateWithResult } from '../types';
@@ -95,7 +96,6 @@ export const membership = (
         error: action.payload.error,
         isLoading: false,
       };
-
     default:
       return state;
   }
@@ -132,7 +132,12 @@ const reducers = combineReducers({
  * @returns {object} New state.
  */
 
-const loyaltyReducer: ReducerSwitch<T.State> = (state, action) =>
-  reducers(state, action);
+const loyaltyReducer: ReducerSwitch<T.State> = (state, action) => {
+  if (action.type === LOGOUT_SUCCESS) {
+    return INITIAL_STATE;
+  }
+
+  return reducers(state, action);
+};
 
 export default loyaltyReducer;


### PR DESCRIPTION
## Description

- Implemeted action to reset loyalty data on logout


## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
