### PR TITLE
chore(client): replace moxios with msw in size scales and size guides

### DIFF
--- a/packages/client/src/sizeGuides/__fixtures__/getSizeGuides.fixtures.ts
+++ b/packages/client/src/sizeGuides/__fixtures__/getSizeGuides.fixtures.ts
@@ -1,34 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { SizeGuide, SizeGuidesQuery } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { SizeGuide } from '../types';
 
-/**
- * Response payloads.
- */
+const path = '/api/commerce/v1/sizeGuides';
+
 export default {
-  success: (params: {
-    query: SizeGuidesQuery;
-    response: SizeGuide[];
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/sizeGuides', {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { query: SizeGuidesQuery }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/sizeGuides', {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: SizeGuide[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/sizeGuides/__tests__/__snapshots__/getSizeGuides.test.ts.snap
+++ b/packages/client/src/sizeGuides/__tests__/__snapshots__/getSizeGuides.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/sizeGuides/__tests__/getSizeGuides.test.ts
+++ b/packages/client/src/sizeGuides/__tests__/getSizeGuides.test.ts
@@ -7,28 +7,22 @@ import {
 } from 'tests/__fixtures__/sizeGuides';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getSizeGuides.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getProductSizeGuides', () => {
   const expectedConfig = undefined;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
     const response = mockSizeGuides;
 
-    fixtures.success({
-      query: mockQuery,
-      response,
-    });
+    mswServer.use(fixtures.success(response));
+    expect.assertions(2);
 
-    await expect(getSizeGuides(mockQuery)).resolves.toBe(response);
+    await expect(getSizeGuides(mockQuery)).resolves.toEqual(response);
+
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/sizeGuides?brandIds=${mockBrandId}&categoryIds=${mockCategoriesIds[0]}&categoryIds=${mockCategoriesIds[1]}&categoryIds=${mockCategoriesIds[2]}`,
       expectedConfig,
@@ -36,11 +30,11 @@ describe('getProductSizeGuides', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({
-      query: mockQuery,
-    });
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(getSizeGuides(mockQuery)).rejects.toMatchSnapshot();
+
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/sizeGuides?brandIds=${mockBrandId}&categoryIds=${mockCategoriesIds[0]}&categoryIds=${mockCategoriesIds[1]}&categoryIds=${mockCategoriesIds[2]}`,
       expectedConfig,

--- a/packages/client/src/sizeScales/__fixtures__/getSizeScale.fixtures.ts
+++ b/packages/client/src/sizeScales/__fixtures__/getSizeScale.fixtures.ts
@@ -1,21 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
+import { rest, RestHandler } from 'msw';
 import type { SizeScale } from '../types';
 
-/**
- * Response payloads.
- */
+const path = '/api/commerce/v1/sizeScales/:id';
+
 export default {
-  success: (params: { id: number; response: SizeScale }): void => {
-    moxios.stubRequest(join('/api/commerce/v1/sizeScales', params.id), {
-      response: params.response,
-      status: 200,
-    });
-  },
-  failure: (params: { id: number }): void => {
-    moxios.stubRequest(join('/api/commerce/v1/sizeScales', params.id), {
-      response: 'stub error',
-      status: 404,
-    });
-  },
+  success: (response: SizeScale): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/sizeScales/__fixtures__/getSizeScaleMappings.fixtures.ts
+++ b/packages/client/src/sizeScales/__fixtures__/getSizeScaleMappings.fixtures.ts
@@ -1,34 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { SizeScaleMapping, SizeScaleMappingsQuery } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { SizeScaleMapping } from '../types';
 
-/**
- * Response payloads.
- */
+const path = '/api/commerce/v1/sizeScaleMappings';
+
 export default {
-  success: (params: {
-    query: SizeScaleMappingsQuery;
-    response: SizeScaleMapping;
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/sizeScaleMappings', {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { query: SizeScaleMappingsQuery }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/sizeScaleMappings', {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: SizeScaleMapping): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/sizeScales/__fixtures__/getSizeScales.fixtures.ts
+++ b/packages/client/src/sizeScales/__fixtures__/getSizeScales.fixtures.ts
@@ -1,34 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { SizeScale, SizeScalesQuery } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { SizeScale } from '../types';
 
-/**
- * Response payloads.
- */
+const path = '/api/commerce/v1/sizeScales';
+
 export default {
-  success: (params: {
-    query: SizeScalesQuery;
-    response: SizeScale[];
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/sizeScales', {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { query: SizeScalesQuery }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/sizeScales', {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: SizeScale[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/sizeScales/__tests__/__snapshots__/getSizeScale.test.ts.snap
+++ b/packages/client/src/sizeScales/__tests__/__snapshots__/getSizeScale.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/sizeScales/__tests__/__snapshots__/getSizeScaleMappings.test.ts.snap
+++ b/packages/client/src/sizeScales/__tests__/__snapshots__/getSizeScaleMappings.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/sizeScales/__tests__/__snapshots__/getSizeScales.test.ts.snap
+++ b/packages/client/src/sizeScales/__tests__/__snapshots__/getSizeScales.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/sizeScales/__tests__/getSizeScale.test.ts
+++ b/packages/client/src/sizeScales/__tests__/getSizeScale.test.ts
@@ -2,18 +2,13 @@ import { getSizeScale } from '../';
 import { mockSizeScale } from 'tests/__fixtures__/sizeScales';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getSizeScale.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('sizeScales client', () => {
   const scaleId = 117;
   const expectedConfig = undefined;
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   describe('getSizeScale()', () => {
     const spy = jest.spyOn(client, 'get');
@@ -21,12 +16,10 @@ describe('sizeScales client', () => {
     it('should handle a client request successfully', async () => {
       const response = mockSizeScale;
 
-      fixtures.success({
-        id: scaleId,
-        response,
-      });
+      mswServer.use(fixtures.success(response));
+      expect.assertions(2);
 
-      await expect(getSizeScale(scaleId)).resolves.toBe(response);
+      await expect(getSizeScale(scaleId)).resolves.toEqual(response);
 
       expect(spy).toHaveBeenCalledWith(
         `/commerce/v1/sizeScales/${scaleId}`,
@@ -35,11 +28,11 @@ describe('sizeScales client', () => {
     });
 
     it('should receive a client request error', async () => {
-      fixtures.failure({
-        id: scaleId,
-      });
+      mswServer.use(fixtures.failure());
+      expect.assertions(2);
 
       await expect(getSizeScale(scaleId)).rejects.toMatchSnapshot();
+
       expect(spy).toHaveBeenCalledWith(
         `/commerce/v1/sizeScales/${scaleId}`,
         expectedConfig,

--- a/packages/client/src/sizeScales/__tests__/getSizeScaleMappings.test.ts
+++ b/packages/client/src/sizeScales/__tests__/getSizeScaleMappings.test.ts
@@ -8,17 +8,12 @@ import {
 } from 'tests/__fixtures__/sizeScales';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getSizeScaleMappings.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('sizeScaleMappings client', () => {
   const expectedConfig = undefined;
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   describe('getSizeScaleMappings()', () => {
     const spy = jest.spyOn(client, 'get');
@@ -26,14 +21,13 @@ describe('sizeScaleMappings client', () => {
     it('should handle a client request successfully', async () => {
       const response = mockSizeScaleMappings;
 
-      fixtures.success({
-        query: mockSizeScaleMappingsQuery,
-        response,
-      });
+      mswServer.use(fixtures.success(response));
+      expect.assertions(2);
 
       await expect(
         getSizeScaleMappings(mockSizeScaleMappingsQuery),
-      ).resolves.toBe(response);
+      ).resolves.toEqual(response);
+
       expect(spy).toHaveBeenCalledWith(
         `/commerce/v1/sizeScaleMappings?brand=${mockSizeScaleMappingsBrandId}&gender=${mockSizeScaleMappingsGenderId}&sizeScale=${mockSizeScaleMappingsScaleId}`,
         expectedConfig,
@@ -41,13 +35,13 @@ describe('sizeScaleMappings client', () => {
     });
 
     it('should receive a client request error', async () => {
-      fixtures.failure({
-        query: mockSizeScaleMappingsQuery,
-      });
+      mswServer.use(fixtures.failure());
+      expect.assertions(2);
 
       await expect(
         getSizeScaleMappings(mockSizeScaleMappingsQuery),
       ).rejects.toMatchSnapshot();
+
       expect(spy).toHaveBeenCalledWith(
         `/commerce/v1/sizeScaleMappings?brand=${mockSizeScaleMappingsBrandId}&gender=${mockSizeScaleMappingsGenderId}&sizeScale=${mockSizeScaleMappingsScaleId}`,
         expectedConfig,

--- a/packages/client/src/sizeScales/__tests__/getSizeScales.test.ts
+++ b/packages/client/src/sizeScales/__tests__/getSizeScales.test.ts
@@ -2,7 +2,7 @@ import { getSizeScales } from '../';
 import { mockSizeScale } from 'tests/__fixtures__/sizeScales';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getSizeScales.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('sizeScales client', () => {
   const mockQuery = {
@@ -10,12 +10,7 @@ describe('sizeScales client', () => {
   };
   const expectedConfig = undefined;
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   describe('getSizeScales()', () => {
     const spy = jest.spyOn(client, 'get');
@@ -23,12 +18,11 @@ describe('sizeScales client', () => {
     it('should handle a client request successfully', async () => {
       const response = [mockSizeScale];
 
-      fixtures.success({
-        query: mockQuery,
-        response,
-      });
+      mswServer.use(fixtures.success(response));
+      expect.assertions(2);
 
-      await expect(getSizeScales(mockQuery)).resolves.toBe(response);
+      await expect(getSizeScales(mockQuery)).resolves.toEqual(response);
+
       expect(spy).toHaveBeenCalledWith(
         '/commerce/v1/sizeScales?categoryId=136301',
         expectedConfig,
@@ -36,11 +30,11 @@ describe('sizeScales client', () => {
     });
 
     it('should receive a client request error', async () => {
-      fixtures.failure({
-        query: mockQuery,
-      });
+      mswServer.use(fixtures.failure());
+      expect.assertions(2);
 
       await expect(getSizeScales(mockQuery)).rejects.toMatchSnapshot();
+
       expect(spy).toHaveBeenCalledWith(
         '/commerce/v1/sizeScales?categoryId=136301',
         expectedConfig,


### PR DESCRIPTION
## Description
This replaces the usage of the `moxios` library with `msw` in the unit tests of the `sizeScales` and `sizeGuides`
chunks.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->
Refs #18 

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
