### PR TITLE
feat(react): add parameter path_clean on GA4 view_page event for next

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/GA4.js
+++ b/packages/react/src/analytics/integrations/GA4/GA4.js
@@ -194,6 +194,7 @@ class GA4 extends integrations.Integration {
         this.measurementId,
         {
           page_path: location.pathname + utils.stringifyQuery(location.query),
+          path_clean: location.pathname,
         },
       ]);
 

--- a/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.js
@@ -311,6 +311,7 @@ describe('GA4 Integration', () => {
                 utils.stringifyQuery(
                   mockedPageData.context.web.window.location.query,
                 ),
+              path_clean: mockedPageData.context.web.window.location.pathname,
             },
           ],
         ];

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.js.snap
@@ -42,6 +42,7 @@ Array [
     "GA-123456-12",
     Object {
       "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
     },
   ],
 ]
@@ -61,6 +62,7 @@ Array [
     "GA-123456-12",
     Object {
       "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
     },
   ],
 ]
@@ -87,6 +89,7 @@ Array [
     "GA-123456-12",
     Object {
       "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
     },
   ],
 ]


### PR DESCRIPTION
## Description

- Added new parameter of path_clean in view_page payload event, with current location url, without query string.

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
