### PR TITLE
fix(redux): add `id` to the lists server initial state

### DIFF
--- a/packages/client/src/products/types/set.types.ts
+++ b/packages/client/src/products/types/set.types.ts
@@ -6,6 +6,7 @@ import type { ProductSummary } from './productSummary.types';
 import type { ShoppingConfig } from './shoppingConfig.types';
 
 export type Set = {
+  id: number;
   name: string;
   products: {
     entries: ProductSummary[];

--- a/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/index.test.ts.snap
@@ -109,6 +109,7 @@ Object {
         "gender": 0,
         "genderName": "Woman",
         "hash": "listing/woman?pageindex=1&sort=price&sortdirection=asc",
+        "id": 120198,
         "name": "New arrivals",
         "products": Object {
           "entries": Array [

--- a/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/lists.test.ts.snap
+++ b/packages/redux/src/products/serverInitialState/__tests__/__snapshots__/lists.test.ts.snap
@@ -109,6 +109,7 @@ Object {
         "gender": 0,
         "genderName": "Woman",
         "hash": "listing/woman?pageindex=1&sort=price&sortdirection=asc",
+        "id": 120198,
         "name": "New arrivals",
         "products": Object {
           "entries": Array [
@@ -257,6 +258,7 @@ Object {
         "gender": 0,
         "genderName": "Woman",
         "hash": "sets/woman?pageindex=1&sort=price&sortdirection=asc",
+        "id": 120198,
         "name": "New arrivals",
         "products": Object {
           "entries": Array [

--- a/packages/redux/src/products/serverInitialState/index.ts
+++ b/packages/redux/src/products/serverInitialState/index.ts
@@ -7,28 +7,9 @@
  */
 import listsServerInitialState from './lists';
 import productsServerInitialState from './products';
-import type { Model, StoreState } from '../../types';
+import type { ServerInitialState } from './types';
 
-export default ({
-  model,
-  options,
-}: {
-  model: Model;
-  options?: { productImgQueryParam?: string };
-}): {
-  entities: StoreState['entities'];
-  products: {
-    attributes: StoreState['products']['attributes'];
-    colorGrouping: StoreState['products']['colorGrouping'];
-    details: StoreState['products']['details'];
-    fittings: StoreState['products']['fittings'];
-    lists: StoreState['products']['lists'];
-    measurements: StoreState['products']['measurements'];
-    sizeGuides: StoreState['products']['sizeGuides'];
-    sizes: StoreState['products']['sizes'];
-    variantsByMerchantsLocations: StoreState['products']['variantsByMerchantsLocations'];
-  };
-} => {
+const serverInitialState: ServerInitialState = ({ model, options }) => {
   const { entities: listsEntities, ...listsState } = listsServerInitialState({
     model,
     options,
@@ -44,3 +25,5 @@ export default ({
     },
   };
 };
+
+export default serverInitialState;

--- a/packages/redux/src/products/serverInitialState/lists.ts
+++ b/packages/redux/src/products/serverInitialState/lists.ts
@@ -4,7 +4,7 @@ import { normalize } from 'normalizr';
 import get from 'lodash/get';
 import parse from 'url-parse';
 import productsList from '../../entities/schemas/productsList';
-import type { Model, StoreState } from '../../types';
+import type { ListsServerInitialState } from './types';
 
 /**
  * Converts server data for a products list (listing or sets) to store state.
@@ -20,16 +20,10 @@ import type { Model, StoreState } from '../../types';
  *
  * @returns {object} Initial state for the products lists reducer.
  */
-const serverInitialState = ({
+const serverInitialState: ListsServerInitialState = ({
   model,
   options: { productImgQueryParam } = {},
-}: {
-  model: Model;
-  options?: { productImgQueryParam?: string };
-}): {
-  lists: StoreState['products']['lists'];
-  entities?: StoreState['entities'];
-} => {
+}) => {
   if (!get(model, 'products')) {
     return { lists: INITIAL_STATE };
   }
@@ -46,6 +40,7 @@ const serverInitialState = ({
     filterSegments,
     gender,
     genderName,
+    id,
     name,
     products,
     redirectInformation,
@@ -54,7 +49,7 @@ const serverInitialState = ({
   } = model;
   const { pathname, query } = parse(slug, true);
   // Remove CDN required `json=true` param from query which breaks our
-  // selectors and causes SSR deoptimization
+  // selectors and causes SSR de-optimization
   delete query.json;
 
   const builtSlug = getSlug(pathname);
@@ -64,7 +59,6 @@ const serverInitialState = ({
   // Normalize it
   const { entities } = normalize(
     {
-      hash,
       breadCrumbs,
       config,
       didYouMean,
@@ -73,9 +67,10 @@ const serverInitialState = ({
       filterSegments,
       gender,
       genderName,
+      hash,
+      id,
       name,
-      // Send this to the entity's `adaptProductImages`
-      productImgQueryParam,
+      productImgQueryParam, // Send this to the entity's `adaptProductImages`
       products,
       redirectInformation,
       searchTerm,

--- a/packages/redux/src/products/serverInitialState/products.ts
+++ b/packages/redux/src/products/serverInitialState/products.ts
@@ -4,7 +4,7 @@ import { INITIAL_STATE as SIZES_INITIAL_STATE } from '../reducer/sizes';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import productSchema from '../../entities/schemas/product';
-import type { Model, StoreState } from '../../types';
+import type { ProductsServerInitialState } from './types';
 
 /**
  * Converts server data for details of a product to store state.
@@ -19,17 +19,10 @@ import type { Model, StoreState } from '../../types';
  *
  * @returns {object} Initial state for the product details reducer.
  */
-const serverInitialState = ({
+const serverInitialState: ProductsServerInitialState = ({
   model,
   options: { productImgQueryParam } = {},
-}: {
-  model: Model;
-  options?: { productImgQueryParam?: string };
-}): {
-  details: StoreState['products']['details'];
-  entities?: StoreState['entities'];
-  sizes: StoreState['products']['sizes'];
-} => {
+}) => {
   // Check if a model object is of a product detail page (type === 'Product')
   // - if not, do nothing
   if (isEmpty(model) || get(model, 'dataLayer.general.type') !== 'Product') {
@@ -56,7 +49,6 @@ const serverInitialState = ({
     recommendedSet,
     relatedSets,
     result: productData,
-    scaleId,
     sizes,
     sizeSet,
     slug,
@@ -77,8 +69,6 @@ const serverInitialState = ({
     productSize,
     recommendedSet,
     relatedSets,
-    // @ts-expect-error scaleId is duplicated on product payload
-    scaleId,
     sizes,
     sizeSet,
     slug,

--- a/packages/redux/src/products/serverInitialState/types/index.ts
+++ b/packages/redux/src/products/serverInitialState/types/index.ts
@@ -1,0 +1,13 @@
+import type { Model, StoreState } from '../../../types';
+import type { State } from '../../types';
+
+export * from './lists.types';
+export * from './products.types';
+
+export type ServerInitialState = (data: {
+  model: Model;
+  options?: { productImgQueryParam?: string };
+}) => {
+  entities: StoreState['entities'];
+  products: Partial<State>;
+};

--- a/packages/redux/src/products/serverInitialState/types/lists.types.ts
+++ b/packages/redux/src/products/serverInitialState/types/lists.types.ts
@@ -1,0 +1,10 @@
+import type { Model, StoreState } from '../../../types';
+import type { ProductsListsState } from '../../types';
+
+export type ListsServerInitialState = (data: {
+  model: Model;
+  options?: { productImgQueryParam?: string };
+}) => {
+  lists: ProductsListsState;
+  entities?: StoreState['entities'];
+};

--- a/packages/redux/src/products/serverInitialState/types/products.types.ts
+++ b/packages/redux/src/products/serverInitialState/types/products.types.ts
@@ -1,0 +1,11 @@
+import type { Model, StoreState } from '../../../types';
+import type { ProductsDetailsState, ProductsSizesState } from '../../types';
+
+export type ProductsServerInitialState = (data: {
+  model: Model;
+  options?: { productImgQueryParam?: string };
+}) => {
+  details: ProductsDetailsState;
+  entities?: StoreState['entities'];
+  sizes: ProductsSizesState;
+};

--- a/packages/redux/src/types/Model.types.ts
+++ b/packages/redux/src/types/Model.types.ts
@@ -6,24 +6,26 @@ import type { Designers } from '@farfetch/blackout-client/designers/types';
 import type {
   Listing,
   Product,
+  Set,
 } from '@farfetch/blackout-client/products/types';
 
-export type Model = Listing &
-  Product & {
-    countryCode: string;
-    countryId: number;
-    cultureCode: string;
-    currencyCode: string;
-    currencyCultureCode: string;
-    designers: Designers;
-    newsletterSubscriptionOptionDefault: boolean;
-    pageType: string;
-    searchContentRequests: [
-      {
-        filters: QueryContents;
-        searchResponse: Contents;
-      },
-    ];
-    slug: string;
-    subfolder: string;
-  };
+type Common = {
+  countryCode: string;
+  countryId: number;
+  cultureCode: string;
+  currencyCode: string;
+  currencyCultureCode: string;
+  designers: Designers;
+  newsletterSubscriptionOptionDefault: boolean;
+  pageType: string;
+  searchContentRequests: [
+    {
+      filters: QueryContents;
+      searchResponse: Contents;
+    },
+  ];
+  slug: string;
+  subfolder: string;
+};
+
+export type Model = Listing & Set & Product & Common;

--- a/tests/__fixtures__/products/details.fixtures.ts
+++ b/tests/__fixtures__/products/details.fixtures.ts
@@ -37,6 +37,7 @@ const mockProductResult = {
   preferedMerchant: {
     merchantId: 9359,
   },
+  scaleId: mockSizeScaleId,
   shortDescription: 'Rockstud sling-back flats',
   customAttributes: null,
 };

--- a/tests/__fixtures__/products/productsLists.fixtures.ts
+++ b/tests/__fixtures__/products/productsLists.fixtures.ts
@@ -701,6 +701,7 @@ export const mockProductsListModel = {
   ],
   gender: 0,
   genderName: 'Woman',
+  id: 120198,
   name: 'New arrivals',
   products: {
     totalPages: 10,


### PR DESCRIPTION
## Description

This adds the missing `id` property to the lists server initial state, letting it pass through.
This also separates the products' `serverInitialState` types for the sake of readability.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
