### PR TITLE
chore(client): replace moxios with msw on products client

### DIFF
--- a/packages/client/src/bags/__fixtures__/getBag.fixtures.ts
+++ b/packages/client/src/bags/__fixtures__/getBag.fixtures.ts
@@ -1,23 +1,15 @@
 import { rest, RestHandler } from 'msw';
-import join from 'proper-url-join';
 import type { Bag } from '../types';
 
-const path = '/api/commerce/v1/bags';
+const path = '/api/commerce/v1/bags/:bagId';
 
 export default {
-  success: (params: { bagId: Bag['id']; response: Bag }): RestHandler =>
-    rest.get(
-      join(path, params.bagId, {
-        query: { hydrate: 'true' },
-      }),
-      async (req, res, ctx) => res(ctx.status(200), ctx.json(params.response)),
+  success: (response: Bag): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
     ),
-  failure: (params: { bagId: Bag['id'] }): RestHandler =>
-    rest.get(
-      join(path, params.bagId, {
-        query: { hydrate: 'true' },
-      }),
-      async (req, res, ctx) =>
-        res(ctx.status(404), ctx.json({ message: 'stub error' })),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
     ),
 };

--- a/packages/client/src/bags/__fixtures__/patchBagItem.fixtures.ts
+++ b/packages/client/src/bags/__fixtures__/patchBagItem.fixtures.ts
@@ -1,26 +1,15 @@
 import { rest, RestHandler } from 'msw';
-import join from 'proper-url-join';
-import type { Bag, BagItem } from '../types';
+import type { Bag } from '../types';
 
-const path = '/api/commerce/v1/bags';
+const path = '/api/commerce/v1/bags/:bagId/items/:bagItemId';
 
 export default {
-  success: (params: {
-    bagId: Bag['id'];
-    bagItemId: BagItem['id'];
-    response: Bag;
-  }): RestHandler =>
-    rest.patch(
-      join(path, params.bagId, 'items', params.bagItemId),
-      async (req, res, ctx) => res(ctx.status(200), ctx.json(params.response)),
+  success: (response: Bag): RestHandler =>
+    rest.patch(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
     ),
-  failure: (params: {
-    bagId: Bag['id'];
-    bagItemId: BagItem['id'];
-  }): RestHandler =>
-    rest.patch(
-      join(path, params.bagId, 'items', params.bagItemId),
-      async (req, res, ctx) =>
-        res(ctx.status(404), ctx.json({ message: 'stub error' })),
+  failure: (): RestHandler =>
+    rest.patch(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
     ),
 };

--- a/packages/client/src/bags/__fixtures__/postBagItem.fixtures.ts
+++ b/packages/client/src/bags/__fixtures__/postBagItem.fixtures.ts
@@ -1,16 +1,15 @@
 import { rest, RestHandler } from 'msw';
-import join from 'proper-url-join';
 import type { Bag } from '../types';
 
-const path = '/api/commerce/v1/bags';
+const path = '/api/commerce/v1/bags/:bagId/items';
 
 export default {
-  success: (params: { bagId: Bag['id']; response: Bag }): RestHandler =>
-    rest.post(join(path, params.bagId, 'items'), async (req, res, ctx) =>
-      res(ctx.status(200), ctx.json(params.response)),
+  success: (response: Bag): RestHandler =>
+    rest.post(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
     ),
-  failure: (params: { bagId: Bag['id'] }): RestHandler =>
-    rest.post(join(path, params.bagId, 'items'), async (req, res, ctx) =>
+  failure: (): RestHandler =>
+    rest.post(path, async (req, res, ctx) =>
       res(ctx.status(404), ctx.json({ message: 'stub error' })),
     ),
 };

--- a/packages/client/src/bags/__tests__/getBag.test.ts
+++ b/packages/client/src/bags/__tests__/getBag.test.ts
@@ -11,9 +11,7 @@ describe('getBag', () => {
   beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    mswServer.use(
-      fixtures.success({ bagId: mockBagId, response: mockResponse }),
-    );
+    mswServer.use(fixtures.success(mockResponse));
 
     expect.assertions(2);
 
@@ -26,7 +24,7 @@ describe('getBag', () => {
   });
 
   it('should receive a client request error', async () => {
-    mswServer.use(fixtures.failure({ bagId: mockBagId }));
+    mswServer.use(fixtures.failure());
 
     expect.assertions(2);
 

--- a/packages/client/src/bags/__tests__/patchBagItem.test.ts
+++ b/packages/client/src/bags/__tests__/patchBagItem.test.ts
@@ -11,25 +11,18 @@ import mswServer from '../../../tests/mswServer';
 
 describe('patchBagItem', () => {
   const expectedConfig = undefined;
-  const response = mockResponse;
   const spy = jest.spyOn(client, 'patch');
 
   beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    mswServer.use(
-      fixtures.success({
-        bagId: mockBagId,
-        bagItemId: mockBagItemId,
-        response,
-      }),
-    );
+    mswServer.use(fixtures.success(mockResponse));
 
     expect.assertions(2);
 
     await expect(
       patchBagItem(mockBagId, mockBagItemId, mockData),
-    ).resolves.toEqual(response);
+    ).resolves.toEqual(mockResponse);
 
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/bags/${mockBagId}/items/${mockBagItemId}`,
@@ -39,12 +32,7 @@ describe('patchBagItem', () => {
   });
 
   it('should receive a client request error', async () => {
-    mswServer.use(
-      fixtures.failure({
-        bagId: mockBagId,
-        bagItemId: mockBagItemId,
-      }),
-    );
+    mswServer.use(fixtures.failure());
 
     expect.assertions(2);
 

--- a/packages/client/src/bags/__tests__/postBagItem.test.ts
+++ b/packages/client/src/bags/__tests__/postBagItem.test.ts
@@ -11,9 +11,7 @@ describe('postBagItem', () => {
   beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    mswServer.use(
-      fixtures.success({ bagId: mockBagId, response: mockResponse }),
-    );
+    mswServer.use(fixtures.success(mockResponse));
 
     expect.assertions(2);
 
@@ -29,7 +27,7 @@ describe('postBagItem', () => {
   });
 
   it('should receive a client request error', async () => {
-    mswServer.use(fixtures.failure({ bagId: mockBagId }));
+    mswServer.use(fixtures.failure());
 
     expect.assertions(2);
 

--- a/packages/client/src/products/__fixtures__/getListing.fixtures.ts
+++ b/packages/client/src/products/__fixtures__/getListing.fixtures.ts
@@ -1,37 +1,18 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Listing, ListingQuery } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { Listing } from '../types';
+
+const path = '/api/commerce/v1/listing/*';
 
 /**
  * Response payloads.
  */
 export default {
-  get: {
-    success: (params: {
-      slug: string;
-      query?: ListingQuery;
-      response: Listing;
-    }): void => {
-      return moxios.stubRequest(
-        join('/api/commerce/v1/listing', params.slug, {
-          query: params.query,
-        }),
-        {
-          response: params.response,
-          status: 200,
-        },
-      );
-    },
-    failure: (params: { slug: string; query?: ListingQuery }): void => {
-      moxios.stubRequest(
-        join('/api/commerce/v1/listing', params.slug, {
-          query: params.query,
-        }),
-        {
-          response: 'stub error',
-          status: 404,
-        },
-      );
-    },
-  },
+  success: (response: Listing): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/products/__fixtures__/getProductAttributes.fixtures.ts
+++ b/packages/client/src/products/__fixtures__/getProductAttributes.fixtures.ts
@@ -1,27 +1,17 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
+import { rest, RestHandler } from 'msw';
 import type { ProductAttribute } from '../types';
 
+const path = '/api/commerce/v1/products/:id/attributes';
 /**
  * Response payloads.
  */
 export default {
-  success: (params: { id: number; response: ProductAttribute[] }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, 'attributes'),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { id: number }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, 'attributes'),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: ProductAttribute[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/products/__fixtures__/getProductColorGrouping.fixtures.ts
+++ b/packages/client/src/products/__fixtures__/getProductColorGrouping.fixtures.ts
@@ -1,35 +1,17 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { ColorGroupingQuery, ProductColorGrouping } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { ProductColorGrouping } from '../types';
 
+const path = '/api/commerce/v1/products/:id/colorgrouping';
 /**
  * Response payloads.
  */
 export default {
-  success: (params: {
-    id: number;
-    query?: ColorGroupingQuery;
-    response: ProductColorGrouping;
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, '/colorgrouping', {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { id: number; query?: ColorGroupingQuery }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, '/colorgrouping', {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: ProductColorGrouping): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/products/__fixtures__/getProductDetails.fixtures.ts
+++ b/packages/client/src/products/__fixtures__/getProductDetails.fixtures.ts
@@ -1,35 +1,17 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { FullProduct, ProductDetailsQuery } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { Product } from '../types';
 
+const path = '/api/commerce/v1/products/:id';
 /**
  * Response payloads.
  */
 export default {
-  success: (params: {
-    id: number;
-    query?: ProductDetailsQuery;
-    response: FullProduct;
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { id: number; query?: ProductDetailsQuery }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: Product): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/products/__fixtures__/getProductFittings.fixtures.ts
+++ b/packages/client/src/products/__fixtures__/getProductFittings.fixtures.ts
@@ -1,31 +1,18 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Product } from '../../products/types';
+import { rest, RestHandler } from 'msw';
 import type { ProductFitting } from '../types';
+
+const path = '/api/commerce/v1/products/:productId/fittings';
 
 /**
  * Response payloads.
  */
 export default {
-  success: (params: {
-    productId: Product['result']['id'];
-    response: ProductFitting[];
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.productId, 'fittings'),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { productId: Product['result']['id'] }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.productId, 'fittings'),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: ProductFitting[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/products/__fixtures__/getProductSizeGuides.fixtures.ts
+++ b/packages/client/src/products/__fixtures__/getProductSizeGuides.fixtures.ts
@@ -1,27 +1,18 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
+import { rest, RestHandler } from 'msw';
 import type { ProductSizeGuide } from '../types';
+
+const path = '/api/commerce/v1/products/:id/sizeguides';
 
 /**
  * Response payloads.
  */
 export default {
-  success: (params: { id: number; response: ProductSizeGuide[] }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, 'sizeguides'),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { id: number }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, 'sizeguides'),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: ProductSizeGuide[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/products/__fixtures__/getProductSizes.fixtures.ts
+++ b/packages/client/src/products/__fixtures__/getProductSizes.fixtures.ts
@@ -1,35 +1,17 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { ProductSizesQuery, Size } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { Size } from '../types';
 
+const path = '/api/commerce/v1/products/:id/sizes';
 /**
  * Response payloads.
  */
 export default {
-  success: (params: {
-    id: number;
-    query?: ProductSizesQuery;
-    response: Size[];
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, 'sizes', {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { id: number; query?: ProductSizesQuery }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, 'sizes', {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: Size[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/products/__fixtures__/getProductVariantsByMerchantsLocations.fixtures.ts
+++ b/packages/client/src/products/__fixtures__/getProductVariantsByMerchantsLocations.fixtures.ts
@@ -1,46 +1,18 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Product, ProductVariantByMerchantLocation } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { ProductVariantByMerchantLocation } from '../types';
 
+const path =
+  '/api/commerce/v1/products/:productId/variants/:variantId/merchantsLocations';
 /**
  * Response payloads.
  */
 export default {
-  success: (params: {
-    productId: Product['result']['id'];
-    variantId: string;
-    response: ProductVariantByMerchantLocation[];
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/products',
-        params.productId,
-        'variants',
-        params.variantId,
-        'merchantsLocations',
-      ),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: {
-    productId: Product['result']['id'];
-    variantId: string;
-  }): void => {
-    moxios.stubRequest(
-      join(
-        '/api/commerce/v1/products',
-        params.productId,
-        'variants',
-        params.variantId,
-        'merchantsLocations',
-      ),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: ProductVariantByMerchantLocation[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/products/__fixtures__/getProductVariantsMeasurements.fixtures.ts
+++ b/packages/client/src/products/__fixtures__/getProductVariantsMeasurements.fixtures.ts
@@ -1,30 +1,17 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
+import { rest, RestHandler } from 'msw';
 import type { ProductVariantMeasurement } from '../types';
 
+const path = '/api/commerce/v1/products/:id/variantsMeasurements';
 /**
  * Response payloads.
  */
 export default {
-  success: (params: {
-    id: number;
-    response: ProductVariantMeasurement[];
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, '/variantsMeasurements'),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { id: number }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/products', params.id, '/variantsMeasurements'),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: ProductVariantMeasurement[]): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/products/__fixtures__/getRecommendedSet.fixtures.ts
+++ b/packages/client/src/products/__fixtures__/getRecommendedSet.fixtures.ts
@@ -1,24 +1,18 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
+import { rest, RestHandler } from 'msw';
 import type { RecommendedSet } from '../types';
+
+const path = '/api/commerce/v1/recommendedsets/:id';
 
 /**
  * Response payloads.
  */
 export default {
-  success: (params: {
-    id: RecommendedSet['id'];
-    response: RecommendedSet;
-  }): void => {
-    moxios.stubRequest(join('/api/commerce/v1/recommendedsets', params.id), {
-      response: params.response,
-      status: 200,
-    });
-  },
-  failure: (params: { id: RecommendedSet['id'] }): void => {
-    moxios.stubRequest(join('/api/commerce/v1/recommendedsets', params.id), {
-      response: 'stub error',
-      status: 404,
-    });
-  },
+  success: (response: RecommendedSet): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/products/__fixtures__/getSet.fixtures.ts
+++ b/packages/client/src/products/__fixtures__/getSet.fixtures.ts
@@ -1,35 +1,18 @@
-import join from 'proper-url-join';
-import moxios from 'moxios';
-import type { Set, SetQuery } from '../types';
+import { rest, RestHandler } from 'msw';
+import type { Set } from '../types';
+
+const path = '/api/commerce/v1/sets/:slug';
 
 /**
  * Response payloads.
  */
 export default {
-  success: (params: {
-    slug: string | number;
-    query?: SetQuery;
-    response: Set;
-  }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/sets', params.slug, {
-        query: params.query,
-      }),
-      {
-        response: params.response,
-        status: 200,
-      },
-    );
-  },
-  failure: (params: { slug: string | number; query?: SetQuery }): void => {
-    moxios.stubRequest(
-      join('/api/commerce/v1/sets', params.slug, {
-        query: params.query,
-      }),
-      {
-        response: 'stub error',
-        status: 404,
-      },
-    );
-  },
+  success: (response: Set): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, async (req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
 };

--- a/packages/client/src/products/__tests__/__snapshots__/getListing.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getListing.test.ts.snap
@@ -1,9 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`listing client getListing should receive a client request error 1`] = `
+exports[`getListing should receive a client request error 1`] = `
 Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/products/__tests__/__snapshots__/getProductAttributes.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductAttributes.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/products/__tests__/__snapshots__/getProductColorGrouping.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductColorGrouping.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/products/__tests__/__snapshots__/getProductDetails.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductDetails.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/products/__tests__/__snapshots__/getProductFittings.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductFittings.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/products/__tests__/__snapshots__/getProductSizeGuides.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductSizeGuides.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/products/__tests__/__snapshots__/getProductSizes.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductSizes.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/products/__tests__/__snapshots__/getProductVariantsByMerchantsLocations.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductVariantsByMerchantsLocations.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/products/__tests__/__snapshots__/getProductVariantsMeasurements.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductVariantsMeasurements.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/products/__tests__/__snapshots__/getRecommendedSet.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getRecommendedSet.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/products/__tests__/__snapshots__/getSet.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getSet.test.ts.snap
@@ -5,5 +5,6 @@ Object {
   "code": -1,
   "message": "stub error",
   "status": 404,
+  "toJSON": [Function],
 }
 `;

--- a/packages/client/src/products/__tests__/getProductAttributes.test.ts
+++ b/packages/client/src/products/__tests__/getProductAttributes.test.ts
@@ -5,30 +5,24 @@ import {
 } from 'tests/__fixtures__/products';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getProductAttributes.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getProductAttributes', () => {
   const expectedConfig = undefined;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
     const response = mockProductAttributes;
 
-    fixtures.success({
-      id: mockProductId,
-      response,
-    });
+    mswServer.use(fixtures.success(response));
 
     expect.assertions(2);
 
-    await expect(getProductAttributes(mockProductId)).resolves.toBe(response);
+    await expect(getProductAttributes(mockProductId)).resolves.toEqual(
+      response,
+    );
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/products/${mockProductId}/attributes`,
       expectedConfig,
@@ -36,9 +30,10 @@ describe('getProductAttributes', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ id: mockProductId });
+    mswServer.use(fixtures.failure());
 
     expect.assertions(2);
+
     await expect(getProductAttributes(mockProductId)).rejects.toMatchSnapshot();
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/products/${mockProductId}/attributes`,

--- a/packages/client/src/products/__tests__/getProductColorGrouping.test.ts
+++ b/packages/client/src/products/__tests__/getProductColorGrouping.test.ts
@@ -5,32 +5,25 @@ import {
 } from 'tests/__fixtures__/products';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getProductColorGrouping.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getProductColorGrouping', () => {
   const expectedConfig = undefined;
   const query = { pageSize: 10 };
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
     const response = mockProductColorGrouping;
 
-    fixtures.success({
-      id: mockProductId,
-      query,
-      response,
-    });
+    mswServer.use(fixtures.success(response));
 
-    await expect(getProductColorGrouping(mockProductId, query)).resolves.toBe(
-      response,
-    );
+    expect.assertions(2);
+
+    await expect(
+      getProductColorGrouping(mockProductId, query),
+    ).resolves.toEqual(response);
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/products/${mockProductId}/colorgrouping?pageSize=10`,
       expectedConfig,
@@ -38,10 +31,9 @@ describe('getProductColorGrouping', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({
-      id: mockProductId,
-      query,
-    });
+    mswServer.use(fixtures.failure());
+
+    expect.assertions(2);
 
     await expect(
       getProductColorGrouping(mockProductId, query),

--- a/packages/client/src/products/__tests__/getProductDetails.test.ts
+++ b/packages/client/src/products/__tests__/getProductDetails.test.ts
@@ -2,30 +2,22 @@ import { getProductDetails } from '..';
 import { mockProductId, mockResponse } from 'tests/__fixtures__/products';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getProductDetails.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getProductDetails', () => {
   const expectedConfig = undefined;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    const response = mockResponse;
-
-    fixtures.success({
-      id: mockProductId,
-      response: mockResponse,
-    });
+    mswServer.use(fixtures.success(mockResponse));
 
     expect.assertions(2);
 
-    await expect(getProductDetails(mockProductId, {})).resolves.toBe(response);
+    await expect(getProductDetails(mockProductId, {})).resolves.toEqual(
+      mockResponse,
+    );
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/products/${mockProductId}`,
       expectedConfig,
@@ -33,9 +25,10 @@ describe('getProductDetails', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ id: mockProductId, query: {} });
+    mswServer.use(fixtures.failure());
 
     expect.assertions(2);
+
     await expect(
       getProductDetails(mockProductId, {}),
     ).rejects.toMatchSnapshot();

--- a/packages/client/src/products/__tests__/getProductFittings.test.ts
+++ b/packages/client/src/products/__tests__/getProductFittings.test.ts
@@ -5,30 +5,22 @@ import {
 } from 'tests/__fixtures__/products';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getProductFittings.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getProductFittings', () => {
   const expectedConfig = undefined;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    const response = mockProductFittings;
-
-    fixtures.success({
-      productId: mockProductId,
-      response,
-    });
+    mswServer.use(fixtures.success(mockProductFittings));
 
     expect.assertions(2);
 
-    await expect(getProductFittings(mockProductId)).resolves.toBe(response);
+    await expect(getProductFittings(mockProductId)).resolves.toEqual(
+      mockProductFittings,
+    );
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/products/${mockProductId}/fittings`,
       expectedConfig,
@@ -36,11 +28,10 @@ describe('getProductFittings', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({
-      productId: mockProductId,
-    });
+    mswServer.use(fixtures.failure());
 
     expect.assertions(2);
+
     await expect(getProductFittings(mockProductId)).rejects.toMatchSnapshot();
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/products/${mockProductId}/fittings`,

--- a/packages/client/src/products/__tests__/getProductSizeGuides.test.ts
+++ b/packages/client/src/products/__tests__/getProductSizeGuides.test.ts
@@ -1,31 +1,26 @@
 import { getProductSizeGuides } from '..';
-import { mockProductId, mockSizeGuides } from 'tests/__fixtures__/products';
+import {
+  mockProductId,
+  mockProductSizeGuides,
+} from 'tests/__fixtures__/products';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getProductSizeGuides.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getProductSizeGuides', () => {
   const expectedConfig = undefined;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    const response = mockSizeGuides;
-
-    fixtures.success({
-      id: mockProductId,
-      response,
-    });
+    mswServer.use(fixtures.success(mockProductSizeGuides));
 
     expect.assertions(2);
 
-    await expect(getProductSizeGuides(mockProductId)).resolves.toBe(response);
+    await expect(getProductSizeGuides(mockProductId)).resolves.toEqual(
+      mockProductSizeGuides,
+    );
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/products/${mockProductId}/sizeguides`,
       expectedConfig,
@@ -33,9 +28,10 @@ describe('getProductSizeGuides', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ id: mockProductId });
+    mswServer.use(fixtures.failure());
 
     expect.assertions(2);
+
     await expect(getProductSizeGuides(mockProductId)).rejects.toMatchSnapshot();
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/products/${mockProductId}/sizeguides`,

--- a/packages/client/src/products/__tests__/getProductSizes.test.ts
+++ b/packages/client/src/products/__tests__/getProductSizes.test.ts
@@ -2,7 +2,7 @@ import { getProductSizes } from '..';
 import { mockProductId, mockProductSizes } from 'tests/__fixtures__/products';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getProductSizes.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getProductSizes', () => {
   const expectedConfig = undefined;
@@ -11,25 +11,16 @@ describe('getProductSizes', () => {
   };
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    const response = mockProductSizes;
-
-    fixtures.success({
-      id: mockProductId,
-      query,
-      response,
-    });
+    mswServer.use(fixtures.success(mockProductSizes));
 
     expect.assertions(2);
 
-    await expect(getProductSizes(mockProductId, query)).resolves.toBe(response);
+    await expect(getProductSizes(mockProductId, query)).resolves.toEqual(
+      mockProductSizes,
+    );
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/products/${mockProductId}/sizes?includeOutOfStock=true`,
       expectedConfig,
@@ -37,9 +28,10 @@ describe('getProductSizes', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ id: mockProductId, query });
+    mswServer.use(fixtures.failure());
 
     expect.assertions(2);
+
     await expect(
       getProductSizes(mockProductId, query),
     ).rejects.toMatchSnapshot();

--- a/packages/client/src/products/__tests__/getProductVariantsByMerchantsLocations.test.ts
+++ b/packages/client/src/products/__tests__/getProductVariantsByMerchantsLocations.test.ts
@@ -1,38 +1,33 @@
 import { getProductVariantsByMerchantsLocations } from '..';
 import {
-  mockMerchantsLocations,
   mockProductId,
+  mockProductVariantsByMerchantsLocationsNormalizedResponse,
   mockVariantId,
 } from 'tests/__fixtures__/products';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getProductVariantsByMerchantsLocations.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getProductVariantsByMerchantsLocations', () => {
   const expectedConfig = undefined;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    const response = mockMerchantsLocations;
-
-    fixtures.success({
-      productId: mockProductId,
-      variantId: mockVariantId,
-      response,
-    });
+    mswServer.use(
+      fixtures.success(
+        mockProductVariantsByMerchantsLocationsNormalizedResponse,
+      ),
+    );
 
     expect.assertions(2);
 
     await expect(
       getProductVariantsByMerchantsLocations(mockProductId, mockVariantId),
-    ).resolves.toBe(response);
+    ).resolves.toEqual(
+      mockProductVariantsByMerchantsLocationsNormalizedResponse,
+    );
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/products/${mockProductId}/variants/${mockVariantId}/merchantsLocations`,
       expectedConfig,
@@ -40,12 +35,10 @@ describe('getProductVariantsByMerchantsLocations', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({
-      productId: mockProductId,
-      variantId: mockVariantId,
-    });
+    mswServer.use(fixtures.failure());
 
     expect.assertions(2);
+
     await expect(
       getProductVariantsByMerchantsLocations(mockProductId, mockVariantId),
     ).rejects.toMatchSnapshot();

--- a/packages/client/src/products/__tests__/getProductVariantsMeasurements.test.ts
+++ b/packages/client/src/products/__tests__/getProductVariantsMeasurements.test.ts
@@ -5,30 +5,22 @@ import {
 } from 'tests/__fixtures__/products';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getProductVariantsMeasurements.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getProductVariantsMeasurements', () => {
   const expectedConfig = undefined;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    const response = mockProductVariantsMeasurements;
+    mswServer.use(fixtures.success(mockProductVariantsMeasurements));
 
-    fixtures.success({
-      id: mockProductId,
-      response,
-    });
+    expect.assertions(2);
 
-    await expect(getProductVariantsMeasurements(mockProductId)).resolves.toBe(
-      response,
-    );
+    await expect(
+      getProductVariantsMeasurements(mockProductId),
+    ).resolves.toEqual(mockProductVariantsMeasurements);
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/products/${mockProductId}/variantsMeasurements`,
       expectedConfig,
@@ -36,9 +28,9 @@ describe('getProductVariantsMeasurements', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({
-      id: mockProductId,
-    });
+    mswServer.use(fixtures.failure());
+
+    expect.assertions(2);
 
     await expect(
       getProductVariantsMeasurements(mockProductId),

--- a/packages/client/src/products/__tests__/getRecommendedSet.test.ts
+++ b/packages/client/src/products/__tests__/getRecommendedSet.test.ts
@@ -5,31 +5,23 @@ import {
 } from 'tests/__fixtures__/products';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getRecommendedSet.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('recommended sets client', () => {
   const expectedConfig = undefined;
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   describe('getRecommendedSet()', () => {
     const spy = jest.spyOn(client, 'get');
 
     it('should handle a client request successfully', async () => {
-      const response = mockRecommendedSet;
+      mswServer.use(fixtures.success(mockRecommendedSet));
 
-      fixtures.success({
-        id: mockRecommendedSetId,
-        response,
-      });
+      expect.assertions(2);
 
-      await expect(getRecommendedSet(mockRecommendedSetId)).resolves.toBe(
-        response,
+      await expect(getRecommendedSet(mockRecommendedSetId)).resolves.toEqual(
+        mockRecommendedSet,
       );
       expect(spy).toHaveBeenCalledWith(
         `/commerce/v1/recommendedsets/${mockRecommendedSetId}`,
@@ -38,9 +30,9 @@ describe('recommended sets client', () => {
     });
 
     it('should receive a client request error', async () => {
-      fixtures.failure({
-        id: mockRecommendedSetId,
-      });
+      mswServer.use(fixtures.failure());
+
+      expect.assertions(2);
 
       await expect(
         getRecommendedSet(mockRecommendedSetId),

--- a/packages/client/src/products/__tests__/getSet.test.ts
+++ b/packages/client/src/products/__tests__/getSet.test.ts
@@ -2,30 +2,20 @@ import { getSet } from '..';
 import { mockSet, mockSetId } from 'tests/__fixtures__/products';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getSet.fixtures';
-import moxios from 'moxios';
+import mswServer from '../../../tests/mswServer';
 
 describe('getSet', () => {
   const expectedConfig = undefined;
   const spy = jest.spyOn(client, 'get');
 
-  beforeEach(() => {
-    moxios.install(client);
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => moxios.uninstall(client));
+  beforeEach(jest.clearAllMocks);
 
   it('should handle a client request successfully', async () => {
-    const response = mockSet;
-
-    fixtures.success({
-      slug: mockSetId,
-      response,
-    });
+    mswServer.use(fixtures.success(mockSet));
 
     expect.assertions(2);
 
-    await expect(getSet(mockSetId, {})).resolves.toBe(response);
+    await expect(getSet(mockSetId)).resolves.toEqual(mockSet);
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/sets/${mockSetId}`,
       expectedConfig,
@@ -33,12 +23,10 @@ describe('getSet', () => {
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({
-      slug: mockSetId,
-      query: {},
-    });
+    mswServer.use(fixtures.failure());
 
     expect.assertions(2);
+
     await expect(getSet(mockSetId, {})).rejects.toMatchSnapshot();
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/sets/${mockSetId}`,

--- a/tests/__fixtures__/products/recommendedSet.fixtures.ts
+++ b/tests/__fixtures__/products/recommendedSet.fixtures.ts
@@ -1,4 +1,4 @@
-import { mockProductId } from './products.fixtures';
+import { mockProductId } from './ids.fixtures';
 
 export const mockRecommendedSetId = 202382;
 


### PR DESCRIPTION
## Description

This replaces moxios with msw on products client tests.
It also modifies the bag client fixtures to use a standardized path.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->


Refs #18 


### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
