### PR TITLE
feat(react|redux): add `useWishlistItem` hook

### DIFF
--- a/packages/react/src/wishlists/hooks/__tests__/useWishlistItem.test.tsx
+++ b/packages/react/src/wishlists/hooks/__tests__/useWishlistItem.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup } from '@testing-library/react';
+import { mockStore } from '../../../../tests/helpers';
+import {
+  mockWishlistItemId,
+  mockWishlistItemPatchData,
+  mockWishlistState,
+} from 'tests/__fixtures__/wishlists';
+import { Provider } from 'react-redux';
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import useWishlistItem from '../useWishlistItem';
+
+jest.mock('@farfetch/blackout-redux/wishlists', () => ({
+  ...jest.requireActual('@farfetch/blackout-redux/wishlists'),
+  removeWishlistItem: jest.fn(() => ({ type: 'remove' })),
+  updateWishlistItem: jest.fn(() => ({ type: 'update' })),
+}));
+
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+const getRenderedHook = (state = mockWishlistState) => {
+  const {
+    result: { current },
+  } = renderHook(() => useWishlistItem(mockWishlistItemId), {
+    wrapper: props => <Provider store={mockStore(state)} {...props} />,
+  });
+
+  return current;
+};
+
+describe('useWishlistItem', () => {
+  beforeEach(jest.clearAllMocks);
+  afterEach(cleanup);
+
+  it('should return values correctly with initial state', () => {
+    const current = getRenderedHook();
+
+    expect(current).toStrictEqual({
+      removeWishlistItem: expect.any(Function),
+      updateWishlistItem: expect.any(Function),
+      error: expect.any(Object),
+      isLoading: expect.any(Boolean),
+      item: expect.any(Object),
+    });
+  });
+
+  it('should render in error state', () => {
+    const mockError = { message: 'This is an error message' };
+    const { error } = getRenderedHook({
+      ...mockWishlistState,
+      wishlist: {
+        ...mockWishlistState.wishlist,
+        items: {
+          ...mockWishlistState.wishlist.items,
+          item: {
+            ...mockWishlistState.wishlist.items.item,
+            error: {
+              [mockWishlistItemId]: mockError,
+            },
+          },
+        },
+      },
+    });
+
+    expect(error).toEqual(mockError);
+  });
+
+  describe('actions', () => {
+    it('should call `removeWishlistItem` action', () => {
+      const { removeWishlistItem } = getRenderedHook();
+
+      removeWishlistItem(mockWishlistItemId);
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'remove' });
+    });
+
+    it('should call `updateWishlistItem` action', () => {
+      const { updateWishlistItem } = getRenderedHook();
+
+      updateWishlistItem(mockWishlistItemId, mockWishlistItemPatchData);
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'update' });
+    });
+  });
+});

--- a/packages/react/src/wishlists/hooks/index.ts
+++ b/packages/react/src/wishlists/hooks/index.ts
@@ -8,3 +8,4 @@
 
 export { default as useWishlist } from './useWishlist';
 export { default as useWishlistSets } from './useWishlistSets';
+export { default as useWishlistItem } from './useWishlistItem';

--- a/packages/react/src/wishlists/hooks/types/index.ts
+++ b/packages/react/src/wishlists/hooks/types/index.ts
@@ -1,2 +1,3 @@
 export * from './useWishlist';
 export * from './useWishlistSets';
+export * from './useWishlistItem';

--- a/packages/react/src/wishlists/hooks/types/useWishlistItem.ts
+++ b/packages/react/src/wishlists/hooks/types/useWishlistItem.ts
@@ -1,0 +1,23 @@
+import type { AxiosRequestConfig } from 'axios';
+import type {
+  PatchWishlistItemData,
+  Wishlist,
+  WishlistItem,
+} from '@farfetch/blackout-client/wishlists/types';
+import type { State } from '@farfetch/blackout-redux/wishlists/types';
+import type { WishlistItemHydrated } from '@farfetch/blackout-redux/entities/types';
+
+export type UseWishlistItem = (wishlistItemId: number) => {
+  error: State['error'] | undefined;
+  isLoading: State['isLoading'] | undefined;
+  item: WishlistItemHydrated | undefined;
+  updateWishlistItem: (
+    wishlistItemId: WishlistItem['id'],
+    data: PatchWishlistItemData,
+    config?: AxiosRequestConfig,
+  ) => Promise<Wishlist | undefined>;
+  removeWishlistItem: (
+    wishlistItemId: WishlistItem['id'],
+    config?: AxiosRequestConfig,
+  ) => Promise<Wishlist | undefined>;
+};

--- a/packages/react/src/wishlists/hooks/useWishlistItem.ts
+++ b/packages/react/src/wishlists/hooks/useWishlistItem.ts
@@ -1,0 +1,77 @@
+/**
+ * Hook to provide data for the business logic attached to a wishlist item.
+ *
+ * @module useWishlistItem
+ * @category Wishlist Item
+ * @subcategory Hooks
+ */
+import {
+  getWishlistItem,
+  getWishlistItemError,
+  isWishlistItemLoading,
+  removeWishlistItem as removeWishlistItemAction,
+  updateWishlistItem as updateWishlistItemAction,
+} from '@farfetch/blackout-redux/wishlists';
+import { useAction } from '../../helpers';
+import { useSelector } from 'react-redux';
+import type { UseWishlistItem } from './types';
+
+/**
+ * Provides Redux actions and state access for dealing with
+ * wishlist item business logic.
+ *
+ * @memberof module:wishlists/hooks
+ *
+ * @param {string} wishlistItemId - Wishlist item identifier.
+ *
+ * @returns {object} All the state, actions and relevant data needed
+ * to manage a wishlist item operation.
+ */
+const useWishlistItem: UseWishlistItem = wishlistItemId => {
+  // Selectors
+  const error = useSelector(state =>
+    getWishlistItemError(state, wishlistItemId),
+  );
+  const isLoading = useSelector(state =>
+    isWishlistItemLoading(state, wishlistItemId),
+  );
+  const item = useSelector(state => getWishlistItem(state, wishlistItemId));
+  // Actions
+  const removeWishlistItem = useAction(removeWishlistItemAction);
+  const updateWishlistItem = useAction(updateWishlistItemAction);
+
+  return {
+    /**
+     * Error state of the fetched wishlist item.
+     *
+     * @type {object|undefined}
+     */
+    error,
+    /**
+     * Whether the wishlist item is loading.
+     *
+     * @type {boolean}
+     */
+    isLoading,
+    /**
+     * Fetched wishlist item.
+     *
+     * @type {object}
+     */
+    item,
+    /**
+     * Updates the wishlist item.
+     *
+     * @type {Function}
+     */
+    updateWishlistItem,
+    /**
+     * Removes the wishlist items.
+     *
+     * @type {Function}
+     */
+    removeWishlistItem,
+  };
+};
+
+export default useWishlistItem;

--- a/packages/redux/src/wishlists/selectors/wishlists.ts
+++ b/packages/redux/src/wishlists/selectors/wishlists.ts
@@ -80,7 +80,11 @@ export const getWishlist = (state: StoreState): State['result'] =>
 export const getWishlistItem = createSelector(
   [
     (state: StoreState, wishlistItemId: WishlistItem['id']) =>
-      getEntityById(state, 'wishlistItems', wishlistItemId),
+      getEntityById(
+        state,
+        'wishlistItems',
+        wishlistItemId,
+      ) as WishlistItemEntity,
     (state: StoreState, wishlistItemId: WishlistItem['id']) => {
       const wishlistItem = getEntityById(
         state,
@@ -139,7 +143,7 @@ export const getWishlistItem = createSelector(
       } as WishlistItemHydrated;
     }
 
-    return { ...newWishListItem, product };
+    return { ...newWishListItem, product } as WishlistItemHydrated | undefined;
   },
 );
 


### PR DESCRIPTION
## Description

This adds the hook `useWishlistItem` that manages all logic related with
a wishlist item.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
