### PR TITLE
chore: remove `rootDir` from `tsconfig` and fix the `paths`

### DIFF
--- a/packages/analytics/tsconfig.build.json
+++ b/packages/analytics/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "exclude": ["**/__tests__/*", "**/__fixtures__/*"],
-  "include": ["src", "../../types"]
+  "include": ["src", "../../types"],
+  "compilerOptions": {
+    "rootDir": "src"
+  }
 }

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../configs/typescript/tsconfig.package-build.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "./dist",
+    "outDir": "dist",
     "typeRoots": ["../../node_modules/@types", "../../types"]
   }
 }

--- a/packages/client/tsconfig.build.json
+++ b/packages/client/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "exclude": ["**/__tests__/*", "**/__fixtures__/*"],
-  "include": ["src", "../../types"]
+  "include": ["src", "../../types"],
+  "compilerOptions": {
+    "rootDir": "src"
+  }
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../configs/typescript/tsconfig.package-build.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "./dist",
+    "outDir": "dist",
     "typeRoots": ["../../node_modules/@types", "../../types"]
   }
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,16 +2,11 @@
   "extends": "../../configs/typescript/tsconfig.package-build.json",
   "compilerOptions": {
     "baseUrl": "../..",
-    "rootDir": "src",
     "outDir": "./dist",
     "lib": ["esnext", "DOM"],
     "paths": {
-      "@farfetch/blackout-client/*": [
-        "node_modules/@farfetch/blackout-client/src/*"
-      ],
-      "@farfetch/blackout-redux/*": [
-        "node_modules/@farfetch/blackout-redux/src/*"
-      ]
+      "@farfetch/blackout-client/*": ["packages/client/src/*"],
+      "@farfetch/blackout-redux/*": ["packages/redux/src/*"]
     },
     "typeRoots": ["../../node_modules/@types", "../../types"]
   }

--- a/packages/redux/tsconfig.json
+++ b/packages/redux/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../configs/typescript/tsconfig.package-build.json",
   "compilerOptions": {
     "baseUrl": "../..",
-    "rootDir": "src",
     "outDir": "./dist",
     "paths": {
-      "@farfetch/blackout-client/*": [
-        "node_modules/@farfetch/blackout-client/src/*"
-      ]
+      "@farfetch/blackout-client/*": ["packages/client/src/*"]
     },
     "typeRoots": ["../../node_modules/@types", "../../types"]
   }


### PR DESCRIPTION
## Description

This removes the `rootDir` property from the `tsconfig` for TS to recognize
eventual files imported from other blackout packages, thus avoiding the
`'rootDir' is expected to contain all source files` error.

This also fixes the `paths` to use the packages folders we're working on,
instead of the node_modules.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
