### PR TITLE
feat(react): add useWishlistSet hook

### DIFF
--- a/packages/react/src/wishlists/hooks/__tests__/useWishlistSet.test.tsx
+++ b/packages/react/src/wishlists/hooks/__tests__/useWishlistSet.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup } from '@testing-library/react';
+import { mockStore } from '../../../../tests/helpers';
+import {
+  mockWishlistSetId,
+  mockWishlistSetPatchData,
+  mockWishlistState,
+} from 'tests/__fixtures__/wishlists';
+import { Provider } from 'react-redux';
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import useWishlistSet from '../useWishlistSet';
+
+jest.mock('@farfetch/blackout-redux/wishlists', () => ({
+  ...jest.requireActual('@farfetch/blackout-redux/wishlists'),
+  removeWishlistSet: jest.fn(() => ({ type: 'remove' })),
+  updateWishlistSet: jest.fn(() => ({ type: 'update' })),
+}));
+
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+const getRenderedHook = (state = mockWishlistState) => {
+  const {
+    result: { current },
+  } = renderHook(() => useWishlistSet(mockWishlistSetId), {
+    wrapper: props => <Provider store={mockStore(state)} {...props} />,
+  });
+
+  return current;
+};
+
+describe('useWishlistSet', () => {
+  beforeEach(jest.clearAllMocks);
+  afterEach(cleanup);
+
+  it('should return values correctly with initial state', () => {
+    const current = getRenderedHook();
+
+    expect(current).toStrictEqual({
+      removeWishlistSet: expect.any(Function),
+      error: expect.any(Object),
+      isFetched: expect.any(Boolean),
+      isLoading: expect.any(Boolean),
+      itemsCounter: expect.any(Number),
+      totalQuantity: expect.any(Number),
+      updateWishlistSet: expect.any(Function),
+      wishlistSet: expect.any(Object),
+    });
+  });
+
+  it('should render in error state', () => {
+    const mockError = { message: 'This is an error message' };
+    const { error } = getRenderedHook({
+      ...mockWishlistState,
+      wishlist: {
+        ...mockWishlistState.wishlist,
+        sets: {
+          ...mockWishlistState.wishlist.sets,
+          set: {
+            ...mockWishlistState.wishlist.sets.set,
+            error: {
+              [mockWishlistSetId]: mockError,
+            },
+          },
+        },
+      },
+    });
+
+    expect(error).toEqual(mockError);
+  });
+
+  describe('actions', () => {
+    it('should call `removeWishlistSet` action', () => {
+      const { removeWishlistSet } = getRenderedHook();
+
+      removeWishlistSet(mockWishlistSetId);
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'remove' });
+    });
+
+    it('should call `updateWishlistSet` action', () => {
+      const { updateWishlistSet } = getRenderedHook();
+
+      updateWishlistSet(mockWishlistSetId, mockWishlistSetPatchData);
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'update' });
+    });
+  });
+});

--- a/packages/react/src/wishlists/hooks/index.ts
+++ b/packages/react/src/wishlists/hooks/index.ts
@@ -7,5 +7,6 @@
  */
 
 export { default as useWishlist } from './useWishlist';
-export { default as useWishlistSets } from './useWishlistSets';
 export { default as useWishlistItem } from './useWishlistItem';
+export { default as useWishlistSet } from './useWishlistSet';
+export { default as useWishlistSets } from './useWishlistSets';

--- a/packages/react/src/wishlists/hooks/types/index.ts
+++ b/packages/react/src/wishlists/hooks/types/index.ts
@@ -1,3 +1,4 @@
 export * from './useWishlist';
-export * from './useWishlistSets';
 export * from './useWishlistItem';
+export * from './useWishlistSet';
+export * from './useWishlistSets';

--- a/packages/react/src/wishlists/hooks/types/useWishlistSet.ts
+++ b/packages/react/src/wishlists/hooks/types/useWishlistSet.ts
@@ -1,0 +1,25 @@
+import type { AxiosRequestConfig } from 'axios';
+import type { Error } from '@farfetch/blackout-client/types';
+import type {
+  PatchWishlistSetData,
+  WishlistSet,
+} from '@farfetch/blackout-client/wishlists/types';
+import type { WishlistSetHydrated } from '@farfetch/blackout-redux/entities/types';
+
+export type UseWishlistSet = (setId: WishlistSet['setId']) => {
+  error: Error | null | undefined;
+  isFetched: boolean | undefined;
+  isLoading: boolean | undefined;
+  itemsCounter: number;
+  removeWishlistSet: (
+    wishlistSetId: WishlistSet['setId'],
+    config?: AxiosRequestConfig,
+  ) => Promise<undefined>;
+  totalQuantity: number;
+  updateWishlistSet: (
+    wishlistSetId: WishlistSet['setId'],
+    data: PatchWishlistSetData,
+    config?: AxiosRequestConfig,
+  ) => Promise<WishlistSet | undefined>;
+  wishlistSet: WishlistSetHydrated | undefined;
+};

--- a/packages/react/src/wishlists/hooks/types/useWishlistSets.ts
+++ b/packages/react/src/wishlists/hooks/types/useWishlistSets.ts
@@ -3,10 +3,8 @@ import type {
   WishlistSets,
 } from '@farfetch/blackout-client/wishlists/types';
 import type { SetsState } from '@farfetch/blackout-redux/wishlists/types';
-import type {
-  WishlistSetsErrors,
-  WishlistSetsHydrated,
-} from '@farfetch/blackout-redux/wishlists/selectors/types';
+import type { WishlistSetsErrors } from '@farfetch/blackout-redux/wishlists/selectors/types';
+import type { WishlistSetsHydrated } from '@farfetch/blackout-redux/entities/types';
 
 export type UseWishlistSets = () => {
   addWishlistSet: (

--- a/packages/react/src/wishlists/hooks/useWishlistSet.ts
+++ b/packages/react/src/wishlists/hooks/useWishlistSet.ts
@@ -1,0 +1,108 @@
+/**
+ * Hook to provide all kinds of data for the business logic attached to the wishlist set.
+ *
+ * @module useWishlistSet
+ * @category Wishlists
+ * @subcategory Hooks
+ */
+import {
+  fetchWishlistSet as fetchWishlistSetAction,
+  getWishlistSet,
+  getWishlistSetError,
+  getWishlistSetItemsCounter,
+  getWishlistSetTotalQuantity,
+  isWishlistSetFetched,
+  isWishlistSetLoading,
+  removeWishlistSet as removeWishlistSetAction,
+  updateWishlistSet as updateWishlistSetAction,
+} from '@farfetch/blackout-redux/wishlists';
+import { useAction } from '../../helpers';
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import type { UseWishlistSet } from './types';
+
+/**
+ * Provides Redux actions and state access to deal with
+ * wishlist set business logic.
+ *
+ * @memberof module:wishlists/hooks
+ *
+ * @param {number} setId - Wishlist set identifier.
+ *
+ * @returns {object} All the state, actions and relevant data needed
+ * to manage a wishlist set.
+ */
+const useWishlistSet: UseWishlistSet = setId => {
+  const error = useSelector(state => getWishlistSetError(state, setId));
+  const isLoading = useSelector(state => isWishlistSetLoading(state, setId));
+  const wishlistSet = useSelector(state => getWishlistSet(state, setId));
+  const itemsCounter = useSelector(state =>
+    getWishlistSetItemsCounter(state, setId),
+  );
+  const totalQuantity = useSelector(state =>
+    getWishlistSetTotalQuantity(state, setId),
+  );
+  const isFetched = useSelector(state => isWishlistSetFetched(state, setId));
+  const fetchWishlistSet = useAction(fetchWishlistSetAction);
+  const removeWishlistSet = useAction(removeWishlistSetAction);
+  const updateWishlistSet = useAction(updateWishlistSetAction);
+
+  useEffect(() => {
+    if (setId && !isLoading && !isFetched) {
+      fetchWishlistSet(setId);
+    }
+  }, [isFetched, fetchWishlistSet, isLoading, setId]);
+
+  return {
+    /**
+     * Error state of the fetched wishlist set.
+     *
+     * @type {object|undefined}
+     */
+    error,
+    /**
+     * Whether the wishlist set is fetched.
+     *
+     * @type {boolean}
+     */
+    isFetched,
+    /**
+     * Whether the wishlist set is loading.
+     *
+     * @type {boolean}
+     */
+    isLoading,
+    /**
+     * Number of different items in the wishlist set.
+     *
+     * @type {number}
+     */
+    itemsCounter,
+    /**
+     * Removes the wishlist set.
+     *
+     * @type {Function}
+     */
+    removeWishlistSet,
+    /**
+     * Total quantity of the items in the wishlist set.
+     *
+     * @type {number}
+     */
+    totalQuantity,
+    /**
+     * Updates the wishlist set.
+     *
+     * @type {Function}
+     */
+    updateWishlistSet,
+    /**
+     * Fetched wishlist set.
+     *
+     * @type {object}
+     */
+    wishlistSet,
+  };
+};
+
+export default useWishlistSet;

--- a/packages/redux/src/entities/types/wishlistSet.types.ts
+++ b/packages/redux/src/entities/types/wishlistSet.types.ts
@@ -18,3 +18,5 @@ export type WishlistSetHydrated = Omit<
     product: ProductEntity | undefined;
   };
 };
+
+export type WishlistSetsHydrated = Array<WishlistSetHydrated> | undefined;

--- a/packages/redux/src/wishlists/selectors/types/wishlistsSets.types.ts
+++ b/packages/redux/src/wishlists/selectors/types/wishlistsSets.types.ts
@@ -1,25 +1,7 @@
 import type { Error } from '@farfetch/blackout-client/types';
-import type { ProductEntity, WishlistSetEntity } from '../../../entities/types';
-import type {
-  WishlistItem,
-  WishlistSetItem,
-} from '@farfetch/blackout-client/wishlists/types';
 
 export type WishlistSetsErrors = Array<{
   id: string;
   name?: string;
   error: Error;
 }>;
-
-export type WishlistSetHydrated = WishlistSetEntity & {
-  wishlistSetItems:
-    | Array<
-        WishlistSetItem &
-          WishlistItem & {
-            product?: ProductEntity;
-          }
-      >
-    | undefined;
-};
-
-export type WishlistSetsHydrated = Array<WishlistSetHydrated> | undefined;

--- a/packages/redux/src/wishlists/selectors/wishlistsSets.ts
+++ b/packages/redux/src/wishlists/selectors/wishlistsSets.ts
@@ -5,12 +5,12 @@ import type { Error } from '@farfetch/blackout-client/types';
 import type { SetsState } from '../types';
 import type { StoreState } from '../../types';
 import type { WishlistSet } from '@farfetch/blackout-client/wishlists/types';
-import type { WishlistSetEntity } from '../../entities/types';
 import type {
+  WishlistSetEntity,
   WishlistSetHydrated,
-  WishlistSetsErrors,
   WishlistSetsHydrated,
-} from './types/wishlistsSets.types';
+} from '../../entities/types';
+import type { WishlistSetsErrors } from './types/wishlistsSets.types';
 
 /**
  * Retrieves the error state of the current user's wishlist sets.


### PR DESCRIPTION
## Description
This adds the hook `useWishlistSet` that manages all logic related with
a wishlist set.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
