### PR TITLE
chore(client): replace `moxios` with `msw` in wishlists

### DIFF
--- a/packages/client/src/wishlists/__fixtures__/deleteWishlistItem.fixtures.ts
+++ b/packages/client/src/wishlists/__fixtures__/deleteWishlistItem.fixtures.ts
@@ -1,41 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Wishlist, WishlistItem } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { Wishlist } from '../types';
+
+const path = '/api/commerce/v1/wishlists/:wishlistId/items/:wishlistItemId';
 
 export default {
-  success: (params: {
-    wishlistId: Wishlist['id'];
-    wishlistItemId: WishlistItem['id'];
-    response: Wishlist;
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/wishlists',
-        params.wishlistId,
-        'items',
-        params.wishlistItemId,
-      ),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: {
-    wishlistId: Wishlist['id'];
-    wishlistItemId: WishlistItem['id'];
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/wishlists',
-        params.wishlistId,
-        'items',
-        params.wishlistItemId,
-      ),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: Wishlist): RestHandler =>
+    rest.delete(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.delete(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/wishlists/__fixtures__/deleteWishlistSet.fixtures.ts
+++ b/packages/client/src/wishlists/__fixtures__/deleteWishlistSet.fixtures.ts
@@ -1,39 +1,13 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Wishlist, WishlistSet } from '../types';
+import { rest, RestHandler } from 'msw';
+
+const path = '/api/commerce/v1/wishlists/:wishlistId/sets/:wishlistSetId';
 
 export default {
-  success: (params: {
-    wishlistId: Wishlist['id'];
-    wishlistSetId: WishlistSet['setId'];
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/wishlists',
-        params.wishlistId,
-        'sets',
-        params.wishlistSetId,
-      ),
-      {
-        status: 204, // No content
-      },
-    );
-  },
-  failure: (params: {
-    wishlistId: Wishlist['id'];
-    wishlistSetId: WishlistSet['setId'];
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/wishlists',
-        params.wishlistId,
-        'sets',
-        params.wishlistSetId,
-      ),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (): RestHandler =>
+    rest.delete(path, async (req, res, ctx) => res(ctx.status(204))),
+
+  failure: (): RestHandler =>
+    rest.delete(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/wishlists/__fixtures__/getWishlist.fixtures.ts
+++ b/packages/client/src/wishlists/__fixtures__/getWishlist.fixtures.ts
@@ -1,31 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
+import { rest, RestHandler } from 'msw';
 import type { Wishlist } from '../types';
 
+const path = '/api/commerce/v1/wishlists/:wishlistId';
+
 export default {
-  success: (params: {
-    wishlistId: Wishlist['id'];
-    response: Wishlist;
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/wishlists', params.wishlistId, {
-        query: { hydrate: 'true' },
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { wishlistId: Wishlist['id'] }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/wishlists', params.wishlistId, {
-        query: { hydrate: 'true' },
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: Wishlist): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/wishlists/__fixtures__/getWishlistSet.fixtures.ts
+++ b/packages/client/src/wishlists/__fixtures__/getWishlistSet.fixtures.ts
@@ -1,41 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Wishlist, WishlistSet } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { WishlistSet } from '../types';
+
+const path = '/api/commerce/v1/wishlists/:wishlistId/sets/:wishlistSetId';
 
 export default {
-  success: (params: {
-    wishlistId: Wishlist['id'];
-    wishlistSetId: WishlistSet['setId'];
-    response: WishlistSet;
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/wishlists',
-        params.wishlistId,
-        'sets',
-        params.wishlistSetId,
-      ),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: {
-    wishlistId: Wishlist['id'];
-    wishlistSetId: WishlistSet['setId'];
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/wishlists',
-        params.wishlistId,
-        'sets',
-        params.wishlistSetId,
-      ),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: WishlistSet): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/wishlists/__fixtures__/getWishlistSets.fixtures.ts
+++ b/packages/client/src/wishlists/__fixtures__/getWishlistSets.fixtures.ts
@@ -1,27 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Wishlist, WishlistSets } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { WishlistSets } from '../types';
+
+const path = '/api/commerce/v1/wishlists/:wishlistId/sets';
 
 export default {
-  success: (params: {
-    wishlistId: Wishlist['id'];
-    response: WishlistSets;
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/wishlists', params.wishlistId, 'sets'),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { wishlistId: Wishlist['id'] }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/wishlists', params.wishlistId, 'sets'),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: WishlistSets): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/wishlists/__fixtures__/patchWishlistItem.fixtures.ts
+++ b/packages/client/src/wishlists/__fixtures__/patchWishlistItem.fixtures.ts
@@ -1,41 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Wishlist, WishlistItem } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { Wishlist } from '../types';
+
+const path = '/api/commerce/v1/wishlists/:wishlistId/items/:wishlistItemId';
 
 export default {
-  success: (params: {
-    wishlistId: Wishlist['id'];
-    wishlistItemId: WishlistItem['id'];
-    response: Wishlist;
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/wishlists',
-        params.wishlistId,
-        'items',
-        params.wishlistItemId,
-      ),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: {
-    wishlistId: Wishlist['id'];
-    wishlistItemId: WishlistItem['id'];
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/wishlists',
-        params.wishlistId,
-        'items',
-        params.wishlistItemId,
-      ),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: Wishlist): RestHandler =>
+    rest.patch(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.patch(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/wishlists/__fixtures__/patchWishlistSet.fixtures.ts
+++ b/packages/client/src/wishlists/__fixtures__/patchWishlistSet.fixtures.ts
@@ -1,39 +1,12 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Wishlist, WishlistSet } from '../types';
+import { rest, RestHandler } from 'msw';
+
+const path = '/api/commerce/v1/wishlists/:wishlistId/sets/:wishlistSetId';
 
 export default {
-  success: (params: {
-    wishlistId: Wishlist['id'];
-    wishlistSetId: WishlistSet['setId'];
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/wishlists',
-        params.wishlistId,
-        'sets',
-        params.wishlistSetId,
-      ),
-      {
-        status: 204, // No content
-      },
-    );
-  },
-  failure: (params: {
-    wishlistId: Wishlist['id'];
-    wishlistSetId: WishlistSet['setId'];
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/wishlists',
-        params.wishlistId,
-        'sets',
-        params.wishlistSetId,
-      ),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (): RestHandler =>
+    rest.patch(path, async (req, res, ctx) => res(ctx.status(204))),
+  failure: (): RestHandler =>
+    rest.patch(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/wishlists/__fixtures__/postWishlistItem.fixtures.ts
+++ b/packages/client/src/wishlists/__fixtures__/postWishlistItem.fixtures.ts
@@ -1,27 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
+import { rest, RestHandler } from 'msw';
 import type { Wishlist } from '../types';
 
+const path = '/api/commerce/v1/wishlists/:wishlistId/items';
+
 export default {
-  success: (params: {
-    wishlistId: Wishlist['id'];
-    response: Wishlist;
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/wishlists', params.wishlistId, 'items'),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { wishlistId: Wishlist['id'] }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/wishlists', params.wishlistId, 'items'),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: Wishlist): RestHandler =>
+    rest.post(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.post(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/wishlists/__fixtures__/postWishlistSet.fixtures.ts
+++ b/packages/client/src/wishlists/__fixtures__/postWishlistSet.fixtures.ts
@@ -1,27 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Wishlist, WishlistSet } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { WishlistSet } from '../types';
+
+const path = '/api/commerce/v1/wishlists/:wishlistId/sets';
 
 export default {
-  success: (params: {
-    wishlistId: Wishlist['id'];
-    response: WishlistSet;
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/wishlists', params.wishlistId, 'sets'),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { wishlistId: Wishlist['id'] }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/wishlists', params.wishlistId, 'sets'),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: WishlistSet): RestHandler =>
+    rest.post(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.post(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/wishlists/__tests__/__snapshots__/deleteWishlistItem.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/deleteWishlistItem.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/wishlists/__tests__/__snapshots__/deleteWishlistSet.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/deleteWishlistSet.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/wishlists/__tests__/__snapshots__/getWishlist.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/getWishlist.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/wishlists/__tests__/__snapshots__/getWishlistSet.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/getWishlistSet.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/wishlists/__tests__/__snapshots__/getWishlistSets.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/getWishlistSets.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/wishlists/__tests__/__snapshots__/patchWishlistItem.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/patchWishlistItem.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/wishlists/__tests__/__snapshots__/patchWishlistSet.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/patchWishlistSet.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/wishlists/__tests__/__snapshots__/postWishlistItem.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/postWishlistItem.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/wishlists/__tests__/__snapshots__/postWishlistSet.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/postWishlistSet.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/wishlists/__tests__/deleteWishlistItem.test.ts
+++ b/packages/client/src/wishlists/__tests__/deleteWishlistItem.test.ts
@@ -2,11 +2,11 @@ import { deleteWishlistItem } from '..';
 import {
   mockWishlistId,
   mockWishlistItemId,
-  mockWishlistResponse,
+  mockWishlistsResponse,
 } from 'tests/__fixtures__/wishlists';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/deleteWishlistItem.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('deleteWishlistItem', () => {
   const expectedConfig = undefined;
@@ -14,25 +14,16 @@ describe('deleteWishlistItem', () => {
   const wishlistItemId = mockWishlistItemId;
   const spy = jest.spyOn(client, 'delete');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    const response = mockWishlistResponse;
+    const response = mockWishlistsResponse;
+    mswServer.use(fixtures.success(response));
+    expect.assertions(2);
 
-    fixtures.success({
-      wishlistId,
-      wishlistItemId,
-      response,
-    });
-
-    await expect(deleteWishlistItem(wishlistId, wishlistItemId)).resolves.toBe(
-      response,
-    );
+    await expect(
+      deleteWishlistItem(wishlistId, wishlistItemId),
+    ).resolves.toEqual(response);
 
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/wishlists/${wishlistId}/items/${wishlistItemId}`,
@@ -41,7 +32,8 @@ describe('deleteWishlistItem', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ wishlistId, wishlistItemId });
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(
       deleteWishlistItem(wishlistId, wishlistItemId),

--- a/packages/client/src/wishlists/__tests__/deleteWishlistSet.test.ts
+++ b/packages/client/src/wishlists/__tests__/deleteWishlistSet.test.ts
@@ -5,7 +5,7 @@ import {
 } from 'tests/__fixtures__/wishlists';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/deleteWishlistSet.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('deleteWishlistSet', () => {
   const expectedConfig = undefined;
@@ -13,18 +13,11 @@ describe('deleteWishlistSet', () => {
   const wishlistSetId = mockWishlistSetId;
   const spy = jest.spyOn(client, 'delete');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    fixtures.success({
-      wishlistId,
-      wishlistSetId,
-    });
+    mswServer.use(fixtures.success());
+    expect.assertions(2);
 
     await expect(deleteWishlistSet(wishlistId, wishlistSetId)).resolves.toEqual(
       expect.objectContaining({ status: 204 }),
@@ -37,7 +30,8 @@ describe('deleteWishlistSet', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ wishlistId, wishlistSetId });
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(
       deleteWishlistSet(wishlistId, wishlistSetId),

--- a/packages/client/src/wishlists/__tests__/getWishlist.test.ts
+++ b/packages/client/src/wishlists/__tests__/getWishlist.test.ts
@@ -1,30 +1,26 @@
 import { getWishlist } from '..';
 import {
   mockWishlistId,
-  mockWishlistResponse,
+  mockWishlistsResponse,
 } from 'tests/__fixtures__/wishlists';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getWishlist.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getWishlist', () => {
   const expectedConfig = undefined;
   const wishlistId = mockWishlistId;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    const response = mockWishlistResponse;
+    const response = mockWishlistsResponse;
 
-    fixtures.success({ wishlistId, response });
+    mswServer.use(fixtures.success(response));
+    expect.assertions(2);
 
-    await expect(getWishlist(wishlistId)).resolves.toBe(response);
+    await expect(getWishlist(wishlistId)).resolves.toEqual(response);
 
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/wishlists/${wishlistId}?hydrate=true`,
@@ -33,7 +29,8 @@ describe('getWishlist', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ wishlistId });
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(getWishlist(wishlistId)).rejects.toMatchSnapshot();
 

--- a/packages/client/src/wishlists/__tests__/getWishlistSet.test.ts
+++ b/packages/client/src/wishlists/__tests__/getWishlistSet.test.ts
@@ -6,7 +6,7 @@ import {
 } from 'tests/__fixtures__/wishlists';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getWishlistSet.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getWishlistSet', () => {
   const expectedConfig = undefined;
@@ -14,19 +14,15 @@ describe('getWishlistSet', () => {
   const wishlistSetId = mockWishlistSetId;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
     const response = mockWishlistsSetResponse;
 
-    fixtures.success({ wishlistId, wishlistSetId, response });
+    mswServer.use(fixtures.success(response));
+    expect.assertions(2);
 
-    await expect(getWishlistSet(wishlistId, wishlistSetId)).resolves.toBe(
+    await expect(getWishlistSet(wishlistId, wishlistSetId)).resolves.toEqual(
       response,
     );
 
@@ -37,7 +33,8 @@ describe('getWishlistSet', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ wishlistId, wishlistSetId });
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(
       getWishlistSet(wishlistId, wishlistSetId),

--- a/packages/client/src/wishlists/__tests__/getWishlistSets.test.ts
+++ b/packages/client/src/wishlists/__tests__/getWishlistSets.test.ts
@@ -5,25 +5,21 @@ import {
 } from 'tests/__fixtures__/wishlists';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getWishlistSets.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getWishlistSets', () => {
   const expectedConfig = undefined;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
     const response = [mockWishlistsSetResponse];
 
-    fixtures.success({ wishlistId: mockWishlistId, response });
+    mswServer.use(fixtures.success(response));
+    expect.assertions(2);
 
-    await expect(getWishlistSets(mockWishlistId)).resolves.toBe(response);
+    await expect(getWishlistSets(mockWishlistId)).resolves.toEqual(response);
 
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/wishlists/${mockWishlistId}/sets`,
@@ -32,7 +28,8 @@ describe('getWishlistSets', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ wishlistId: mockWishlistId });
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(getWishlistSets(mockWishlistId)).rejects.toMatchSnapshot();
 

--- a/packages/client/src/wishlists/__tests__/patchWishlistItem.test.ts
+++ b/packages/client/src/wishlists/__tests__/patchWishlistItem.test.ts
@@ -2,38 +2,30 @@ import {
   mockWishlistId,
   mockWishlistItemId,
   mockWishlistItemPatchData,
-  mockWishlistResponse,
+  mockWishlistsResponse,
 } from 'tests/__fixtures__/wishlists';
 import { patchWishlistItem } from '..';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/patchWishlistItem.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('patchWishlistItem', () => {
   const expectedConfig = undefined;
   const wishlistId = mockWishlistId;
   const wishlistItemId = mockWishlistItemId;
   const data = mockWishlistItemPatchData;
-  const response = mockWishlistResponse;
+  const response = mockWishlistsResponse;
   const spy = jest.spyOn(client, 'patch');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    fixtures.success({
-      wishlistId,
-      wishlistItemId,
-      response,
-    });
+    mswServer.use(fixtures.success(response));
+    expect.assertions(2);
 
     await expect(
       patchWishlistItem(wishlistId, wishlistItemId, data),
-    ).resolves.toBe(response);
+    ).resolves.toEqual(response);
 
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/wishlists/${wishlistId}/items/${wishlistItemId}`,
@@ -43,11 +35,8 @@ describe('patchWishlistItem', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({
-      wishlistId,
-      wishlistItemId,
-      response,
-    });
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(
       patchWishlistItem(wishlistId, wishlistItemId, data),

--- a/packages/client/src/wishlists/__tests__/patchWishlistSet.test.ts
+++ b/packages/client/src/wishlists/__tests__/patchWishlistSet.test.ts
@@ -6,7 +6,7 @@ import {
 import { patchWishlistSet } from '..';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/patchWishlistSet.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('patchWishlistSet', () => {
   const expectedConfig = undefined;
@@ -15,18 +15,11 @@ describe('patchWishlistSet', () => {
   const data = mockWishlistSetPatchData;
   const spy = jest.spyOn(client, 'patch');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    fixtures.success({
-      wishlistId,
-      wishlistSetId,
-    });
+    mswServer.use(fixtures.success());
+    expect.assertions(2);
 
     await expect(
       patchWishlistSet(wishlistId, wishlistSetId, data),
@@ -40,10 +33,8 @@ describe('patchWishlistSet', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({
-      wishlistId,
-      wishlistSetId,
-    });
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(
       patchWishlistSet(wishlistId, wishlistSetId, data),

--- a/packages/client/src/wishlists/__tests__/postWishlistItem.test.ts
+++ b/packages/client/src/wishlists/__tests__/postWishlistItem.test.ts
@@ -6,7 +6,7 @@ import {
 import { postWishlistItem } from '..';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/postWishlistItem.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('postWishlistItem', () => {
   const expectedConfig = undefined;
@@ -14,19 +14,15 @@ describe('postWishlistItem', () => {
   const data = mockWishlistItemPostData;
   const spy = jest.spyOn(client, 'post');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
     const response = mockWishlistsResponse;
 
-    fixtures.success({ wishlistId, response });
+    mswServer.use(fixtures.success(response));
+    expect.assertions(2);
 
-    await expect(postWishlistItem(wishlistId, data)).resolves.toBe(response);
+    await expect(postWishlistItem(wishlistId, data)).resolves.toEqual(response);
 
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/wishlists/${wishlistId}/items`,
@@ -36,7 +32,8 @@ describe('postWishlistItem', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ wishlistId });
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(postWishlistItem(wishlistId, data)).rejects.toMatchSnapshot();
 

--- a/packages/client/src/wishlists/__tests__/postWishlistSet.test.ts
+++ b/packages/client/src/wishlists/__tests__/postWishlistSet.test.ts
@@ -5,7 +5,7 @@ import {
 import { postWishlistSet } from '..';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/postWishlistSet.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('postWishlistSet', () => {
   const expectedConfig = undefined;
@@ -13,19 +13,15 @@ describe('postWishlistSet', () => {
   const data = mockWishlistsSetResponse;
   const spy = jest.spyOn(client, 'post');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
     const response = mockWishlistsSetResponse;
 
-    fixtures.success({ wishlistId, response });
+    mswServer.use(fixtures.success(response));
+    expect.assertions(2);
 
-    await expect(postWishlistSet(wishlistId, data)).resolves.toBe(response);
+    await expect(postWishlistSet(wishlistId, data)).resolves.toEqual(response);
 
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/wishlists/${wishlistId}/sets`,
@@ -35,7 +31,8 @@ describe('postWishlistSet', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ wishlistId });
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(postWishlistSet(wishlistId, data)).rejects.toMatchSnapshot();
 


### PR DESCRIPTION
## Description
This replaces the `moxios` package with `msw` in the fixtures and tests related with wishlists.

Refs #18 

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->



<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
