### PR TITLE
feat: add `addWishlistItem` to `useWishlist` hook

### DIFF
--- a/packages/react/src/wishlists/hooks/__tests__/useWishlist.test.tsx
+++ b/packages/react/src/wishlists/hooks/__tests__/useWishlist.test.tsx
@@ -8,6 +8,7 @@ import useWishlist from '../useWishlist';
 
 jest.mock('@farfetch/blackout-redux/wishlists', () => ({
   ...jest.requireActual('@farfetch/blackout-redux/wishlists'),
+  addWishlistItem: jest.fn(() => ({ type: 'addItem' })),
   fetchWishlist: jest.fn(() => ({ type: 'fetch' })),
   resetWishlist: jest.fn(() => ({ type: 'reset' })),
   resetWishlistState: jest.fn(() => ({ type: 'resetState' })),
@@ -38,6 +39,7 @@ describe('useWishlist', () => {
     const current = getRenderedHook();
 
     expect(current).toStrictEqual({
+      addWishlistItem: expect.any(Function),
       error: undefined,
       fetchWishlist: expect.any(Function),
       id: expect.any(String),
@@ -112,6 +114,14 @@ describe('useWishlist', () => {
   });
 
   describe('actions', () => {
+    it('should call `addWishlistItem` action', () => {
+      const { addWishlistItem } = getRenderedHook();
+
+      addWishlistItem();
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'addItem' });
+    });
+
     it('should call `fetchWishlist` action', () => {
       const { fetchWishlist } = getRenderedHook();
 

--- a/packages/react/src/wishlists/hooks/types/useWishlist.ts
+++ b/packages/react/src/wishlists/hooks/types/useWishlist.ts
@@ -1,10 +1,21 @@
-import type { State } from '@farfetch/blackout-redux/wishlists/types';
+import type { AxiosRequestConfig } from 'axios';
+import type {
+  PostWishlistItemActionData,
+  State,
+} from '@farfetch/blackout-redux/wishlists/types';
 import type { Wishlist } from '@farfetch/blackout-client/wishlists/types';
 import type { WishlistItemHydrated } from '@farfetch/blackout-redux/entities/types';
 
 export type UseWishlist = () => {
   error: State['error'] | undefined;
-  fetchWishlist: () => Promise<Wishlist | undefined>;
+  fetchWishlist: (
+    wishlistId: number,
+    config?: AxiosRequestConfig,
+  ) => Promise<Wishlist | undefined>;
+  addWishlistItem: (
+    data: PostWishlistItemActionData,
+    config?: AxiosRequestConfig,
+  ) => Promise<Wishlist | undefined>;
   id: State['id'];
   isEmpty: boolean;
   isLoading: boolean;

--- a/packages/react/src/wishlists/hooks/useWishlist.ts
+++ b/packages/react/src/wishlists/hooks/useWishlist.ts
@@ -6,6 +6,7 @@
  * @subcategory Hooks
  */
 import {
+  addWishlistItem as addWishlistItemAction,
   fetchWishlist as fetchWishlistAction,
   getWishlist,
   getWishlistError,
@@ -41,6 +42,7 @@ const useWishlist: UseWishlist = () => {
   const totalQuantity = useSelector(getWishlistTotalQuantity);
   const wishlist = useSelector(getWishlist);
   // Actions
+  const addWishlistItem = useAction(addWishlistItemAction);
   const fetchWishlist = useAction(fetchWishlistAction);
   const resetWishlist = useAction(resetWishlistAction);
   const resetWishlistState = useAction(resetWishlistStateAction);
@@ -51,6 +53,12 @@ const useWishlist: UseWishlist = () => {
   const isLoading = (!wishlist && !error) || isWishlistLoading;
 
   return {
+    /**
+     * Add item to wishlist.
+     *
+     * @type {Function}
+     */
+    addWishlistItem,
     /**
      * Error state of the fetched wishlist.
      *


### PR DESCRIPTION


## Description
This adds the `addWishlistItem` method, responsible for adding an item to the wishlist, to the
`useWishlist` hook.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
