### PR TITLE
feat(client|redux): reset orders data (entities and state) on logout

### DIFF
--- a/packages/client/src/orders/redux/__tests__/reducer.test.js
+++ b/packages/client/src/orders/redux/__tests__/reducer.test.js
@@ -3,26 +3,41 @@ import {
   expectedNormalizedPayload,
   expectedOrderDetailsNormalizedPayload,
   expectedOrderReturnOptionsNormalizedPayload,
+  expectedTrackingNormalizedPayload,
   merchantId,
   merchantId2,
   orderId,
   orderItemId,
 } from '../__fixtures__/orders.fixtures';
-import { getInitialState } from '../../../../tests';
+// @TODO: Fix the path when the split to the redux folder is done
+// import { LOGOUT_SUCCESS } from '../../authentication/actionTypes';
+import { LOGOUT_SUCCESS } from '../../../../../redux/src/authentication/actionTypes';
 import merge from 'lodash/merge';
 import omit from 'lodash/omit';
 import reducer, { actionTypes, entitiesMapper } from '..';
 
 let initialState;
+const randomAction = { type: 'this_is_a_random_action' };
 
 describe('orders reducer', () => {
   beforeEach(() => {
-    initialState = getInitialState(reducer());
+    initialState = fromReducer.INITIAL_STATE;
+  });
+
+  describe('reset handling', () => {
+    it('should return the initial state when is a LOGOUT_SUCCESS action', () => {
+      expect(
+        reducer(undefined, {
+          payload: {},
+          type: LOGOUT_SUCCESS,
+        }),
+      ).toEqual(initialState);
+    });
   });
 
   describe('error() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer().error;
+      const state = reducer(undefined, randomAction).error;
 
       expect(state).toBe(initialState.error);
       expect(state).toBeNull();
@@ -61,13 +76,13 @@ describe('orders reducer', () => {
     it('should handle other actions by returning the previous state', () => {
       const state = { error: 'foo' };
 
-      expect(reducer(state).error).toBe(state.error);
+      expect(reducer(state, randomAction).error).toBe(state.error);
     });
   });
 
   describe('isLoading() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer().isLoading;
+      const state = reducer(undefined, randomAction).isLoading;
 
       expect(state).toBe(initialState.isLoading);
       expect(state).toBe(false);
@@ -112,13 +127,13 @@ describe('orders reducer', () => {
     it('should handle other actions by returning the previous state', () => {
       const state = { isLoading: 'foo' };
 
-      expect(reducer(state).isLoading).toBe(state.isLoading);
+      expect(reducer(state, randomAction).isLoading).toBe(state.isLoading);
     });
   });
 
   describe('orderDetails() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer().orderDetails;
+      const state = reducer(undefined, randomAction).orderDetails;
 
       expect(state).toEqual(initialState.orderDetails);
       expect(state).toEqual({ error: {}, isLoading: {} });
@@ -161,13 +176,15 @@ describe('orders reducer', () => {
     it('should handle other actions by returning the previous state', () => {
       const state = { orderDetails: { isLoading: { foo: false } } };
 
-      expect(reducer(state).orderDetails).toEqual(state.orderDetails);
+      expect(reducer(state, randomAction).orderDetails).toEqual(
+        state.orderDetails,
+      );
     });
   });
 
   describe('orderReturnOptions() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer().orderReturnOptions;
+      const state = reducer(undefined, randomAction).orderReturnOptions;
 
       expect(state).toEqual(initialState.orderReturnOptions);
       expect(state).toEqual({ error: {}, isLoading: {} });
@@ -210,7 +227,7 @@ describe('orders reducer', () => {
     it('should handle other actions by returning the previous state', () => {
       const state = { orderReturnOptions: { isLoading: { foo: false } } };
 
-      expect(reducer(state).orderReturnOptions).toEqual(
+      expect(reducer(state, randomAction).orderReturnOptions).toEqual(
         state.orderReturnOptions,
       );
     });
@@ -637,6 +654,29 @@ describe('orders reducer', () => {
         expect(
           entitiesMapper[actionTypes.RESET_ORDERS](merge({}, state)),
         ).toEqual(expectedResult);
+      });
+    });
+
+    describe('for LOGOUT_SUCCESS', () => {
+      const state = {
+        ...expectedNormalizedPayload.entities,
+        ...expectedOrderDetailsNormalizedPayload.entities,
+        ...expectedOrderReturnOptionsNormalizedPayload.entities,
+        ...expectedTrackingNormalizedPayload.entities,
+      };
+      const expectedResult = {
+        ...omit(state, [
+          'orders',
+          'orderItems',
+          'labelTracking',
+          'returnOptions',
+        ]),
+      };
+
+      it('should handle LOGOUT_SUCCESS action type', () => {
+        expect(entitiesMapper[LOGOUT_SUCCESS](merge({}, state))).toEqual(
+          expectedResult,
+        );
       });
     });
   });

--- a/packages/client/src/orders/redux/actions/__tests__/addOrderDocument.test.js
+++ b/packages/client/src/orders/redux/actions/__tests__/addOrderDocument.test.js
@@ -1,12 +1,14 @@
+import { actionTypes } from '../..';
 import { addOrderDocument } from '../';
 import {
   fileId,
   mockOrderDocumentPayload,
 } from '../../__fixtures__/orders.fixtures';
+import { INITIAL_STATE } from '../../reducer';
 import { mockStore } from '../../../../../tests';
-import reducer, { actionTypes } from '../..';
 
-const ordersMockStore = (state = {}) => mockStore({ orders: reducer() }, state);
+const ordersMockStore = (state = {}) =>
+  mockStore({ orders: INITIAL_STATE }, state);
 const orderId = '24BJKS';
 const expectedConfig = undefined;
 let store;

--- a/packages/client/src/orders/redux/actions/__tests__/fetchOrderDetails.test.js
+++ b/packages/client/src/orders/redux/actions/__tests__/fetchOrderDetails.test.js
@@ -1,12 +1,13 @@
 import * as normalizr from 'normalizr';
+import { actionTypes } from '../../';
 import {
   expectedOrderDetailsNormalizedPayload,
   mockOrderDetailsResponse,
   orderId,
 } from '../../__fixtures__/orders.fixtures';
 import { fetchOrderDetails } from '../';
+import { INITIAL_STATE } from '../../reducer';
 import { mockStore } from '../../../../../tests';
-import reducer, { actionTypes } from '../../';
 import thunk from 'redux-thunk';
 
 const mockProductImgQueryParam = '?c=2';
@@ -16,9 +17,9 @@ const mockMiddlewares = [
   }),
 ];
 const ordersMockStore = (state = {}) =>
-  mockStore({ orders: reducer() }, state, mockMiddlewares);
+  mockStore({ orders: INITIAL_STATE }, state, mockMiddlewares);
 const ordersMockStoreWithoutMiddlewares = (state = {}) =>
-  mockStore({ orders: reducer() }, state);
+  mockStore({ orders: INITIAL_STATE }, state);
 const normalizeSpy = jest.spyOn(normalizr, 'normalize');
 const expectedConfig = undefined;
 let store;

--- a/packages/client/src/orders/redux/actions/__tests__/fetchOrderDocument.test.js
+++ b/packages/client/src/orders/redux/actions/__tests__/fetchOrderDocument.test.js
@@ -1,12 +1,14 @@
+import { actionTypes } from '../..';
 import { fetchOrderDocument } from '../';
 import {
   fileId,
   mockOrderDocumentsResponse,
 } from '../../__fixtures__/orders.fixtures';
+import { INITIAL_STATE } from '../../reducer';
 import { mockStore } from '../../../../../tests';
-import reducer, { actionTypes } from '../..';
 
-const ordersMockStore = (state = {}) => mockStore({ orders: reducer() }, state);
+const ordersMockStore = (state = {}) =>
+  mockStore({ orders: INITIAL_STATE }, state);
 const orderId = '24BJKS';
 const expectedConfig = undefined;
 let store;

--- a/packages/client/src/orders/redux/actions/__tests__/fetchOrderDocuments.test.js
+++ b/packages/client/src/orders/redux/actions/__tests__/fetchOrderDocuments.test.js
@@ -1,9 +1,11 @@
+import { actionTypes } from '../..';
 import { fetchOrderDocuments } from '../';
+import { INITIAL_STATE } from '../../reducer';
 import { mockOrderDocumentsResponse } from '../../__fixtures__/orders.fixtures';
 import { mockStore } from '../../../../../tests';
-import reducer, { actionTypes } from '../..';
 
-const ordersMockStore = (state = {}) => mockStore({ orders: reducer() }, state);
+const ordersMockStore = (state = {}) =>
+  mockStore({ orders: INITIAL_STATE }, state);
 const orderId = '24BJKS';
 const expectedConfig = undefined;
 const types = ['ComercialInvoice'];

--- a/packages/client/src/orders/redux/actions/__tests__/fetchOrderReturnOptions.test.js
+++ b/packages/client/src/orders/redux/actions/__tests__/fetchOrderReturnOptions.test.js
@@ -1,12 +1,13 @@
 import * as normalizr from 'normalizr';
+import { actionTypes } from '../../';
 import {
   expectedOrderReturnOptionsNormalizedPayload,
   mockOrderReturnOptionsResponse,
   orderId,
 } from '../../__fixtures__/orders.fixtures';
 import { fetchOrderReturnOptions } from '../';
+import { INITIAL_STATE } from '../../reducer';
 import { mockStore } from '../../../../../tests';
-import reducer, { actionTypes } from '../../';
 import thunk from 'redux-thunk';
 
 const mockMiddlewares = [
@@ -15,7 +16,7 @@ const mockMiddlewares = [
   }),
 ];
 const ordersMockStore = (state = {}) =>
-  mockStore({ orders: reducer() }, state, mockMiddlewares);
+  mockStore({ orders: INITIAL_STATE }, state, mockMiddlewares);
 const normalizeSpy = jest.spyOn(normalizr, 'normalize');
 const expectedConfig = undefined;
 let store;

--- a/packages/client/src/orders/redux/actions/__tests__/fetchOrders.test.js
+++ b/packages/client/src/orders/redux/actions/__tests__/fetchOrders.test.js
@@ -1,11 +1,12 @@
 import * as normalizr from 'normalizr';
+import { actionTypes } from '../../';
 import {
   expectedNormalizedPayload,
   mockOrdersResponse,
 } from '../../__fixtures__/orders.fixtures';
 import { fetchOrders } from '../';
+import { INITIAL_STATE } from '../../reducer';
 import { mockStore } from '../../../../../tests';
-import reducer, { actionTypes } from '../../';
 import thunk from 'redux-thunk';
 
 const userId = 112233;
@@ -15,7 +16,7 @@ const mockMiddlewares = [
   }),
 ];
 const ordersMockStore = (state = {}) =>
-  mockStore({ orders: reducer() }, state, mockMiddlewares);
+  mockStore({ orders: INITIAL_STATE }, state, mockMiddlewares);
 const normalizeSpy = jest.spyOn(normalizr, 'normalize');
 const expectedConfig = undefined;
 let store;

--- a/packages/client/src/orders/redux/actions/__tests__/fetchTrackings.test.js
+++ b/packages/client/src/orders/redux/actions/__tests__/fetchTrackings.test.js
@@ -1,11 +1,12 @@
 import * as normalizr from 'normalizr';
+import { actionTypes } from '../../';
 import {
   expectedTrackingNormalizedPayload,
   mockTrackingResponse,
 } from '../../__fixtures__/orders.fixtures';
 import { fetchTrackings } from '../';
+import { INITIAL_STATE } from '../../reducer';
 import { mockStore } from '../../../../../tests';
-import reducer, { actionTypes } from '../../';
 import thunk from 'redux-thunk';
 
 const mockMiddlewares = [
@@ -14,7 +15,7 @@ const mockMiddlewares = [
   }),
 ];
 const ordersMockStore = (state = {}) =>
-  mockStore({ orders: reducer() }, state, mockMiddlewares);
+  mockStore({ orders: INITIAL_STATE }, state, mockMiddlewares);
 const normalizeSpy = jest.spyOn(normalizr, 'normalize');
 const expectedConfig = undefined;
 let store;

--- a/packages/client/src/orders/redux/actions/__tests__/resetOrders.test.js
+++ b/packages/client/src/orders/redux/actions/__tests__/resetOrders.test.js
@@ -1,8 +1,10 @@
+import { actionTypes } from '../../';
+import { INITIAL_STATE } from '../../reducer';
 import { mockStore } from '../../../../../tests';
 import { resetOrders } from '../';
-import reducer, { actionTypes } from '../../';
 
-const ordersMockStore = (state = {}) => mockStore({ orders: reducer() }, state);
+const ordersMockStore = (state = {}) =>
+  mockStore({ orders: INITIAL_STATE }, state);
 let store;
 
 describe('resetOrders() action creator', () => {

--- a/packages/client/src/orders/redux/reducer.js
+++ b/packages/client/src/orders/redux/reducer.js
@@ -7,13 +7,16 @@
 import * as actionTypes from './actionTypes';
 import { adaptDate } from '../../helpers/adapters';
 import { combineReducers } from 'redux';
+// @TODO: Fix the path when the split to the redux folder is done
+// import { LOGOUT_SUCCESS } from '../authentication/actionTypes';
+import { LOGOUT_SUCCESS } from '../../../../redux/src/authentication/actionTypes';
 import { reducerFactory } from '../../helpers/redux';
 import get from 'lodash/get';
 import merge from 'lodash/merge';
 import omit from 'lodash/omit';
 import produce from 'immer';
 
-const INITIAL_STATE = {
+export const INITIAL_STATE = {
   error: null,
   isLoading: false,
   result: null,
@@ -229,7 +232,18 @@ export const entitiesMapper = {
   [actionTypes.RESET_ORDERS]: state => {
     const { orders, orderItems, ...remainingEntities } = state;
 
-    return { ...remainingEntities };
+    return remainingEntities;
+  },
+  [LOGOUT_SUCCESS]: state => {
+    const {
+      orders,
+      orderItems,
+      labelTracking,
+      returnOptions,
+      ...remainingEntities
+    } = state;
+
+    return remainingEntities;
   },
 };
 
@@ -351,6 +365,17 @@ export const getOrderReturnOptions = state => state.orderReturnOptions;
 export const getTrackings = state => state.trackings;
 export const getDocuments = state => state.documents;
 
+const reducer = combineReducers({
+  error,
+  isLoading,
+  result,
+  ordersList,
+  orderDetails,
+  orderReturnOptions,
+  trackings,
+  documents,
+});
+
 /**
  * Reducer for orders state.
  *
@@ -362,13 +387,12 @@ export const getDocuments = state => state.documents;
  *
  * @returns {object} New state.
  */
-export default combineReducers({
-  error,
-  isLoading,
-  result,
-  ordersList,
-  orderDetails,
-  orderReturnOptions,
-  trackings,
-  documents,
-});
+const ordersReducer = (state, action) => {
+  if (action.type === LOGOUT_SUCCESS) {
+    return INITIAL_STATE;
+  }
+
+  return reducer(state, action);
+};
+
+export default ordersReducer;

--- a/packages/redux/src/entities/__tests__/__snapshots__/reducer.test.js.snap
+++ b/packages/redux/src/entities/__tests__/__snapshots__/reducer.test.js.snap
@@ -43,6 +43,7 @@ Object {
     "@farfetch/blackout-client/FETCH_ORDER_DETAILS_SUCCESS": [Function],
     "@farfetch/blackout-client/FETCH_ORDER_RETURN_OPTIONS_SUCCESS": [Function],
     "@farfetch/blackout-client/RESET_ORDERS": [Function],
+    "@farfetch/blackout-redux/LOGOUT_SUCCESS": [Function],
   },
   "payments": Object {
     "@farfetch/blackout-redux/LOGOUT_SUCCESS": [Function],


### PR DESCRIPTION
## Description

This resets the orders data (state and entities) when the user proceeds with a logout action. Some arrangements are made in the tests files in order to use the reducer with the new changes.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
