### PR TITLE
fix(redux): multiple entries generates same hash contents

### DIFF
--- a/packages/redux/src/entities/schemas/content.ts
+++ b/packages/redux/src/entities/schemas/content.ts
@@ -4,7 +4,7 @@ export const content = new schema.Entity(
   'contents',
   {},
   {
-    idAttribute: (entity, { hash }) => hash,
+    idAttribute: ({ publicationId }) => publicationId,
   },
 );
 

--- a/tests/__fixtures__/contents/contents.ts
+++ b/tests/__fixtures__/contents/contents.ts
@@ -267,7 +267,7 @@ export const expectedNormalizedPayload = {
         error: null,
         isLoading: false,
         result: {
-          entries: [contentHash],
+          entries: [mockContents.entries[0].publicationId],
           hash: contentHash,
           number: 1,
           totalItems: 1,
@@ -278,7 +278,7 @@ export const expectedNormalizedPayload = {
         error: null,
         isLoading: false,
         result: {
-          entries: [widgetHash],
+          entries: [mockWidget.entries[0].publicationId],
           hash: widgetHash,
           number: 1,
           totalItems: 1,
@@ -289,7 +289,7 @@ export const expectedNormalizedPayload = {
         error: null,
         isLoading: false,
         result: {
-          entries: [navbarsHash],
+          entries: [mockNavbars.entries[0].publicationId],
           hash: navbarsHash,
           number: 1,
           totalItems: 1,
@@ -301,7 +301,10 @@ export const expectedNormalizedPayload = {
         isLoading: false,
         result: {
           // We will need to fix this duplication when the codes is 'all'
-          entries: [contentTypeHash, contentTypeHash],
+          entries: [
+            mockContentType.entries[0].publicationId,
+            mockContentType.entries[1].publicationId,
+          ],
           hash: contentTypeHash,
           number: 1,
           totalItems: 2,
@@ -312,7 +315,7 @@ export const expectedNormalizedPayload = {
         error: null,
         isLoading: false,
         result: {
-          entries: [contentTypeHashWithCodes],
+          entries: [mockContentType.entries[1].publicationId],
           hash: contentTypeHashWithCodes,
           number: 1,
           totalItems: 1,
@@ -323,14 +326,11 @@ export const expectedNormalizedPayload = {
   },
   entities: {
     contents: {
-      [contentHash]: mockContents.entries[0],
-      [widgetHash]: mockWidget.entries[0],
-      [navbarsHash]: mockNavbars.entries[0],
-      [contentTypeHash]: {
-        ...mockContentType.entries[0],
-        ...mockContentType.entries[1],
-      },
-      [contentTypeHashWithCodes]: mockContentType.entries[1],
+      [mockContents.entries[0].publicationId]: mockContents.entries[0],
+      [mockWidget.entries[0].publicationId]: mockWidget.entries[0],
+      [mockNavbars.entries[0].publicationId]: mockNavbars.entries[0],
+      [mockContentType.entries[0].publicationId]: mockContentType.entries[0],
+      [mockContentType.entries[1].publicationId]: mockContentType.entries[1],
     },
   },
 };


### PR DESCRIPTION
## Description

Fix multiple entries that have the same hash on content searchResults

- fix contentEntries schema normalizr to entries identifier be publicationId instead of hash

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
