### PR TITLE
fix(core): add `id` to the listing server initial state

### DIFF
--- a/packages/core/src/products/listing/redux/__tests__/__snapshots__/serverInitialState.test.js.snap
+++ b/packages/core/src/products/listing/redux/__tests__/__snapshots__/serverInitialState.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`listing serverInitialState() should initialise server state for a listing 1`] = `
+exports[`listing serverInitialState() should initialize server state for a listing 1`] = `
 Object {
   "entities": Object {
     "products": Object {
@@ -59,6 +59,7 @@ Object {
         "gender": 0,
         "genderName": "Woman",
         "hash": "/us/listing/woman/clothing",
+        "id": 120198,
         "name": "New arrivals",
         "products": Object {
           "entries": Array [
@@ -86,7 +87,7 @@ Object {
 }
 `;
 
-exports[`listing serverInitialState() should initialise server state for a non listing 1`] = `
+exports[`listing serverInitialState() should initialize server state for a non listing 1`] = `
 Object {
   "listing": Object {
     "error": Object {},

--- a/packages/core/src/products/listing/redux/__tests__/serverInitialState.test.js
+++ b/packages/core/src/products/listing/redux/__tests__/serverInitialState.test.js
@@ -2,7 +2,7 @@ import { mockListingModel } from 'tests/__fixtures__/products';
 import { serverInitialState } from '../';
 
 describe('listing serverInitialState()', () => {
-  it('should initialise server state for a listing', () => {
+  it('should initialize server state for a listing', () => {
     const state = serverInitialState({ model: mockListingModel });
 
     expect(state).toMatchSnapshot();
@@ -20,9 +20,7 @@ describe('listing serverInitialState()', () => {
 
     const state = serverInitialState({ model });
 
-    expect(Object.keys(state.entities.searchResults)).toEqual(
-      expect.arrayContaining([expectedHash]),
-    );
+    expect(Object.keys(state.entities.searchResults)).toEqual([expectedHash]);
     expect(state.listing.hash).toBe(expectedHash);
   });
 
@@ -33,13 +31,11 @@ describe('listing serverInitialState()', () => {
     const model = { ...mockListingModel, slug, subfolder };
     const state = serverInitialState({ model });
 
-    expect(Object.keys(state.entities.searchResults)).toEqual(
-      expect.arrayContaining([expectedHash]),
-    );
+    expect(Object.keys(state.entities.searchResults)).toEqual([expectedHash]);
     expect(state.listing.hash).toBe(expectedHash);
   });
 
-  it('should initialise server state for a non listing', () => {
+  it('should initialize server state for a non listing', () => {
     const model = {};
     const state = serverInitialState({ model });
 

--- a/packages/core/src/products/listing/redux/serverInitialState.js
+++ b/packages/core/src/products/listing/redux/serverInitialState.js
@@ -33,6 +33,7 @@ export default ({ model, options: { productImgQueryParam } = {} }) => {
     filterSegments,
     gender,
     genderName,
+    id,
     name,
     products,
     redirectInformation,
@@ -43,7 +44,7 @@ export default ({ model, options: { productImgQueryParam } = {} }) => {
   const { pathname, query } = parse(slug, true);
 
   // Remove CDN required `json=true` param from query which breaks our
-  // selectors and causes SSR deoptimization
+  // selectors and causes SSR de-optimization
   delete query.json;
 
   const builtSlug = getSlug(pathname);
@@ -51,7 +52,6 @@ export default ({ model, options: { productImgQueryParam } = {} }) => {
   // Normalize it
   const { entities } = normalize(
     {
-      hash,
       breadCrumbs,
       config,
       didYouMean,
@@ -60,9 +60,10 @@ export default ({ model, options: { productImgQueryParam } = {} }) => {
       filterSegments,
       gender,
       genderName,
+      hash,
+      id,
       name,
-      // Send this to the entity's `adaptProductImages`
-      productImgQueryParam,
+      productImgQueryParam, // Send this to the entity's `adaptProductImages`
       products,
       redirectInformation,
       searchTerm,

--- a/tests/__fixtures__/products/listing.fixtures.js
+++ b/tests/__fixtures__/products/listing.fixtures.js
@@ -396,6 +396,7 @@ export const mockListingModel = {
   ],
   gender: 0,
   genderName: 'Woman',
+  id: 120198,
   name: 'New arrivals',
   products: {
     totalPages: 10,


### PR DESCRIPTION
## Description

This adds the missing `id` property to the listing server initial state, letting it pass through.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
