### PR TITLE
chore(client): replace moxios with msw in search and promotion evaluations

### DIFF
--- a/packages/client/src/promotionEvaluations/__fixtures__/getPromotionEvaluationItems.fixtures.ts
+++ b/packages/client/src/promotionEvaluations/__fixtures__/getPromotionEvaluationItems.fixtures.ts
@@ -1,35 +1,17 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { PromotionEvaluationId, PromotionEvaluationItem } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { PromotionEvaluationItem } from '../types';
+
+const path =
+  '/api/commerce/v1/promotionEvaluations/:promotionEvaluationId/promotionEvaluationItems';
 
 export default {
-  success: (params: {
-    promotionEvaluationId: PromotionEvaluationId;
-    response: Array<PromotionEvaluationItem>;
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/promotionEvaluations',
-        params.promotionEvaluationId,
-        'promotionEvaluationItems',
-      ),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { promotionEvaluationId: PromotionEvaluationId }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/promotionEvaluations',
-        params.promotionEvaluationId,
-        'promotionEvaluationItems',
-      ),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: PromotionEvaluationItem[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/promotionEvaluations/__tests__/__snapshots__/getPromotionEvaluationItems.test.ts.snap
+++ b/packages/client/src/promotionEvaluations/__tests__/__snapshots__/getPromotionEvaluationItems.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/promotionEvaluations/__tests__/getPromotionEvaluationItems.test.ts
+++ b/packages/client/src/promotionEvaluations/__tests__/getPromotionEvaluationItems.test.ts
@@ -5,30 +5,25 @@ import {
 } from 'tests/__fixtures__/promotionEvaluations';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getPromotionEvaluationItems.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getPromotionEvaluationItems()', () => {
   const expectedConfig = undefined;
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
+  beforeEach(jest.clearAllMocks);
 
-  afterEach(() => moxios.uninstall(client));
   const spy = jest.spyOn(client, 'get');
 
   it('should handle a client request successfully', async () => {
     const response = mockPromotionEvaluationsItemsResponse;
 
-    fixtures.success({
-      promotionEvaluationId: mockPromotionEvaluationId,
-      response,
-    });
+    mswServer.use(fixtures.success(response));
+    expect.assertions(2);
 
     await expect(
       getPromotionEvaluationItems(mockPromotionEvaluationId),
-    ).resolves.toBe(response);
+    ).resolves.toEqual(response);
+
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/promotionEvaluations/${mockPromotionEvaluationId}/promotionEvaluationItems`,
       expectedConfig,
@@ -36,13 +31,13 @@ describe('getPromotionEvaluationItems()', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({
-      promotionEvaluationId: mockPromotionEvaluationId,
-    });
+    mswServer.use(fixtures.failure());
+    expect.assertions(2);
 
     await expect(
       getPromotionEvaluationItems(mockPromotionEvaluationId),
     ).rejects.toMatchSnapshot();
+
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/promotionEvaluations/${mockPromotionEvaluationId}/promotionEvaluationItems`,
       expectedConfig,

--- a/packages/client/src/search/__fixtures__/getSearchDidYouMean.fixtures.ts
+++ b/packages/client/src/search/__fixtures__/getSearchDidYouMean.fixtures.ts
@@ -1,34 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { SearchDidYouMean, SearchDidYouMeanQuery } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { SearchDidYouMean } from '../types';
 
-/**
- * Response payloads.
- */
+const path = '/api/commerce/v1/search/didyoumean';
+
 export default {
-  success: (params: {
-    query: SearchDidYouMeanQuery;
-    response: SearchDidYouMean[];
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/search/didyoumean', {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { query: SearchDidYouMeanQuery }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/search/didyoumean', {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: SearchDidYouMean[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/search/__fixtures__/getSearchIntents.fixtures.ts
+++ b/packages/client/src/search/__fixtures__/getSearchIntents.fixtures.ts
@@ -1,34 +1,16 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { SearchIntents, SearchIntentsQuery } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { SearchIntents } from '../types';
 
-/**
- * Response payloads.
- */
+const path = '/api/commerce/v1/search/intent';
+
 export default {
-  success: (params: {
-    query: SearchIntentsQuery;
-    response: SearchIntents;
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/search/intent', {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { query: SearchIntentsQuery }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/search/intent', {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: SearchIntents): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/search/__fixtures__/getSearchSuggestions.fixtures.ts
+++ b/packages/client/src/search/__fixtures__/getSearchSuggestions.fixtures.ts
@@ -1,34 +1,15 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { SearchSuggestion, SearchSuggestionsQuery } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { SearchSuggestion } from '../types';
 
-/**
- * Response payloads.
- */
+const path = '/api/commerce/v1/search/suggestions';
+
 export default {
-  success: (params: {
-    query: SearchSuggestionsQuery;
-    response: SearchSuggestion[];
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/search/suggestions', {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { query: SearchSuggestionsQuery }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/search/suggestions', {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: SearchSuggestion[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/search/__tests__/__snapshots__/getSearchDidYouMean.test.ts.snap
+++ b/packages/client/src/search/__tests__/__snapshots__/getSearchDidYouMean.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/search/__tests__/__snapshots__/getSearchIntents.test.ts.snap
+++ b/packages/client/src/search/__tests__/__snapshots__/getSearchIntents.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/search/__tests__/__snapshots__/getSearchSuggestions.test.ts.snap
+++ b/packages/client/src/search/__tests__/__snapshots__/getSearchSuggestions.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/search/__tests__/getSearchDidYouMean.test.ts
+++ b/packages/client/src/search/__tests__/getSearchDidYouMean.test.ts
@@ -5,18 +5,13 @@ import {
 } from 'tests/__fixtures__/search';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getSearchDidYouMean.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('search did you mean client', () => {
   const expectedConfig = undefined;
   const query = mockSearchDidYouMeanQuery;
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   describe('getSearchDidYouMean', () => {
     const spy = jest.spyOn(client, 'get');
@@ -24,14 +19,10 @@ describe('search did you mean client', () => {
     it('should handle a client request successfully', async () => {
       const response = mockSearchDidYouMeanResponse;
 
-      fixtures.success({
-        response,
-        query,
-      });
-
+      mswServer.use(fixtures.success(response));
       expect.assertions(2);
 
-      await expect(getSearchDidYouMean(query)).resolves.toBe(response);
+      await expect(getSearchDidYouMean(query)).resolves.toEqual(response);
 
       expect(spy).toHaveBeenCalledWith(
         '/commerce/v1/search/didyoumean?genders=0&genders=1&searchTerms=balenciga',
@@ -40,10 +31,7 @@ describe('search did you mean client', () => {
     });
 
     it('should receive a client request error', async () => {
-      fixtures.failure({
-        query,
-      });
-
+      mswServer.use(fixtures.failure());
       expect.assertions(2);
 
       await expect(getSearchDidYouMean(query)).rejects.toMatchSnapshot();

--- a/packages/client/src/search/__tests__/getSearchIntents.test.ts
+++ b/packages/client/src/search/__tests__/getSearchIntents.test.ts
@@ -5,18 +5,13 @@ import {
 } from 'tests/__fixtures__/search';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getSearchIntents.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('search intents client', () => {
   const expectedConfig = undefined;
   const query = mockSearchIntentsQuery;
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   describe('getSearchIntents', () => {
     const spy = jest.spyOn(client, 'get');
@@ -24,14 +19,10 @@ describe('search intents client', () => {
     it('should handle a client request successfully', async () => {
       const response = mockSearchIntentsResponse;
 
-      fixtures.success({
-        response,
-        query,
-      });
-
+      mswServer.use(fixtures.success(response));
       expect.assertions(2);
 
-      await expect(getSearchIntents(query)).resolves.toBe(response);
+      await expect(getSearchIntents(query)).resolves.toEqual(response);
 
       expect(spy).toHaveBeenCalledWith(
         '/commerce/v1/search/intent?gender=0&searchTerms=white%20dresses',
@@ -40,10 +31,7 @@ describe('search intents client', () => {
     });
 
     it('should receive a client request error', async () => {
-      fixtures.failure({
-        query,
-      });
-
+      mswServer.use(fixtures.failure());
       expect.assertions(2);
 
       await expect(getSearchIntents(query)).rejects.toMatchSnapshot();

--- a/packages/client/src/search/__tests__/getSearchSuggestions.test.ts
+++ b/packages/client/src/search/__tests__/getSearchSuggestions.test.ts
@@ -5,18 +5,13 @@ import {
 } from 'tests/__fixtures__/search';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getSearchSuggestions.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('search suggestions client', () => {
   const expectedConfig = undefined;
   const query = mockSearchSuggestionsQuery;
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   describe('getSearchSuggestions', () => {
     const spy = jest.spyOn(client, 'get');
@@ -24,14 +19,10 @@ describe('search suggestions client', () => {
     it('should handle a client request successfully', async () => {
       const response = mockSearchSuggestionsResponse;
 
-      fixtures.success({
-        response,
-        query,
-      });
-
+      mswServer.use(fixtures.success(response));
       expect.assertions(2);
 
-      await expect(getSearchSuggestions(query)).resolves.toBe(response);
+      await expect(getSearchSuggestions(query)).resolves.toEqual(response);
 
       expect(spy).toHaveBeenCalledWith(
         '/commerce/v1/search/suggestions?gender=0&ignoreFilterExclusions=true&query=dresses',
@@ -40,10 +31,7 @@ describe('search suggestions client', () => {
     });
 
     it('should receive a client request error', async () => {
-      fixtures.failure({
-        query,
-      });
-
+      mswServer.use(fixtures.failure());
       expect.assertions(2);
 
       await expect(getSearchSuggestions(query)).rejects.toMatchSnapshot();


### PR DESCRIPTION
## Description
This replaces the usage of the `moxios` library with `msw` in the unit tests of the `search` and `promotionEvaluations`
chunks.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->
Refs #18 

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
