### PR TITLE
fix(react): truncate categories if the categories sent are greater than limit

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/eventMapping.js
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.js
@@ -73,7 +73,7 @@ const getProductCategories = productCategoryString => {
     return {};
   }
 
-  const productCategories = productCategoryString
+  let productCategories = productCategoryString
     .split('/')
     .filter(category => category);
 
@@ -81,6 +81,12 @@ const getProductCategories = productCategoryString => {
     utils.logger.warn(
       `[GA4] - Product category hierarchy exceeded maximum of ${MAX_PRODUCT_CATEGORIES}. GA4 only allows up to ${MAX_PRODUCT_CATEGORIES} levels.`,
     );
+
+    // Use the first and the last four categories
+    productCategories = [
+      productCategories[0],
+      ...productCategories.slice(-MAX_PRODUCT_CATEGORIES + 1),
+    ];
   }
 
   // GA4 only supports 5 level of categories


### PR DESCRIPTION
## Description

Previously, all product categories were being sent to GA4, 
even if the categories were above the limit of 5.
This changes that logic to truncate the categories if they exceed the limit
by getting the first category and the last 4 categories that were sent as
requested by Paul.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
