### PR TITLE
feat(react): add custom user id property option

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/GA4.js
+++ b/packages/react/src/analytics/integrations/GA4/GA4.js
@@ -37,6 +37,7 @@ import {
   OPTION_PRODUCT_MAPPINGS,
   OPTION_SCHEMAS,
   OPTION_SCOPE_COMMANDS,
+  OPTION_SET_CUSTOM_USER_ID_PROPERTY,
 } from './constants';
 import { validateFields } from './validation/optionsValidator';
 import defaultEventCommands, {
@@ -146,6 +147,12 @@ class GA4 extends integrations.Integration {
     );
 
     this.onPreProcessCommands = options[OPTION_ON_PRE_PROCESS_COMMANDS];
+
+    this.setCustomUserIdProperty = get(
+      options,
+      OPTION_SET_CUSTOM_USER_ID_PROPERTY,
+      true,
+    );
 
     this.loadGtagScript(options);
   }
@@ -333,6 +340,7 @@ class GA4 extends integrations.Integration {
       window.gtag('set', 'user_properties', {
         user_id: isGuest ? null : userId,
         is_guest: isGuest,
+        crm_id: isGuest || !this.setCustomUserIdProperty ? null : userId,
       });
 
       const userCommandBuilder = get(this.scopeCommands, 'user');

--- a/packages/react/src/analytics/integrations/GA4/constants.js
+++ b/packages/react/src/analytics/integrations/GA4/constants.js
@@ -19,3 +19,4 @@ export const OPTION_SCHEMAS = 'schemas';
 export const OPTION_DATA_LAYER_NAME = 'dataLayerName';
 export const OPTION_EXCLUDE_ARRAY_PARAMETERS_EVENTS =
   'excludeArrayParametersEvents';
+export const OPTION_SET_CUSTOM_USER_ID_PROPERTY = 'setCustomUserIdProperty';

--- a/packages/react/src/analytics/integrations/GA4/validation/optionsValidator.js
+++ b/packages/react/src/analytics/integrations/GA4/validation/optionsValidator.js
@@ -11,6 +11,7 @@ import {
   OPTION_PRODUCT_MAPPINGS,
   OPTION_SCHEMAS,
   OPTION_SCOPE_COMMANDS,
+  OPTION_SET_CUSTOM_USER_ID_PROPERTY,
 } from '../constants';
 import isEmpty from 'lodash/isEmpty';
 import isNil from 'lodash/isNil';
@@ -26,6 +27,7 @@ const optionsInterface = {
   [OPTION_SCOPE_COMMANDS]: { type: 'object', required: false },
   [OPTION_DATA_LAYER_NAME]: { type: 'string', required: false },
   [OPTION_EXCLUDE_ARRAY_PARAMETERS_EVENTS]: { type: 'object', required: false },
+  [OPTION_SET_CUSTOM_USER_ID_PROPERTY]: { type: 'boolean', required: false },
 };
 
 /**


### PR DESCRIPTION
## Description

- This adds a boolean option `setCustomUserIdProperty` to GA4 that
  when set to `true`, will set a custom user property called `crm_id`
  containing the same value as the `user_id` property. This is because
  the `user_id` property cannot be used in reports and explorations
  in GA4, so the suggested workaround is to set a new user property
  containing the same value.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
