### PR TITLE
chore: prevent CI action to run on draft pull requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ on:
       - '**/docs/**'
       - '**.md'
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
     paths-ignore:
       - '**/docs/**'
       - '**.md'
@@ -25,6 +25,8 @@ jobs:
   CI:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    # Do not run if the pull request is a draft
+    if: ${{ !github.event.pull_request.draft }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
## Description

This prevents the CI action to run on draft pull requests.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
