### PR TITLE
chore(client): replace moxios with msw in brands

### DIFF
--- a/packages/client/src/brands/__fixtures__/getBrand.fixtures.ts
+++ b/packages/client/src/brands/__fixtures__/getBrand.fixtures.ts
@@ -1,21 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
+import { rest, RestHandler } from 'msw';
 import type { Brand } from '../types';
 
-/**
- * Response payloads.
- */
+const path = '/api/commerce/v1/brands/:id';
+
 export default {
-  success: (params: { id: Brand['id']; response: Brand }): void => {
-    moxios.stubRequest(join('/api/commerce/v1/brands', params.id), {
-      response: params.response,
-      status: 200,
-    });
-  },
-  failure: (params: { id: Brand['id'] }): void => {
-    moxios.stubRequest(join('/api/commerce/v1/brands', params.id), {
-      response: 'stub error',
-      status: 404,
-    });
-  },
+  success: (response: Brand): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/brands/__fixtures__/getBrands.fixtures.ts
+++ b/packages/client/src/brands/__fixtures__/getBrands.fixtures.ts
@@ -1,31 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Brands, BrandsQuery } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { Brands } from '../types';
 
-/**
- * Response payloads.
- */
+const path = '/api/commerce/v1/brands';
+
 export default {
-  success: (params: { query: BrandsQuery; response: Brands }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/brands', {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { query: BrandsQuery }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/brands', {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: Brands): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/brands/__tests__/__snapshots__/getBrand.test.ts.snap
+++ b/packages/client/src/brands/__tests__/__snapshots__/getBrand.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/brands/__tests__/__snapshots__/getBrands.test.ts.snap
+++ b/packages/client/src/brands/__tests__/__snapshots__/getBrands.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/brands/__tests__/getBrand.test.ts
+++ b/packages/client/src/brands/__tests__/getBrand.test.ts
@@ -2,17 +2,12 @@ import { getBrand } from '../';
 import { mockBrandId, mockBrandResponse } from 'tests/__fixtures__/brands';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getBrand.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('brands client', () => {
   const expectedConfig = undefined;
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   describe('getBrand()', () => {
     const spy = jest.spyOn(client, 'get');
@@ -20,12 +15,11 @@ describe('brands client', () => {
     it('should handle a client request successfully', async () => {
       const response = mockBrandResponse;
 
-      fixtures.success({
-        id: mockBrandId,
-        response,
-      });
+      mswServer.use(fixtures.success(response));
+      expect.assertions(2);
 
-      await expect(getBrand(mockBrandId)).resolves.toBe(response);
+      await expect(getBrand(mockBrandId)).resolves.toEqual(response);
+
       expect(spy).toHaveBeenCalledWith(
         `/commerce/v1/brands/${mockBrandId}`,
         expectedConfig,
@@ -33,11 +27,11 @@ describe('brands client', () => {
     });
 
     it('should receive a client request error', async () => {
-      fixtures.failure({
-        id: mockBrandId,
-      });
+      mswServer.use(fixtures.failure());
+      expect.assertions(2);
 
       await expect(getBrand(mockBrandId)).rejects.toMatchSnapshot();
+
       expect(spy).toHaveBeenCalledWith(
         `/commerce/v1/brands/${mockBrandId}`,
         expectedConfig,

--- a/packages/client/src/brands/__tests__/getBrands.test.ts
+++ b/packages/client/src/brands/__tests__/getBrands.test.ts
@@ -2,17 +2,12 @@ import { getBrands } from '../';
 import { mockBrandsResponse, mockQuery } from 'tests/__fixtures__/brands';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getBrands.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('brands client', () => {
   const expectedConfig = undefined;
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   describe('getBrands()', () => {
     const spy = jest.spyOn(client, 'get');
@@ -20,12 +15,11 @@ describe('brands client', () => {
     it('should handle a client request successfully', async () => {
       const response = mockBrandsResponse;
 
-      fixtures.success({
-        query: mockQuery,
-        response,
-      });
+      mswServer.use(fixtures.success(response));
+      expect.assertions(2);
 
-      await expect(getBrands(mockQuery)).resolves.toBe(response);
+      await expect(getBrands(mockQuery)).resolves.toEqual(response);
+
       expect(spy).toHaveBeenCalledWith(
         '/commerce/v1/brands?id=211376%2C%20110127',
         expectedConfig,
@@ -33,11 +27,12 @@ describe('brands client', () => {
     });
 
     it('should receive a client request error', async () => {
-      fixtures.failure({
-        query: mockQuery,
-      });
+      mswServer.use(fixtures.failure());
+
+      expect.assertions(2);
 
       await expect(getBrands(mockQuery)).rejects.toMatchSnapshot();
+
       expect(spy).toHaveBeenCalledWith(
         '/commerce/v1/brands?id=211376%2C%20110127',
         expectedConfig,


### PR DESCRIPTION
## Description
This replaces the usage of the `moxios` library with `msw` in the unit tests of the `brands`
chunk.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->
Refs #18 

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
