### PR TITLE
feat(react): add `useProductsList` hook

### DIFF
--- a/packages/react/src/products/hooks/__tests__/useProductsList.test.tsx
+++ b/packages/react/src/products/hooks/__tests__/useProductsList.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup } from '@testing-library/react';
+import { getSlug } from '@farfetch/blackout-redux/products/utils';
+import {
+  mockProductsListPathname,
+  mockProductsState,
+  mockQuery,
+} from 'tests/__fixtures__/products';
+import { mockStore } from '../../../../tests/helpers';
+import { Provider } from 'react-redux';
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import useProductsList, { PRODUCTS_LIST_TYPES } from '../useProductsList';
+import type { UseProductsListParams } from '../types';
+
+jest.mock('@farfetch/blackout-redux/products', () => ({
+  ...jest.requireActual('@farfetch/blackout-redux/products'),
+  fetchListing: jest.fn(() => ({ type: 'fetchListing' })),
+  fetchSet: jest.fn(() => ({ type: 'fetchSet' })),
+}));
+
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+const getRenderedHook = (
+  props: Partial<UseProductsListParams> = {},
+  state: unknown = mockProductsState,
+) => {
+  const {
+    result: { current },
+  } = renderHook(
+    () => {
+      return useProductsList({
+        slug: getSlug(mockProductsListPathname),
+        query: mockQuery,
+        ...props,
+      } as UseProductsListParams);
+    },
+    {
+      wrapper: props => <Provider store={mockStore(state)} {...props} />,
+    },
+  );
+
+  return current;
+};
+
+describe('useProductsList', () => {
+  beforeEach(jest.clearAllMocks);
+  afterEach(cleanup);
+
+  it('should return values correctly with initial state', () => {
+    const current = getRenderedHook({});
+
+    expect(current).toStrictEqual({
+      error: expect.any(Object),
+      isFetched: expect.any(Boolean),
+      isLoading: expect.any(Boolean),
+      productsListHash: expect.any(String),
+      products: expect.any(Array),
+      result: expect.any(Object),
+    });
+  });
+
+  describe('behaviour', () => {
+    it('should fetch a listing', () => {
+      getRenderedHook(undefined, {
+        ...mockProductsState,
+        products: {
+          ...mockProductsState.products,
+          lists: {
+            error: {},
+            isHydrated: {},
+            isLoading: {},
+            hash: undefined,
+          },
+        },
+        entities: {},
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'fetchListing' });
+    });
+
+    it('should fetch a set', () => {
+      getRenderedHook({ type: PRODUCTS_LIST_TYPES.SET });
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'fetchSet' });
+    });
+
+    it('should not fetch anything if there is no slug', () => {
+      getRenderedHook({ slug: undefined });
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/src/products/hooks/index.ts
+++ b/packages/react/src/products/hooks/index.ts
@@ -7,3 +7,4 @@
  */
 
 export { default as useProductDetails } from './useProductDetails';
+export { default as useProductsList } from './useProductsList';

--- a/packages/react/src/products/hooks/types/index.ts
+++ b/packages/react/src/products/hooks/types/index.ts
@@ -1,1 +1,2 @@
 export * from './useProductDetails';
+export * from './useProductsList';

--- a/packages/react/src/products/hooks/types/useProductsList.ts
+++ b/packages/react/src/products/hooks/types/useProductsList.ts
@@ -1,0 +1,37 @@
+import type { Error } from '@farfetch/blackout-client/src/types';
+import type {
+  ListingQuery,
+  SetQuery,
+} from '@farfetch/blackout-client/src/products/types';
+import type {
+  ProductEntity,
+  ProductsListEntity,
+} from '@farfetch/blackout-redux/src/entities/types';
+
+export type ProductsListTypes = {
+  LISTING: 'listing';
+  SET: 'set';
+};
+
+export type UseProductsListParams = {
+  query: ListingQuery | SetQuery;
+  setProductsListHash?: boolean;
+  slug: string;
+  type: ProductsListTypes['LISTING'] | ProductsListTypes['SET'];
+  useCache?: boolean;
+};
+
+export type UseProductsList = ({
+  query,
+  setProductsListHash,
+  slug,
+  type,
+  useCache,
+}: UseProductsListParams) => {
+  error: Error | undefined;
+  isFetched: boolean | undefined;
+  isLoading: boolean | undefined;
+  products: ProductEntity[];
+  productsListHash: string;
+  result: ProductsListEntity;
+};

--- a/packages/react/src/products/hooks/useProductsList.ts
+++ b/packages/react/src/products/hooks/useProductsList.ts
@@ -1,0 +1,135 @@
+/**
+ * Hook to provide all kinds of data for the business logic attached to a product list.
+ *
+ * @module useProductsList
+ * @category Products
+ * @subcategory Hooks
+ */
+import {
+  fetchListing,
+  fetchSet,
+  getProductsListError,
+  getProductsListProducts,
+  getProductsListResult,
+  isProductsListFetched,
+  isProductsListLoading,
+} from '@farfetch/blackout-redux/products';
+import { generateProductsListHash } from '@farfetch/blackout-redux/products/utils';
+import { useDispatch, useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import type {
+  ListingQuery,
+  SetQuery,
+} from '@farfetch/blackout-client/products/types';
+import type {
+  ProductsListTypes,
+  UseProductsList,
+} from './types/useProductsList';
+
+export const PRODUCTS_LIST_TYPES: ProductsListTypes = {
+  LISTING: 'listing',
+  SET: 'set',
+};
+
+/**
+ * Hook to handle listing logic.
+ *
+ * @param {object} props - Object containing the necessary info to use inside the hook.
+ * @param {string} [props.slug] - The slug of the given product list.
+ * @param {Object} [props.query] - The query parameters of the given product list.
+ * @param {string} [props.type='listing'] - Listing type ('listing' or 'set').
+ * @param {boolean} [props.useCache=true] - To use cache when fetching a product list.
+ * @param {boolean} [props.setProductsListHash=true] - Wether to set the reducer's hash on the store when requesting a product list.
+ *
+ * @returns {Object} All the info needed to get listing results and information.
+ */
+const useProductsList: UseProductsList = ({
+  query,
+  setProductsListHash = true,
+  slug,
+  type = PRODUCTS_LIST_TYPES.LISTING,
+  useCache = true,
+}) => {
+  const isSetPage = type === PRODUCTS_LIST_TYPES.SET;
+  const dispatch = useDispatch();
+  const productsListHash = generateProductsListHash(slug, query, {
+    isSet: isSetPage,
+  });
+  const error = useSelector(state =>
+    getProductsListError(state, productsListHash),
+  );
+  const isLoading = useSelector(state =>
+    isProductsListLoading(state, productsListHash),
+  );
+  const result = useSelector(state =>
+    getProductsListResult(state, productsListHash),
+  );
+  const products = useSelector(state =>
+    getProductsListProducts(state, productsListHash),
+  );
+  const isFetched = useSelector(state =>
+    isProductsListFetched(state, productsListHash),
+  );
+
+  useEffect(() => {
+    if (slug !== undefined && !isFetched) {
+      dispatch(
+        isSetPage
+          ? fetchSet(slug, query as SetQuery, { useCache, setProductsListHash })
+          : fetchListing(slug, query as ListingQuery, {
+              useCache,
+              setProductsListHash,
+            }),
+      );
+    }
+  }, [
+    dispatch,
+    isFetched,
+    isSetPage,
+    query,
+    setProductsListHash,
+    slug,
+    useCache,
+  ]);
+
+  return {
+    /**
+     * Error state of a product list.
+     *
+     * @type {object|undefined}
+     */
+    error,
+    /**
+     * Whether the product list is fetched.
+     *
+     * @type {boolean|undefined}
+     */
+    isFetched,
+    /**
+     * Whether the product list is loading.
+     *
+     * @type {boolean|undefined}
+     */
+    isLoading,
+    /**
+     * The hash of the product list.
+     *
+     * @type {string}
+     */
+    productsListHash,
+    /**
+     * Array of products that belong to the product list.
+     *
+     * @type {Array}
+     */
+    products,
+    /**
+     * Information about the fetched product list.
+     *
+     * @type {Object}
+     */
+    result,
+  };
+};
+
+export default useProductsList;

--- a/tests/__fixtures__/products/productsLists.fixtures.ts
+++ b/tests/__fixtures__/products/productsLists.fixtures.ts
@@ -2,6 +2,7 @@ import { mockBreadCrumbs } from './products.fixtures';
 import { mockPriceAdaptedEmpty } from './price.fixtures';
 import { mockSetId } from './ids.fixtures';
 
+export const mockProductsListPathname = 'shopping/woman/clothing';
 export const mockProductsListSlug = '/woman/clothing';
 export const mockQuery = { categories: '135971', colors: '6', pageIndex: '1' };
 export const mockQueryWithoutPageIndex = {


### PR DESCRIPTION
## Description
This adds the `useProductsList` hook, with selectors and logic useful
in products lists.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
