### PR TITLE
chore(client): replace moxios with msw in categories and designers

### DIFF
--- a/packages/client/src/categories/__fixtures__/getCategories.fixtures.ts
+++ b/packages/client/src/categories/__fixtures__/getCategories.fixtures.ts
@@ -1,18 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
+import { rest, RestHandler } from 'msw';
 import type { Category } from '../types';
 
+const path = '/api/commerce/v1/categories';
+
 export default {
-  success: (params: { response: Category[] }): void => {
-    moxios.stubRequest(join('/api/commerce/v1/categories'), {
-      response: params.response,
-      status: 200,
-    });
-  },
-  failure: (): void => {
-    moxios.stubRequest(join('/api/commerce/v1/categories'), {
-      response: 'stub error',
-      status: 404,
-    });
-  },
+  success: (response: Category[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/categories/__fixtures__/getTopCategories.fixtures.ts
+++ b/packages/client/src/categories/__fixtures__/getTopCategories.fixtures.ts
@@ -1,18 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
+import { rest, RestHandler } from 'msw';
 import type { Category } from '../types';
 
+const path = '/api/commerce/v1/categories/top';
+
 export default {
-  success: (params: { response: Category[] }): void => {
-    moxios.stubRequest(join('/api/commerce/v1/categories/top'), {
-      response: params.response,
-      status: 200,
-    });
-  },
-  failure: (): void => {
-    moxios.stubRequest(join('/api/commerce/v1/categories/top'), {
-      response: 'stub error',
-      status: 404,
-    });
-  },
+  success: (response: Category[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/categories/__tests__/__snapshots__/getCategories.test.ts.snap
+++ b/packages/client/src/categories/__tests__/__snapshots__/getCategories.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/categories/__tests__/__snapshots__/getTopCategories.test.ts.snap
+++ b/packages/client/src/categories/__tests__/__snapshots__/getTopCategories.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/categories/__tests__/getCategories.test.ts
+++ b/packages/client/src/categories/__tests__/getCategories.test.ts
@@ -2,32 +2,29 @@ import { getCategories } from '../';
 import { mockCategories } from 'tests/__fixtures__/categories';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getCategories.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getCategories()', () => {
   const expectedConfig = undefined;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    fixtures.success({
-      response: mockCategories,
-    });
+    mswServer.use(fixtures.success(mockCategories));
+    expect.assertions(2);
 
-    await expect(getCategories()).resolves.toBe(mockCategories);
+    await expect(getCategories()).resolves.toEqual(mockCategories);
+
     expect(spy).toHaveBeenCalledWith('/commerce/v1/categories', expectedConfig);
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure();
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(getCategories()).rejects.toMatchSnapshot();
+
     expect(spy).toHaveBeenCalledWith('/commerce/v1/categories', expectedConfig);
   });
 });

--- a/packages/client/src/categories/__tests__/getTopCategories.test.ts
+++ b/packages/client/src/categories/__tests__/getTopCategories.test.ts
@@ -2,25 +2,20 @@ import { getTopCategories } from '..';
 import { mockTopCategories } from 'tests/__fixtures__/categories';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getTopCategories.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getTopCategories()', () => {
   const expectedConfig = undefined;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    fixtures.success({
-      response: mockTopCategories,
-    });
+    mswServer.use(fixtures.success(mockTopCategories));
+    expect.assertions(2);
 
     await expect(getTopCategories()).resolves.toEqual(mockTopCategories);
+
     expect(spy).toHaveBeenCalledWith(
       '/commerce/v1/categories/top',
       expectedConfig,
@@ -28,9 +23,11 @@ describe('getTopCategories()', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure();
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(getTopCategories()).rejects.toMatchSnapshot();
+
     expect(spy).toHaveBeenCalledWith(
       '/commerce/v1/categories/top',
       expectedConfig,

--- a/packages/client/src/designers/__fixtures__/getDesigners.fixtures.ts
+++ b/packages/client/src/designers/__fixtures__/getDesigners.fixtures.ts
@@ -1,34 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Designers, GetDesignersQuery } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { Designers } from '../types';
 
-/**
- * Response payloads.
- */
+const path = '/api/legacy/v1/designers';
+
 export default {
-  success: (params: {
-    query: GetDesignersQuery;
-    response: Designers;
-  }): void => {
-    moxios.stubRequest(
-      join('/api/legacy/v1/designers', {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { query: GetDesignersQuery }): void => {
-    moxios.stubRequest(
-      join('/api/legacy/v1/designers', {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: Designers): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/designers/__tests__/__snapshots__/getDesigners.test.ts.snap
+++ b/packages/client/src/designers/__tests__/__snapshots__/getDesigners.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/designers/__tests__/getDesigners.test.ts
+++ b/packages/client/src/designers/__tests__/getDesigners.test.ts
@@ -3,30 +3,23 @@ import { mockQuery, mockResponse } from 'tests/__fixtures__/designers';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getDesigners.fixtures';
 import join from 'proper-url-join';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('designers client', () => {
   const expectedConfig = undefined;
   const query = mockQuery;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   describe('getDesigners()', () => {
     it('should handle a client request successfully', async () => {
       const response = mockResponse.result;
 
-      fixtures.success({
-        response,
-        query,
-      });
+      mswServer.use(fixtures.success(response));
+      expect.assertions(2);
 
-      await expect(getDesigners(query)).resolves.toBe(response);
+      await expect(getDesigners(query)).resolves.toEqual(response);
 
       expect(spy).toHaveBeenCalledWith(
         join('/legacy/v1/designers', { query }),
@@ -35,9 +28,8 @@ describe('designers client', () => {
     });
 
     it('should receive a client request error', async () => {
-      fixtures.failure({
-        query,
-      });
+      mswServer.use(fixtures.failure());
+      expect.assertions(2);
 
       await expect(getDesigners(query)).rejects.toMatchSnapshot();
 


### PR DESCRIPTION
## Description
This replaces the usage of the `moxios` library with `msw` in the unit tests of the `categories` and `designers`
chunks.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->
Refs #18 

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
