### PR TITLE
chore(client): replace `moxios` with `msw` in `staffMembers`

### DIFF
--- a/packages/client/src/staffMembers/__fixtures__/getStaffMember.fixtures.ts
+++ b/packages/client/src/staffMembers/__fixtures__/getStaffMember.fixtures.ts
@@ -1,21 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
+import { rest, RestHandler } from 'msw';
 import type { StaffMember } from '../types';
 
-/**
- * Response payloads.
- */
+const path = '/api/account/v1/staffMembers/:id';
+
 export default {
-  success: (params: { id: number; response: StaffMember }): void => {
-    moxios.stubRequest(join('/api/account/v1/staffMembers', params.id), {
-      response: params.response,
-      status: 200,
-    });
-  },
-  failure: (params: { id: number }): void => {
-    moxios.stubRequest(join('/api/account/v1/staffMembers', params.id), {
-      response: 'stub error',
-      status: 404,
-    });
-  },
+  success: (response: StaffMember): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/staffMembers/__tests__/__snapshots__/getStaffMember.test.ts.snap
+++ b/packages/client/src/staffMembers/__tests__/__snapshots__/getStaffMember.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/staffMembers/__tests__/getStaffMember.test.ts
+++ b/packages/client/src/staffMembers/__tests__/getStaffMember.test.ts
@@ -6,30 +6,21 @@ import {
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getStaffMember.fixtures';
 import join from 'proper-url-join';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getStaffMember', () => {
   const spy = jest.spyOn(client, 'get');
   const expectedConfig = undefined;
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
     const response = mockStaffMember;
 
-    fixtures.success({
-      response,
-      id: mockStaffMemberId,
-    });
-
+    mswServer.use(fixtures.success(response));
     expect.assertions(2);
 
-    await expect(getStaffMember(mockStaffMemberId)).resolves.toBe(response);
+    await expect(getStaffMember(mockStaffMemberId)).resolves.toEqual(response);
 
     expect(spy).toHaveBeenCalledWith(
       join('/account/v1/staffMembers', mockStaffMemberId),
@@ -37,12 +28,11 @@ describe('getStaffMember', () => {
     );
   });
 
-  it('should receive a client request error', () => {
-    fixtures.failure({ id: mockStaffMemberId });
-
+  it('should receive a client request error', async () => {
+    mswServer.use(fixtures.failure());
     expect.assertions(2);
 
-    expect(getStaffMember(mockStaffMemberId)).rejects.toMatchSnapshot();
+    await expect(getStaffMember(mockStaffMemberId)).rejects.toMatchSnapshot();
 
     expect(spy).toHaveBeenCalledWith(
       join('/account/v1/staffMembers', mockStaffMemberId),


### PR DESCRIPTION
## Description
This replaces the usage of the `moxios` library with `msw` in the unit tests of the `staffMembers`
chunk.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->
Refs #18 

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
