### PR TITLE
fix(redux): fix fetchWishlistSetFactory

### DIFF
--- a/packages/redux/src/wishlists/actions/factories/fetchWishlistSetFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/fetchWishlistSetFactory.ts
@@ -39,6 +39,10 @@ const fetchWishlistSetFactory =
     const state = getState();
     const wishlistId = getWishlistId(state);
 
+    if (!wishlistSetId) {
+      throw new Error('No wishlist set id is set');
+    }
+
     if (!wishlistId) {
       throw new Error('No wishlist id is set');
     }


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

The fetchWishlistSetFactory method was not throwing an error when
the wishlistSetId was undefined.
This PR adds a new error throwing an error when there is
no wishlistSetId

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
