### PR TITLE
fix(redux): fix getWishlistSetItemsCounter

### DIFF
--- a/packages/redux/src/wishlists/selectors/__tests__/wishlistsSets.test.ts
+++ b/packages/redux/src/wishlists/selectors/__tests__/wishlistsSets.test.ts
@@ -239,6 +239,12 @@ describe('wishlists redux selectors', () => {
         ),
       ).toBe(0);
     });
+
+    it('should return 0 when setId is undefined', () => {
+      expect(
+        selectors.getWishlistSetItemsCounter(mockWishlistState, undefined),
+      ).toBe(0);
+    });
   });
 
   describe('getWishlistSetTotalQuantity()', () => {

--- a/packages/redux/src/wishlists/selectors/wishlistsSets.ts
+++ b/packages/redux/src/wishlists/selectors/wishlistsSets.ts
@@ -254,7 +254,7 @@ export const getWishlistSetItemsCounter = (
     setId,
   ) as WishlistSetEntity;
 
-  if (!wishlistSet || wishlistSet.wishlistSetItems.length === 0) {
+  if (!setId || !wishlistSet || wishlistSet.wishlistSetItems.length === 0) {
     return 0;
   }
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

This PR fixes getWishlistSetItemsCounter when
the setId is undefined

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
