### PR TITLE
feat(react): add ga4 change size event on first selection next

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.js
@@ -1251,8 +1251,11 @@ describe('GA4 Integration', () => {
 
             // delete unwanted case scenarios
             delete clonedEvent.properties.oldQuantity;
+            delete clonedEvent.properties.quantity;
             delete clonedEvent.properties.oldSize;
+            delete clonedEvent.properties.size;
             delete clonedEvent.properties.oldColour;
+            delete clonedEvent.properties.colour;
 
             await ga4Instance.track(clonedEvent);
             expect(ga4Spy).not.toHaveBeenCalled();
@@ -1268,7 +1271,9 @@ describe('GA4 Integration', () => {
 
             // delete unwanted case scenarios
             delete clonedEvent.properties.oldSize;
+            delete clonedEvent.properties.size;
             delete clonedEvent.properties.oldColour;
+            delete clonedEvent.properties.colour;
 
             await ga4Instance.track(clonedEvent);
             expect(ga4Spy.mock.calls).toMatchSnapshot();
@@ -1284,6 +1289,7 @@ describe('GA4 Integration', () => {
 
             // delete unwanted case scenarios
             delete clonedEvent.properties.oldSize;
+            delete clonedEvent.properties.size;
 
             await ga4Instance.track(clonedEvent);
 
@@ -1299,8 +1305,10 @@ describe('GA4 Integration', () => {
             );
 
             // delete unwanted case scenarios
-            delete clonedEvent.properties.oldSize;
             delete clonedEvent.properties.oldQuantity;
+            delete clonedEvent.properties.quantity;
+            delete clonedEvent.properties.oldSize;
+            delete clonedEvent.properties.size;
 
             await ga4Instance.track(clonedEvent);
 

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.js.snap
@@ -732,7 +732,7 @@ Array [
     "event",
     "change_colour",
     Object {
-      "Items": "[{\\"item_category\\":\\"Clothing\\",\\"item_category2\\":\\"Tops\\",\\"item_category3\\":\\"T-shirts\\",\\"currency\\":\\"USD\\",\\"item_brand\\":\\"Just A T-Shirt\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Gareth McConnell Dreamscape T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"quantity\\":1,\\"size_id\\":\\"L\\"}]",
+      "Items": "[{\\"item_category\\":\\"Clothing\\",\\"item_category2\\":\\"Tops\\",\\"item_category3\\":\\"T-shirts\\",\\"currency\\":\\"USD\\",\\"item_brand\\":\\"Just A T-Shirt\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Gareth McConnell Dreamscape T-Shirt\\",\\"item_variant\\":\\"Black\\"}]",
       "currency": "USD",
       "from": "Bag",
       "item_list_id": undefined,
@@ -751,7 +751,7 @@ Array [
     "event",
     "change_quantity",
     Object {
-      "Items": "[{\\"item_category\\":\\"Clothing\\",\\"item_category2\\":\\"Tops\\",\\"item_category3\\":\\"T-shirts\\",\\"currency\\":\\"USD\\",\\"item_brand\\":\\"Just A T-Shirt\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Gareth McConnell Dreamscape T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"quantity\\":1,\\"size_id\\":\\"L\\"}]",
+      "Items": "[{\\"item_category\\":\\"Clothing\\",\\"item_category2\\":\\"Tops\\",\\"item_category3\\":\\"T-shirts\\",\\"currency\\":\\"USD\\",\\"item_brand\\":\\"Just A T-Shirt\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Gareth McConnell Dreamscape T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"quantity\\":1}]",
       "currency": "USD",
       "from": "Bag",
       "item_list_id": undefined,
@@ -817,7 +817,7 @@ Array [
     "event",
     "change_quantity",
     Object {
-      "Items": "[{\\"item_category\\":\\"Clothing\\",\\"item_category2\\":\\"Tops\\",\\"item_category3\\":\\"T-shirts\\",\\"currency\\":\\"USD\\",\\"item_brand\\":\\"Just A T-Shirt\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Gareth McConnell Dreamscape T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"quantity\\":1,\\"size_id\\":\\"L\\"}]",
+      "Items": "[{\\"item_category\\":\\"Clothing\\",\\"item_category2\\":\\"Tops\\",\\"item_category3\\":\\"T-shirts\\",\\"currency\\":\\"USD\\",\\"item_brand\\":\\"Just A T-Shirt\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Gareth McConnell Dreamscape T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"quantity\\":1}]",
       "currency": "USD",
       "from": "Bag",
       "item_list_id": undefined,
@@ -831,7 +831,7 @@ Array [
     "event",
     "change_colour",
     Object {
-      "Items": "[{\\"item_category\\":\\"Clothing\\",\\"item_category2\\":\\"Tops\\",\\"item_category3\\":\\"T-shirts\\",\\"currency\\":\\"USD\\",\\"item_brand\\":\\"Just A T-Shirt\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Gareth McConnell Dreamscape T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"quantity\\":1,\\"size_id\\":\\"L\\"}]",
+      "Items": "[{\\"item_category\\":\\"Clothing\\",\\"item_category2\\":\\"Tops\\",\\"item_category3\\":\\"T-shirts\\",\\"currency\\":\\"USD\\",\\"item_brand\\":\\"Just A T-Shirt\\",\\"item_id\\":\\"507f1f77bcf86cd799439011\\",\\"item_name\\":\\"Gareth McConnell Dreamscape T-Shirt\\",\\"item_variant\\":\\"Black\\",\\"quantity\\":1}]",
       "currency": "USD",
       "from": "Bag",
       "item_list_id": undefined,

--- a/packages/react/src/analytics/integrations/GA4/commands.js
+++ b/packages/react/src/analytics/integrations/GA4/commands.js
@@ -87,7 +87,7 @@ export const getProductUpdatedEventList = data => {
   const dispatchGA4EventList = [];
 
   if (
-    eventProperties.oldQuantity &&
+    eventProperties.quantity &&
     eventProperties.oldQuantity !== eventProperties.quantity
   ) {
     dispatchGA4EventList.push(
@@ -96,14 +96,14 @@ export const getProductUpdatedEventList = data => {
   }
 
   if (
-    eventProperties.oldColour &&
+    eventProperties.colour &&
     eventProperties.oldColour !== eventProperties.colour
   ) {
     dispatchGA4EventList.push(InternalEventTypes.PRODUCT_UPDATED.CHANGE_COLOUR);
   }
 
   if (
-    eventProperties.oldSize &&
+    eventProperties.size &&
     eventProperties.oldSize !== eventProperties.size
   ) {
     dispatchGA4EventList.push(InternalEventTypes.PRODUCT_UPDATED.CHANGE_SIZE);

--- a/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.js
+++ b/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.js
@@ -31,9 +31,9 @@ import {
 import { InternalEventTypes } from '../eventMapping';
 
 export const errorCodes = {
-  InvalidOldSize: 'ga4_invalid_old_size',
-  InvalidOldQuantity: 'ga4_invalid_old_size',
-  InvalidOldColour: 'ga4_invalid_old_colour',
+  InvalidSize: 'ga4_invalid_size',
+  InvalidQuantity: 'ga4_invalid_quantity',
+  InvalidColour: 'ga4_invalid_colour',
 };
 
 export const locationId = yup.object({
@@ -188,10 +188,14 @@ const changeSizeProductInCartSchema = updateProductInCart.concat(
     oldSize: yup.string(),
     size: yup
       .string()
-      .test(errorCodes.InvalidOldSize, errorCodes.InvalidOldSize, function () {
-        const { oldSize } = this.parent;
+      .test(errorCodes.InvalidSize, errorCodes.InvalidSize, function () {
+        const { oldSize, size } = this.parent;
+        // This validation can be unused at the moment because ga4 responds to
+        // product_updated event, which ar a special event because analyzes metadata,
+        // and assigns different events, like change_size if provided data shows
+        // a change size intent.
 
-        return oldSize !== undefined;
+        return oldSize !== size;
       }),
   }),
 );
@@ -202,14 +206,35 @@ const changeQuantityProductInCartSchema = updateProductInCart.concat(
     quantity: yup
       .number()
       .test(
-        errorCodes.InvalidOldQuantity,
-        errorCodes.InvalidOldQuantity,
+        errorCodes.InvalidQuantity,
+        errorCodes.InvalidQuantity,
         function () {
-          const { oldQuantity } = this.parent;
+          const { oldQuantity, quantity } = this.parent;
+          // This validation can be unused at the moment because ga4 responds to
+          // product_updated event, which ar a special event because analyzes metadata,
+          // and assigns different events, like change_quantity if provided data shows
+          // a change size intent.
 
-          return oldQuantity !== undefined;
+          return oldQuantity !== quantity;
         },
       ),
+  }),
+);
+
+const colourChangedSchema = updateProductInCart.concat(
+  yup.object({
+    oldColour: yup.string(),
+    colour: yup
+      .string()
+      .test(errorCodes.InvalidColour, errorCodes.InvalidColour, function () {
+        const { oldColour, colour } = this.parent;
+        // This validation can be unused at the moment because ga4 responds to
+        // product_updated event, which ar a special event because analyzes metadata,
+        // and assigns different events, like change_colour if provided data shows
+        // a change size intent.
+
+        return oldColour !== colour;
+      }),
   }),
 );
 
@@ -224,22 +249,6 @@ const placeOrderStartedSchema = purchaseAndRefundSchema;
 const sameBillingAddressSelectedSchema = checkoutShippingStepSchema;
 const addressInfoAddedSchema = checkoutShippingStepSchema;
 const shippingMethodAddedSchema = checkoutShippingStepSchema;
-const colourChangedSchema = updateProductInCart.concat(
-  yup.object({
-    oldColour: yup.string(),
-    colour: yup
-      .string()
-      .test(
-        errorCodes.InvalidOldColour,
-        errorCodes.InvalidOldColour,
-        function () {
-          const { oldColour } = this.parent;
-
-          return oldColour !== undefined;
-        },
-      ),
-  }),
-);
 
 const interactContentSchema = yup.object({
   interactionType: yup

--- a/tests/__fixtures__/analytics/track/productUpdatedTrackData.fixtures.ts
+++ b/tests/__fixtures__/analytics/track/productUpdatedTrackData.fixtures.ts
@@ -16,10 +16,10 @@ export default {
     price: 18.99,
     currency: 'USD',
     size: 'L',
-    oldSize: 'XL',
+    oldSize: undefined,
     quantity: 1,
-    oldQuantity: 2,
+    oldQuantity: undefined,
     colour: 'white',
-    oldColour: 'red',
+    oldColour: undefined,
   },
 };


### PR DESCRIPTION
## Description

- Allowing trigger ga4's change size event on the first selection of size.
    - This permit tracking change_size event, when old selected value is undefined.

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
