### PR TITLE
fix(react): truncate categories if the categories sent are greater than limit (next)

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.js
@@ -10,6 +10,7 @@ import {
 import {
   DEFAULT_DATA_LAYER_NAME,
   INIT_ERROR,
+  MAX_PRODUCT_CATEGORIES,
   MESSAGE_PREFIX,
   NON_INTERACTION_FLAG,
   OPTION_DATA_LAYER_NAME,
@@ -1221,6 +1222,51 @@ describe('GA4 Integration', () => {
             await ga4Instance.track(clonedEvent);
 
             expect(ga4Spy.mock.calls).toMatchSnapshot();
+          });
+        });
+
+        describe('Product categories max validation', () => {
+          fit(`Should display a warning and truncate the categories if the product categories exceed ${MAX_PRODUCT_CATEGORIES}`, async () => {
+            ga4Instance = createGA4InstanceAndLoad(validOptions, loadData);
+
+            const ga4Spy = getWindowGa4Spy();
+
+            const clonedEvent = cloneDeep(
+              trackEventsData[eventTypes.PRODUCT_ADDED_TO_CART],
+            );
+
+            clonedEvent.properties.category =
+              'Category_1/Category_2/Category_3/Category_4/Category_5/Category_6';
+
+            // Make sure our dummy categories exceed the max length
+            expect(
+              clonedEvent.properties.category.split('/').length,
+            ).toBeGreaterThan(MAX_PRODUCT_CATEGORIES);
+
+            // We want the first + last 4 categories
+            const expectedCategories = {
+              item_category: 'Category_1',
+              item_category2: 'Category_3',
+              item_category3: 'Category_4',
+              item_category4: 'Category_5',
+              item_category5: 'Category_6',
+            };
+
+            await ga4Instance.track(clonedEvent);
+
+            expect(utils.logger.warn).toHaveBeenCalledWith(
+              '[GA4] - Product category hierarchy exceeded maximum of 5. GA4 only allows up to 5 levels.',
+            );
+
+            const eventPropertiesSentGa4 = ga4Spy.mock.calls[0].pop();
+
+            expect(eventPropertiesSentGa4).toEqual(
+              expect.objectContaining({
+                items: expect.arrayContaining([
+                  expect.objectContaining(expectedCategories),
+                ]),
+              }),
+            );
           });
         });
       });

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.js
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.js
@@ -69,7 +69,7 @@ const getProductCategories = productCategoryString => {
     return {};
   }
 
-  const productCategories = productCategoryString
+  let productCategories = productCategoryString
     .split('/')
     .filter(category => category);
 
@@ -77,6 +77,12 @@ const getProductCategories = productCategoryString => {
     utils.logger.warn(
       `[GA4] - Product category hierarchy exceeded maximum of ${MAX_PRODUCT_CATEGORIES}. GA4 only allows up to ${MAX_PRODUCT_CATEGORIES} levels.`,
     );
+
+    // Use the first and the last four categories
+    productCategories = [
+      productCategories[0],
+      ...productCategories.slice(-MAX_PRODUCT_CATEGORIES + 1),
+    ];
   }
 
   // GA4 only supports 5 level of categories


### PR DESCRIPTION
## Description

Previously, all product categories were being sent to GA4,
even if the categories were above the limit of 5.
This changes that logic to truncate the categories, if they exceed the limit
by getting the first category and the last 4 categories that were sent as
requested by Paul.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
