### PR TITLE
feat(react): update billing support on handleSetShippingAddress

### DIFF
--- a/packages/react/src/checkout/hooks/useCheckout.ts
+++ b/packages/react/src/checkout/hooks/useCheckout.ts
@@ -190,11 +190,21 @@ export default ({
     }
   };
 
-  const handleSetShippingAddress = async (address: { id: number }) => {
+  const handleSetShippingAddress = async (
+    address: { id: number },
+    isSameAsBilling = false,
+  ) => {
+    const data = isSameAsBilling
+      ? {
+          shippingAddress: address,
+          billingAddress: address,
+        }
+      : {
+          shippingAddress: address,
+        };
+
     setCheckoutSelectedShipping(address.id);
-    await updateCheckout(checkoutId, {
-      shippingAddress: address,
-    });
+    await updateCheckout(checkoutId, data);
   };
 
   const handleSetBillingAddress = async (address: { id: number }) => {


### PR DESCRIPTION
## Description

- This adds a boolean param `isSameAsBilling` to the useCheckout hook function `handleSetShippingAddress` to support update the shipping and billing address in the same request (`updateCheckout`)

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
