### PR TITLE
chore(next): remove exported constant from useProductsList

### DIFF
--- a/packages/react/src/products/hooks/__tests__/useProductsList.test.tsx
+++ b/packages/react/src/products/hooks/__tests__/useProductsList.test.tsx
@@ -9,7 +9,7 @@ import { mockStore } from '../../../../tests/helpers';
 import { Provider } from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
-import useProductsList, { PRODUCTS_LIST_TYPES } from '../useProductsList';
+import useProductsList from '../useProductsList';
 import type { UseProductsListParams } from '../types';
 
 jest.mock('@farfetch/blackout-redux/products', () => ({
@@ -84,7 +84,7 @@ describe('useProductsList', () => {
     });
 
     it('should fetch a set', () => {
-      getRenderedHook({ type: PRODUCTS_LIST_TYPES.SET });
+      getRenderedHook({ type: 'set' });
 
       expect(mockDispatch).toHaveBeenCalledWith({ type: 'fetchSet' });
     });

--- a/packages/react/src/products/hooks/useProductsList.ts
+++ b/packages/react/src/products/hooks/useProductsList.ts
@@ -26,7 +26,7 @@ import type {
   UseProductsList,
 } from './types/useProductsList';
 
-export const PRODUCTS_LIST_TYPES: ProductsListTypes = {
+const PRODUCTS_LIST_TYPES: ProductsListTypes = {
   LISTING: 'listing',
   SET: 'set',
 };


### PR DESCRIPTION
## Description
This removes the export of a constant in the `useProductsList` file to avoid its usage
in not intended ways.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
