### PR TITLE
feat(react): move `handleAddOrUpdateItem` method to new hook

### DIFF
--- a/packages/client/src/helpers/adapters/types/adaptCustomAttributes.types.ts
+++ b/packages/client/src/helpers/adapters/types/adaptCustomAttributes.types.ts
@@ -1,4 +1,4 @@
-export type CustomAttributesAdapted = Record<string, string> | string | null;
+export type CustomAttributesAdapted = unknown | null;
 
 export type AdaptCustomAttributes = (
   attributes: string,

--- a/packages/react/src/bags/hooks/__tests__/useAddOrUpdateBagItem.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useAddOrUpdateBagItem.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup } from '@testing-library/react';
+import { getBagItems } from '@farfetch/blackout-redux/bags';
+import { mockBagItem, mockInitialState } from 'tests/__fixtures__/bags';
+import { mockStore } from '../../../../tests/helpers';
+import { Provider } from 'react-redux';
+import { renderHook } from '@testing-library/react-hooks';
+import { useAddOrUpdateBagItem } from '../..';
+import React from 'react';
+
+jest.mock('@farfetch/blackout-redux/bags', () => ({
+  ...jest.requireActual('@farfetch/blackout-redux/bags'),
+  addBagItem: jest.fn(() => ({ type: 'add' })),
+  updateBagItem: jest.fn(() => ({ type: 'update' })),
+  getBagItems: jest.fn(() => [mockBagItem]),
+}));
+
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+const getRenderedHook = (state = mockInitialState) => {
+  const {
+    result: { current },
+  } = renderHook(() => useAddOrUpdateBagItem(mockBagItem), {
+    wrapper: props => <Provider store={mockStore(state)} {...props} />,
+  });
+
+  return current;
+};
+
+describe('useAddOrUpdateBagItem', () => {
+  beforeEach(jest.clearAllMocks);
+  afterEach(cleanup);
+
+  it('should return values correctly with initial state', () => {
+    const current = getRenderedHook();
+
+    expect(current).toStrictEqual(expect.any(Function));
+  });
+
+  describe('handleAddOrUpdateItem', () => {
+    it('should call handleAddOrUpdateItem and add item', async () => {
+      getBagItems.mockImplementationOnce(() => []);
+      const handleAddOrUpdateItem = getRenderedHook();
+
+      await handleAddOrUpdateItem(mockBagItem);
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'add' });
+    });
+
+    it('should call handleAddOrUpdateItem and update item', async () => {
+      const handleAddOrUpdateItem = getRenderedHook();
+
+      await handleAddOrUpdateItem({ ...mockBagItem, quantity: 6 });
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'update' });
+    });
+
+    it('should update and then add when current merchant has less stock than new quantity', async () => {
+      // Mock bag item has quantity 5
+      // The respective merchants have 7 and 5 available
+      const handleAddOrUpdateItem = getRenderedHook();
+
+      await handleAddOrUpdateItem({
+        quantity: 9,
+        size: {
+          ...mockBagItem.size,
+          stock: [
+            ...mockBagItem.size.stock,
+            {
+              merchantId: 213,
+              quantity: 5,
+            },
+          ],
+        },
+      });
+
+      expect(mockDispatch).toHaveBeenCalledTimes(2);
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'update' });
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'add' });
+    });
+  });
+});

--- a/packages/react/src/bags/hooks/__tests__/useBagItem.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useBagItem.test.tsx
@@ -50,7 +50,6 @@ describe('useBagItem', () => {
       bagItem: expect.any(Object),
       deleteBagItem: expect.any(Function),
       error: undefined,
-      handleAddOrUpdateItem: expect.any(Function),
       handleDeleteBagItem: expect.any(Function),
       handleFullUpdate: expect.any(Function),
       handleQuantityChange: expect.any(Function),
@@ -99,20 +98,6 @@ describe('useBagItem', () => {
       updateBagItem(mockBagItemId, mockData);
 
       expect(mockDispatch).toHaveBeenCalledWith({ type: 'update' });
-    });
-  });
-
-  describe('handleAddOrUpdateItem', () => {
-    it('should call handleAddOrUpdateItem', async () => {
-      const { handleAddOrUpdateItem } = getRenderedHook();
-
-      await handleAddOrUpdateItem({});
-
-      // This ensures `handleAddOrUpdateItem` is correctly working. It's logic is
-      // already extensively tested within `handleQuantityChange` and `handleSizeChange`
-      expect(mockDispatch).toHaveBeenCalledTimes(2);
-      expect(mockDispatch).toHaveBeenCalledWith({ type: 'update' });
-      expect(mockDispatch).toHaveBeenCalledWith({ type: 'add' });
     });
   });
 

--- a/packages/react/src/bags/hooks/index.ts
+++ b/packages/react/src/bags/hooks/index.ts
@@ -6,5 +6,6 @@
  * @subcategory Hooks
  */
 
+export { default as useAddOrUpdateBagItem } from './useAddOrUpdateBagItem';
 export { default as useBagItem } from './useBagItem';
 export { default as useBag } from './useBag';

--- a/packages/react/src/bags/hooks/types/index.ts
+++ b/packages/react/src/bags/hooks/types/index.ts
@@ -1,2 +1,3 @@
+export * from './useAddOrUpdateBagItem';
 export * from './useBagItem';
 export * from './useBag';

--- a/packages/react/src/bags/hooks/types/useAddOrUpdateBagItem.ts
+++ b/packages/react/src/bags/hooks/types/useAddOrUpdateBagItem.ts
@@ -1,0 +1,31 @@
+import type {
+  BagItemHydrated,
+  ProductEntity,
+} from '@farfetch/blackout-redux/entities/types';
+import type {
+  CustomAttributesAdapted,
+  SizeAdapted,
+} from '@farfetch/blackout-client/helpers/adapters/types';
+
+export type HandleAddOrUpdateItem = ({
+  customAttributes,
+  from,
+  product,
+  productAggregatorId,
+  quantity,
+  size,
+}: {
+  customAttributes?: CustomAttributesAdapted;
+  from?: string;
+  product?: ProductEntity;
+  productAggregatorId?: Exclude<
+    BagItemHydrated['productAggregator'],
+    null
+  >['id'];
+  quantity?: number;
+  size?: SizeAdapted;
+}) => Promise<void>;
+
+export type UseAddOrUpdateBagItem = (
+  bagItem?: BagItemHydrated,
+) => HandleAddOrUpdateItem;

--- a/packages/react/src/bags/hooks/types/useBagItem.ts
+++ b/packages/react/src/bags/hooks/types/useBagItem.ts
@@ -4,34 +4,9 @@ import type {
   PostBagItemData,
   Query,
 } from '@farfetch/blackout-client/bags/types';
-import type {
-  BagItemHydrated,
-  ProductEntity,
-} from '@farfetch/blackout-redux/entities/types';
-import type {
-  CustomAttributesAdapted,
-  SizeAdapted,
-} from '@farfetch/blackout-client/helpers/adapters/types';
+import type { BagItemHydrated } from '@farfetch/blackout-redux/entities/types';
 import type { Error } from '@farfetch/blackout-client/types';
 
-export type HandleAddOrUpdateItemType = ({
-  customAttributes,
-  product,
-  productAggregatorId,
-  quantity,
-  size,
-  from,
-}: {
-  customAttributes?: CustomAttributesAdapted;
-  product?: ProductEntity;
-  productAggregatorId?: Exclude<
-    BagItemHydrated['productAggregator'],
-    null
-  >['id'];
-  quantity?: number;
-  size?: SizeAdapted | undefined;
-  from?: string;
-}) => Promise<void>;
 export type HandleQuantityChangeType = (
   newQuantity: number,
   from?: string,
@@ -68,7 +43,6 @@ export type UseBagItem = (
   bagItem: BagItemHydrated;
   error: Error | null | undefined;
   isLoading: boolean | undefined;
-  handleAddOrUpdateItem: HandleAddOrUpdateItemType;
   handleQuantityChange: HandleQuantityChangeType;
   handleSizeChange: HandleSizeChangeType;
   handleFullUpdate: HandleFullUpdateType;

--- a/packages/react/src/bags/hooks/useAddOrUpdateBagItem.ts
+++ b/packages/react/src/bags/hooks/useAddOrUpdateBagItem.ts
@@ -1,0 +1,149 @@
+/**
+ * Hook to provide all kinds of data for the business logic attached to the
+ * actions of adding or updating an item to the bag.
+ *
+ * @module useAddOrUpdateItem
+ * @category Bags
+ * @subcategory Hooks
+ */
+import {
+  addBagItem as addBagItemAction,
+  getBagItems,
+  updateBagItem as updateBagItemAction,
+} from '@farfetch/blackout-redux/bags';
+import {
+  buildBagItem,
+  generateBagItemHash,
+} from '@farfetch/blackout-redux/bags/utils';
+import { shallowEqual, useSelector } from 'react-redux';
+import { useAction } from '../../helpers';
+import type { HandleAddOrUpdateItem, UseAddOrUpdateBagItem } from './types';
+
+/**
+ * Provides handler for adding or updating a bag item.
+ *
+ * @memberof module:bags/hooks
+ *
+ * @param {number} [bagItem] - Bag item to work on.
+ *
+ * @returns {Function} Handle to manage bag item related operations.
+ */
+const useAddOrUpdateBagItem: UseAddOrUpdateBagItem = bagItem => {
+  // Selectors
+  const bagItems = useSelector(getBagItems, shallowEqual);
+  // Actions
+  const addBagItem = useAction(addBagItemAction);
+  const updateBagItem = useAction(updateBagItemAction);
+  const productSize = bagItem?.product?.sizes?.find(
+    size => size.id === bagItem?.size?.id,
+  );
+
+  /**
+   * Automatically manages the merchant available, according to its stock,
+   * to be used in both "add" and "update" operations. It starts with the
+   * preferred merchant, skips to the next when the previous runs out of
+   * stock, and so on.
+   * <br />
+   * This is useful for when the operation is done outside the bag, for
+   * example, on the "move to bag" from the wishlist.
+   * <br />
+   * <br />
+   * <i><small>This operation is over the bag item that instantiated the hook by
+   * default.</small></i>.
+   *
+   * @param {object} [item] - Item to add/update the bag with.
+   * @param {string} [item.customAttributes=bagItem.customAttributes] - Custom attributes
+   * of the bag item to handle.
+   * @param {string} [item.from] - Provenience of action.
+   * @param {object} [item.product=bagItem.product] - Product of the bag item
+   * to handle. Defaults to the product of the bag item that instantiated the
+   * hook.
+   * @param {number} [item.productAggregatorId = bagItem.productAggregator.id] - Product
+   * aggregator id that represents the bundle variant that owns it.
+   * @param {number} [item.quantity=bagItem.quantity] - Quantity of the
+   * product to add/update. Defaults to the quantity of the bag item that
+   * instantiated the hook or 1 when adding an item for the first time.
+   * @param {object} [item.size=productSize] - Size of the product to
+   * add/update. Defaults to the size of the bag item that instantiated the
+   * hook.
+   */
+  const handleAddOrUpdateItem: HandleAddOrUpdateItem = async ({
+    customAttributes = bagItem?.customAttributes,
+    from,
+    product = bagItem?.product,
+    productAggregatorId = bagItem?.productAggregator?.id,
+    quantity = bagItem?.quantity || 1,
+    size = productSize,
+    ...otherParams
+  }) => {
+    let quantityToHandle = quantity;
+
+    if (!size?.stock || !product) {
+      return;
+    }
+
+    // Iterate through the stock of different merchants
+    for (const { merchantId, quantity: merchantQuantity } of size.stock) {
+      // If there is no quantity on this merchant jump to the next one
+      if (merchantQuantity === 0) {
+        continue;
+      }
+
+      // The quantity we want to add might be limited by the merchant stock
+      const quantityToAdd = Math.min(quantityToHandle, merchantQuantity);
+      // Format the data to send to the request
+      const requestData = buildBagItem({
+        customAttributes,
+        merchantId,
+        product,
+        productAggregatorId,
+        quantity: quantityToAdd,
+        size,
+        ...otherParams,
+      });
+      // Checks if the item we want to add is already in bag
+      // by comparing the bag items' hash
+      const hash = generateBagItemHash(requestData);
+      const itemInBag = bagItems?.find(
+        item => generateBagItemHash(item) === hash,
+      );
+
+      // When the item is in bag, we update its quantity
+      if (itemInBag) {
+        const newQuantity = quantityToAdd + itemInBag.quantity;
+
+        // Check if our quantity to update fits on the current merchant's stock
+        // and if not, try adding less
+        for (let i = newQuantity; i > itemInBag.quantity; i--) {
+          if (i <= merchantQuantity) {
+            await updateBagItem(itemInBag.id, {
+              ...requestData,
+              quantity: i,
+              oldQuantity: itemInBag.quantity,
+              oldSize: itemInBag.size,
+            });
+
+            // Now we have less quantity to add to the next merchant
+            quantityToHandle -= i - itemInBag.quantity;
+            break;
+          }
+        }
+      } else {
+        // When the item is not in the bag, we add it
+        await addBagItem(requestData);
+
+        // Now we have less quantity to add to the next merchant
+        quantityToHandle -= quantityToAdd;
+      }
+
+      // If there's no more quantity to add, we have finished
+      if (quantityToHandle === 0) {
+        return;
+      }
+    }
+  };
+
+  return handleAddOrUpdateItem;
+};
+
+export default useAddOrUpdateBagItem;

--- a/packages/react/src/bags/hooks/useBagItem.ts
+++ b/packages/react/src/bags/hooks/useBagItem.ts
@@ -10,19 +10,15 @@ import {
   addBagItem as addBagItemAction,
   getBagItem,
   getBagItemError,
-  getBagItems,
   isBagItemLoading,
   removeBagItem as removeBagItemAction,
   updateBagItem as updateBagItemAction,
 } from '@farfetch/blackout-redux/bags';
-import {
-  buildBagItem,
-  generateBagItemHash,
-} from '@farfetch/blackout-redux/bags/utils';
-import { shallowEqual, useSelector } from 'react-redux';
+import { buildBagItem } from '@farfetch/blackout-redux/bags/utils';
 import { useAction } from '../../helpers';
+import { useSelector } from 'react-redux';
+import useAddOrUpdateBagItem from './useAddOrUpdateBagItem';
 import type {
-  HandleAddOrUpdateItemType,
   HandleDeleteBagItemType,
   HandleFullUpdateType,
   HandleQuantityChangeType,
@@ -30,7 +26,7 @@ import type {
   UseBagItem,
 } from './types';
 import type { SizeAdapted } from '@farfetch/blackout-client/helpers/adapters/types';
-import type { StoreState } from '@farfetch/blackout-redux/src/types';
+import type { StoreState } from '@farfetch/blackout-redux/types';
 
 /**
  * Provides Redux actions and state access, as well as handlers for dealing with
@@ -38,138 +34,28 @@ import type { StoreState } from '@farfetch/blackout-redux/src/types';
  *
  * @memberof module:bags/hooks
  *
- * @param {number} [bagItemId] - Bag item id to work on. Optional only if you need
- * to use the `handleAddOrUpdateItem` method. For more information and/or future plans
- * check the [respective issue](https://github.com/Farfetch/blackout/issues/16).
+ * @param {number} [bagItemId] - Bag item id to work on.
  *
  * @returns {object} All the handlers, state, actions and relevant data needed
  * to manage any bag item or product bag-related operation.
  */
 const useBagItem: UseBagItem = bagItemId => {
+  // Selectors
   const bagItem = useSelector((state: StoreState) =>
     getBagItem(state, bagItemId),
   );
-  const bagItems = useSelector(getBagItems, shallowEqual);
   const error = useSelector((state: StoreState) =>
     getBagItemError(state, bagItemId),
   );
   const isLoading = useSelector((state: StoreState) =>
     isBagItemLoading(state, bagItemId),
   );
-  const productSize = bagItem?.product?.sizes?.find(
-    size => size.id === bagItem?.size?.id,
-  );
 
   // Actions
   const addBagItem = useAction(addBagItemAction);
   const deleteBagItem = useAction(removeBagItemAction);
   const updateBagItem = useAction(updateBagItemAction);
-
-  /**
-   * Automatically manages the merchant available, according to its stock,
-   * to be used in both "add" and "update" operations. It starts with the
-   * preferred merchant, skips to the next when the previous runs out of
-   * stock, and so on.
-   * <br />
-   * This is useful for when the operation is done outside the bag, for
-   * example, on the "move to bag" from the wishlist or when adding to the bag
-   * on a listing or PDP.
-   * <br />
-   * <br />
-   * <i><small>This operation is over the bag item that instantiated the hook by
-   * default.</small></i>.
-   *
-   * @function handleAddOrUpdateItem
-   *
-   * @param {object} [item] - Item to add/update the bag with.
-   * @param {string} [item.customAttributes=''] - Bag item custom attributes.
-   * @param {object} [item.product=bagItem.product] - Product of the bag item
-   * to handle. Defaults to the product of the bag item that instantiated the
-   * hook.
-   * @param {number} [item.productAggregatorId=bagItem.productAggregator.id] -
-   * Product aggregator identifier.
-   * @param {number} [item.quantity=bagItem.quantity] - Quantity of the
-   * product to add/update. Defaults to the quantity of the bag item that
-   * instantiated the hook.
-   * @param {object} [item.size=productSize] - Size of the product to
-   * add/update. Defaults to the size of the bag item that instantiated the
-   * hook.
-   * @param {string} [item.from] - Provenience of action.
-   */
-  const handleAddOrUpdateItem: HandleAddOrUpdateItemType = async ({
-    customAttributes = bagItem?.customAttributes,
-    product = bagItem?.product,
-    productAggregatorId = bagItem?.productAggregator?.id,
-    quantity = bagItem?.quantity,
-    size = productSize,
-    ...otherParams
-  }) => {
-    let quantityToHandle = quantity;
-
-    if (!size?.stock || !product) {
-      return;
-    }
-
-    // Iterate through the stock of different merchants
-    for (const { merchantId, quantity: merchantQuantity } of size.stock) {
-      // If there is no quantity on this merchant jump to the next one
-      if (merchantQuantity === 0) {
-        continue;
-      }
-
-      // The quantity we want to add might be limited by the merchant stock
-      const quantityToAdd = Math.min(quantityToHandle, merchantQuantity);
-      // Format the data to send to the request
-      const requestData = buildBagItem({
-        customAttributes,
-        merchantId,
-        product,
-        productAggregatorId,
-        quantity: quantityToAdd,
-        size,
-        ...otherParams,
-      });
-      // Checks if the item we want to add is already in bag
-      // by comparing the bag items' hash
-      const hash = generateBagItemHash(requestData);
-      const itemInBag =
-        bagItems && bagItems.find(item => generateBagItemHash(item) === hash);
-
-      // When the item is in bag, we update its quantity
-      if (itemInBag) {
-        const newQuantity = quantityToAdd + itemInBag.quantity;
-
-        // Check if our quantity to update fits on the current merchant's stock
-        // and if not, try adding less
-        for (let i = newQuantity; i > itemInBag.quantity; i--) {
-          if (i <= merchantQuantity) {
-            await updateBagItem(itemInBag.id, {
-              ...requestData,
-              quantity: i,
-              oldQuantity: itemInBag.quantity,
-              oldSize: itemInBag.size,
-            });
-
-            // Now we have less quantity to add to the next merchant
-            quantityToHandle -= i - itemInBag.quantity;
-            break;
-          }
-        }
-      } else {
-        // When the item is not in the bag, we add it
-        await addBagItem(requestData);
-
-        // Now we have less quantity to add to the next merchant
-        quantityToHandle -= quantityToAdd;
-      }
-
-      // If there's no more quantity to add, we have finished
-      if (quantityToHandle === 0) {
-        return;
-      }
-    }
-  };
-
+  const handleAddOrUpdateItem = useAddOrUpdateBagItem(bagItem);
   /**
    * Handles the quantity update of a bag item. If the quantity to
    * update is bigger than the stock of the current merchant, it'll be
@@ -211,7 +97,10 @@ const useBagItem: UseBagItem = bagItemId => {
 
     const quantityToAdd = quantityToHandle - bagItem.quantity;
 
-    handleAddOrUpdateItem({ quantity: quantityToAdd, from });
+    handleAddOrUpdateItem({
+      from,
+      quantity: quantityToAdd,
+    });
   };
 
   /**
@@ -431,13 +320,6 @@ const useBagItem: UseBagItem = bagItemId => {
      * @type {boolean}
      */
     isLoading,
-    /**
-     * @type {Function}
-     * @variation Member
-     *
-     * @see {@link module:useBagItem~handleAddOrUpdateItem|handleAddOrUpdateItem} method
-     */
-    handleAddOrUpdateItem,
     /**
      * @type {Function}
      * @variation Member

--- a/packages/redux/src/entities/types/bagItem.types.ts
+++ b/packages/redux/src/entities/types/bagItem.types.ts
@@ -1,9 +1,9 @@
+import type { BagItem } from '@farfetch/blackout-client/bags/types';
 import type {
-  AttributesAdapted,
   CustomAttributesAdapted,
   PriceAdapted,
+  SizeAdapted,
 } from '@farfetch/blackout-client/helpers/adapters/types';
-import type { BagItem } from '@farfetch/blackout-client/bags/types';
 import type { MerchantEntity } from './merchant.types';
 import type { ProductEntity } from './product.types';
 
@@ -35,7 +35,7 @@ export type BagItemEntity = Omit<
   merchant: MerchantEntity['id'];
   price: PriceAdapted;
   product: ProductEntity['id'];
-  size: AttributesAdapted;
+  size: SizeAdapted;
 };
 
 export type BagItemHydrated = Omit<BagItemEntity, 'product'> & {

--- a/tests/__fixtures__/bags/bagItem.fixtures.ts
+++ b/tests/__fixtures__/bags/bagItem.fixtures.ts
@@ -4,15 +4,21 @@ export const mockBagItemId = 134;
 export const mockProductAggregatorId = 321;
 
 export const mockBagItem = {
+  customAttributes: { a: '1', b: '2', c: '3' },
   id: mockBagItemId,
-  customAttributes: { a: 1, b: 2, c: { d: 3 } },
-  quantity: 5,
-  merchantId: mockMerchantId,
+  isAvailable: true,
   merchant: mockMerchantId,
+  merchantId: mockMerchantId,
+  product: mockProduct,
+  productAggregator: {
+    bundleSlug: '/slug',
+    id: mockProductAggregatorId,
+  },
+  quantity: 5,
   size: {
     id: 23,
-    scale: 'IT',
     name: '11',
+    scale: 'IT',
     stock: [
       {
         merchantId: mockMerchantId,
@@ -21,12 +27,6 @@ export const mockBagItem = {
     ],
   },
   sizeId: 23,
-  isAvailable: true,
-  product: mockProduct,
-  productAggregator: {
-    bundleSlug: '/slug',
-    id: mockProductAggregatorId,
-  },
 };
 
 export const mockBagItemEntity = {
@@ -35,7 +35,7 @@ export const mockBagItemEntity = {
 };
 
 export const mockIdenticalBagItem = {
-  customAttributes: { a: 1, b: 2, c: { d: 3 } },
+  customAttributes: { a: '1', b: '2', c: '3' },
   id: 5,
   product: {
     id: mockProductId,

--- a/tests/__fixtures__/products/products.fixtures.ts
+++ b/tests/__fixtures__/products/products.fixtures.ts
@@ -115,23 +115,22 @@ export const mockSet = {
 };
 
 export const mockProduct = {
-  merchant: mockMerchantId,
-  price: mockPriceAdapted,
-  sizes: mockProductSizesAdapted,
-  tag: mockTag,
-  id: mockProductId,
-  shortDescription: 'Chuck 70 U-Throat Ballet sneakers',
+  associationsInformation: {
+    hasColorGrouping: true,
+  },
+  attributes: mockProductAttributes,
   brand: mockBrandId,
-  slug: 'chuck-70-u-throat-ballet-sneakers-12913174',
-  quantity: 7,
-  promotions: mockPromotions,
+  breadCrumbs: mockBreadCrumbs,
+  colorGrouping: mockProductColorGrouping,
+  fittings: mockProductFittings,
+  id: mockProductId,
+  isDuplicated: false,
   labels: mockLabels,
   measurements: mockProductVariantsMeasurements,
-  colorGrouping: mockProductColorGrouping,
-  attributes: mockProductAttributes,
-  variants: mockProductVariants,
-  fittings: mockProductFittings,
-  sizeGuides: mockProductSizeGuides,
+  merchant: mockMerchantId,
+  price: mockPriceAdapted,
+  promotions: mockPromotions,
+  quantity: 7,
   recommendedSet: mockSetId,
   relatedSets: [
     {
@@ -144,9 +143,10 @@ export const mockProduct = {
     },
   ],
   scaleId: mockSizeScaleId,
-  breadCrumbs: mockBreadCrumbs,
-  isDuplicated: false,
-  associationsInformation: {
-    hasColorGrouping: true,
-  },
+  shortDescription: 'Chuck 70 U-Throat Ballet sneakers',
+  sizeGuides: mockProductSizeGuides,
+  sizes: mockProductSizesAdapted,
+  slug: 'chuck-70-u-throat-ballet-sneakers-12913174',
+  tag: mockTag,
+  variants: mockProductVariants,
 };


### PR DESCRIPTION
## Description

BREAKING CHANGE: This moves the method `handleAddOrUpdateItem` to a new hook `useAddOrUpdateBagItem`. The new hook is necessary since we are using selector and actions outside a React component.

To adapt this breaking change, we need to update all instances of:

```
const { handleAddOrUpdateItem } = useBagItem();
```

to

```
const handleAddOrUpdateItem = useAddOrUpdateBagItem();
```

Closes #16

It also changes the type of `customAttributes` to `unknown` because this is in fact an unknown value that depends on the implementation of each experience.


### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
