### PR TITLE
feat(react): add GA4 custom scroll event mappings

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/GA4.js
+++ b/packages/react/src/analytics/integrations/GA4/GA4.js
@@ -15,7 +15,6 @@
  * @subcategory Integrations
  */
 import {
-  eventTypes as analyticsEventTypes,
   pageTypes as analyticsPageTypes,
   trackTypes as analyticsTrackTypes,
   integrations,
@@ -39,9 +38,8 @@ import {
   OPTION_SET_CUSTOM_USER_ID_PROPERTY,
 } from './constants';
 import { validateFields } from './validation/optionsValidator';
-import defaultEventCommands, {
+import defaultCommandsBuilder, {
   commandListSchema,
-  getProductUpdatedEventList,
   nonInteractionEvents,
 } from './commands';
 import defaultSchemaEventsMap from '../shared/validation/eventSchemas';
@@ -222,30 +220,6 @@ class GA4 extends integrations.Integration {
   }
 
   /**
-   * Preprocess GA4 event to prevent multiple ga4 track events at once.
-   *
-   * @async
-   *
-   * @param {object} data - Event data provided by analytics.
-   *
-   * @returns {Promise} Promise that will resolve when the method finishes.
-   */
-  async processTrackEvent(data) {
-    const eventName = get(data, 'event');
-
-    switch (eventName) {
-      case analyticsEventTypes.PRODUCT_UPDATED:
-        return await Promise.all([
-          getProductUpdatedEventList(data).map(event =>
-            this.trackEvent({ ...data, event }),
-          ),
-        ]);
-      default:
-        return this.trackEvent(data);
-    }
-  }
-
-  /**
    * Send events to GA4 if the input event data passes schema validation.
    *
    * @async
@@ -262,7 +236,7 @@ class GA4 extends integrations.Integration {
         return await this.processPageEvent(data);
 
       case analyticsTrackTypes.TRACK:
-        return await this.processTrackEvent(data);
+        return await this.trackEvent(data);
       /* istanbul ignore next */
       default:
         /* istanbul ignore next */
@@ -543,7 +517,7 @@ class GA4 extends integrations.Integration {
       return commandBuilder;
     }
 
-    return get(defaultEventCommands, event);
+    return defaultCommandsBuilder;
   }
 
   /**

--- a/packages/react/src/analytics/integrations/GA4/commands.js
+++ b/packages/react/src/analytics/integrations/GA4/commands.js
@@ -4,7 +4,7 @@
  */
 import {
   eventTypes,
-  pageTypes,
+  interactionTypes,
   utils,
 } from '@farfetch/blackout-core/analytics';
 import { validationSchemaBuilder } from '../shared/validation/eventSchemas';
@@ -13,60 +13,17 @@ import ga4EventNameMapping, {
   InternalEventTypes,
 } from './eventMapping';
 
-const getCommandForEvent = data => {
+const genericCommandsBuilder = data => {
   const eventName = ga4EventNameMapping[data.event];
+
+  if (!eventName) {
+    return null;
+  }
+
   return [['event', eventName, getEventProperties(data.event, data)]];
 };
 
-export default {
-  [eventTypes.PRODUCT_ADDED_TO_CART]: getCommandForEvent,
-  [eventTypes.PRODUCT_REMOVED_FROM_CART]: getCommandForEvent,
-  [eventTypes.PAYMENT_INFO_ADDED]: getCommandForEvent,
-  [eventTypes.PRODUCT_ADDED_TO_WISHLIST]: getCommandForEvent,
-  [eventTypes.PRODUCT_REMOVED_FROM_WISHLIST]: getCommandForEvent,
-  [eventTypes.SHIPPING_INFO_ADDED]: getCommandForEvent,
-  [eventTypes.CHECKOUT_STARTED]: getCommandForEvent,
-  [eventTypes.ORDER_COMPLETED]: getCommandForEvent,
-  [eventTypes.ORDER_REFUNDED]: getCommandForEvent,
-  [pageTypes.SEARCH]: getCommandForEvent,
-  [eventTypes.SELECT_CONTENT]: getCommandForEvent,
-  [eventTypes.PRODUCT_CLICKED]: getCommandForEvent,
-  [eventTypes.PRODUCT_VIEWED]: getCommandForEvent,
-  [eventTypes.PRODUCT_LIST_VIEWED]: getCommandForEvent,
-  [pageTypes.BAG]: getCommandForEvent,
-  [pageTypes.WISHLIST]: getCommandForEvent,
-  [eventTypes.LOGIN]: getCommandForEvent,
-  [eventTypes.SIGNUP_FORM_COMPLETED]: getCommandForEvent,
-  [eventTypes.FILTERS_APPLIED]: getCommandForEvent,
-  [eventTypes.FILTERS_CLEARED]: getCommandForEvent,
-  [eventTypes.SHARE]: getCommandForEvent,
-  [eventTypes.CHECKOUT_STARTED]: getCommandForEvent,
-  [eventTypes.PLACE_ORDER_STARTED]: getCommandForEvent,
-  [eventTypes.CHECKOUT_ABANDONED]: getCommandForEvent,
-  [eventTypes.PROMOCODE_APPLIED]: getCommandForEvent,
-  [eventTypes.CHECKOUT_STEP_EDITING]: getCommandForEvent,
-  [eventTypes.ADDRESS_INFO_ADDED]: getCommandForEvent,
-  [eventTypes.SHIPPING_METHOD_ADDED]: getCommandForEvent,
-  [InternalEventTypes.PRODUCT_UPDATED.CHANGE_QUANTITY]: getCommandForEvent,
-  [InternalEventTypes.PRODUCT_UPDATED.CHANGE_SIZE]: getCommandForEvent,
-  [InternalEventTypes.PRODUCT_UPDATED.CHANGE_COLOUR]: getCommandForEvent,
-  [eventTypes.INTERACT_CONTENT]: getCommandForEvent,
-  [eventTypes.SIGNUP_NEWSLETTER]: getCommandForEvent,
-};
-
-// Schema used to validate the output of command functions
-export const commandListSchema = validationSchemaBuilder
-  .array()
-  .of(validationSchemaBuilder.array());
-
-// List of default non-interaction events
-export const nonInteractionEvents = {
-  [eventTypes.CHECKOUT_STEP_VIEWED]: true,
-  [eventTypes.PRODUCT_LIST_VIEWED]: true,
-  [eventTypes.PRODUCT_VIEWED]: true,
-};
-
-export const getProductUpdatedEventList = data => {
+const getProductUpdatedEventList = data => {
   const eventProperties = utils.getProperties(data);
   const dispatchGA4EventList = [];
 
@@ -95,4 +52,60 @@ export const getProductUpdatedEventList = data => {
 
   // return list of events which will be triggered
   return dispatchGA4EventList;
+};
+
+const productUpdatedEventCommandsBuilder = data => {
+  const internalEvents = getProductUpdatedEventList(data);
+
+  const commands = internalEvents.map(internalEvent =>
+    genericCommandsBuilder({ ...data, event: internalEvent })?.shift(),
+  );
+
+  return commands;
+};
+
+const interactContentEventCommandsBuilder = data => {
+  const eventProperties = data.properties;
+
+  if (
+    eventProperties.interactionType === interactionTypes.SCROLL &&
+    eventProperties.target === document.body
+  ) {
+    return genericCommandsBuilder({
+      ...data,
+      event: InternalEventTypes.PAGE_SCROLL,
+    });
+  }
+
+  return genericCommandsBuilder(data);
+};
+
+const specializedCommandsBuilderByEvent = {
+  [eventTypes.PRODUCT_UPDATED]: productUpdatedEventCommandsBuilder,
+  [eventTypes.INTERACT_CONTENT]: interactContentEventCommandsBuilder,
+};
+
+const defaultCommandsBuilder = data => {
+  const specializedEventCommandsBuilder =
+    specializedCommandsBuilderByEvent[data.event];
+
+  if (specializedEventCommandsBuilder) {
+    return specializedEventCommandsBuilder(data);
+  }
+
+  return genericCommandsBuilder(data);
+};
+
+export default defaultCommandsBuilder;
+
+// Schema used to validate the output of command functions
+export const commandListSchema = validationSchemaBuilder
+  .array()
+  .of(validationSchemaBuilder.array());
+
+// List of default non-interaction events
+export const nonInteractionEvents = {
+  [eventTypes.CHECKOUT_STEP_VIEWED]: true,
+  [eventTypes.PRODUCT_LIST_VIEWED]: true,
+  [eventTypes.PRODUCT_VIEWED]: true,
 };

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.js
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.js
@@ -14,6 +14,7 @@ export const InternalEventTypes = {
     CHANGE_QUANTITY: 'change_quantity',
     CHANGE_COLOUR: 'change_colour',
   },
+  PAGE_SCROLL: 'scroll',
 };
 
 /**
@@ -58,6 +59,7 @@ export default {
     InternalEventTypes.PRODUCT_UPDATED.CHANGE_SIZE,
   [InternalEventTypes.PRODUCT_UPDATED.CHANGE_COLOUR]:
     InternalEventTypes.PRODUCT_UPDATED.CHANGE_COLOUR,
+  [InternalEventTypes.PAGE_SCROLL]: InternalEventTypes.PAGE_SCROLL,
 };
 
 /**
@@ -586,6 +588,19 @@ const getSignupNewsletterParametersFromEvent = eventProperties => {
 };
 
 /**
+ * Returns the scroll parameters formatted for the GA4 event.
+ *
+ * @param {object} eventProperties - Properties from a track event.
+ *
+ * @returns {object} Parameters formatted for the GA4's scroll event.
+ */
+const getScrollParametersFromEvent = eventProperties => {
+  return {
+    percent_scrolled: eventProperties.percentageScrolled,
+  };
+};
+
+/**
  * Returns event properties mapping by GA4 event name.
  *
  * @param {string} event - Event name.
@@ -672,6 +687,9 @@ export function getEventProperties(event, data) {
 
     case eventTypes.SIGNUP_NEWSLETTER:
       return getSignupNewsletterParametersFromEvent(eventProperties);
+
+    case InternalEventTypes.PAGE_SCROLL:
+      return getScrollParametersFromEvent(eventProperties);
 
     default:
       /* istanbul ignore next */

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.js
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.js
@@ -596,7 +596,7 @@ const getSignupNewsletterParametersFromEvent = eventProperties => {
  */
 const getScrollParametersFromEvent = eventProperties => {
   return {
-    percent_scrolled: eventProperties.percentageScrolled,
+    percent_scrolled: `${eventProperties.percentageScrolled}%`,
   };
 };
 

--- a/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.js
+++ b/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.js
@@ -33,6 +33,7 @@ import {
   pageTypes,
 } from '@farfetch/blackout-core/analytics';
 import { SignupNewsletterGenderMappings } from '../../shared/dataMappings/';
+import isElement from 'lodash/isElement';
 
 export const errorCodes = {
   InvalidSize: 'ga4_invalid_size',
@@ -200,24 +201,6 @@ const placeOrderStartedSchema = currencyRequiredSchema
 const shippingMethodAddedSchema = checkoutShippingStepSchema;
 const addressInfoAddedSchema = checkoutShippingStepSchema;
 
-/**
- * Returns true if the argument is a DOM element.
- *
- * @param {*} o - The value to check.
- *
- * @returns {boolean} True if the argument is a DOM element, false otherwise.
- */
-function isElement(o) {
-  return (
-    o instanceof HTMLElement ||
-    (o &&
-      typeof o === 'object' &&
-      o !== null &&
-      o.nodeType === 1 &&
-      typeof o.nodeName === 'string')
-  );
-}
-
 const interactContentSchema = yup
   .object({
     interactionType: yup
@@ -241,10 +224,14 @@ const interactContentSchema = yup
   )
   .test(
     'scroll_invalid_percentage_scrolled_parameter',
-    "invalid 'percentageScrolled' parameter for 'SCROLL' interaction type. It must be a string containing a percentage.",
+    "invalid 'percentageScrolled' parameter for 'SCROLL' interaction type. It must be a number representing a percentage between [0,100].",
     value => {
       if (value.interactionType === interactionTypes.SCROLL) {
-        return typeof value.percentageScrolled === 'string';
+        return (
+          typeof value.percentageScrolled === 'number' &&
+          value.percentageScrolled >= 0 &&
+          value.percentageScrolled <= 100
+        );
       }
 
       return true;

--- a/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.js
+++ b/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.js
@@ -32,7 +32,6 @@ import {
   interactionTypes,
   pageTypes,
 } from '@farfetch/blackout-core/analytics';
-import { InternalEventTypes } from '../eventMapping';
 import { SignupNewsletterGenderMappings } from '../../shared/dataMappings/';
 
 export const errorCodes = {
@@ -160,60 +159,14 @@ const manageProductInCartSchema = fromSchema
 const manageProductInWishlistSchema =
   manageProductInCartSchema.concat(wishlistIdSchema);
 
-const updateProductSchema = fromSchema.concat(productRequiredSchema);
-
-const changeSizeProductInCartSchema = updateProductSchema.concat(
-  yup.object({
-    oldSize: yup.string(),
-    size: yup
-      .string()
-      .test(errorCodes.InvalidSize, errorCodes.InvalidSize, function () {
-        const { oldSize, size } = this.parent;
-        // This validation can be unused at the moment because ga4 responds to
-        // product_updated event, which ar a special event because analyzes metadata,
-        // and assigns different events, like change_size if provided data shows
-        // a change size intent.
-
-        return oldSize !== size;
-      }),
-  }),
-);
-
-const changeQuantityProductInCartSchema = updateProductSchema.concat(
+const productUpdatedSchema = fromSchema.concat(productRequiredSchema).concat(
   yup.object({
     oldQuantity: yup.number(),
-    quantity: yup
-      .number()
-      .test(
-        errorCodes.InvalidQuantity,
-        errorCodes.InvalidQuantity,
-        function () {
-          const { oldQuantity, quantity } = this.parent;
-          // This validation can be unused at the moment because ga4 responds to
-          // product_updated event, which ar a special event because analyzes metadata,
-          // and assigns different events, like change_quantity if provided data shows
-          // a change size intent.
-
-          return oldQuantity !== quantity;
-        },
-      ),
-  }),
-);
-
-const colourChangedSchema = updateProductSchema.concat(
-  yup.object({
+    quantity: yup.number(),
+    oldSize: yup.string(),
+    size: yup.string(),
     oldColour: yup.string(),
-    colour: yup
-      .string()
-      .test(errorCodes.InvalidColour, errorCodes.InvalidColour, function () {
-        const { oldColour, colour } = this.parent;
-        // This validation can be unused at the moment because ga4 responds to
-        // product_updated event, which ar a special event because analyzes metadata,
-        // and assigns different events, like change_colour if provided data shows
-        // a change size intent.
-
-        return oldColour !== colour;
-      }),
+    colour: yup.string(),
   }),
 );
 
@@ -247,15 +200,56 @@ const placeOrderStartedSchema = currencyRequiredSchema
 const shippingMethodAddedSchema = checkoutShippingStepSchema;
 const addressInfoAddedSchema = checkoutShippingStepSchema;
 
-const interactContentSchema = yup.object({
-  interactionType: yup
-    .string()
-    .test(
-      'match_interaction_type',
-      'The interactionType must match one of the built-in "interationTypes"',
-      value => Object.values(interactionTypes).includes(value),
-    ),
-});
+/**
+ * Returns true if the argument is a DOM element.
+ *
+ * @param {*} o - The value to check.
+ *
+ * @returns {boolean} True if the argument is a DOM element, false otherwise.
+ */
+function isElement(o) {
+  return (
+    o instanceof HTMLElement ||
+    (o &&
+      typeof o === 'object' &&
+      o !== null &&
+      o.nodeType === 1 &&
+      typeof o.nodeName === 'string')
+  );
+}
+
+const interactContentSchema = yup
+  .object({
+    interactionType: yup
+      .string()
+      .test(
+        'match_interaction_type',
+        'The interactionType must match one of the built-in "interationTypes"',
+        value => Object.values(interactionTypes).includes(value),
+      ),
+  })
+  .test(
+    'scroll_invalid_target_parameter',
+    "invalid 'target' parameter for 'SCROLL' interaction type. It must be a DOM Element.",
+    value => {
+      if (value.interactionType === interactionTypes.SCROLL) {
+        return isElement(value.target);
+      }
+
+      return true;
+    },
+  )
+  .test(
+    'scroll_invalid_percentage_scrolled_parameter',
+    "invalid 'percentageScrolled' parameter for 'SCROLL' interaction type. It must be a string containing a percentage.",
+    value => {
+      if (value.interactionType === interactionTypes.SCROLL) {
+        return typeof value.percentageScrolled === 'string';
+      }
+
+      return true;
+    },
+  );
 
 const signupNewsletterSchema = yup.object({
   gender: yup.string().oneOf(Object.keys(SignupNewsletterGenderMappings)),
@@ -285,11 +279,7 @@ export default {
   [eventTypes.CHECKOUT_STEP_EDITING]: checkoutStepEditingSchema,
   [eventTypes.ADDRESS_INFO_ADDED]: addressInfoAddedSchema,
   [eventTypes.SHIPPING_METHOD_ADDED]: shippingMethodAddedSchema,
-  [InternalEventTypes.PRODUCT_UPDATED.CHANGE_SIZE]:
-    changeSizeProductInCartSchema,
-  [InternalEventTypes.PRODUCT_UPDATED.CHANGE_QUANTITY]:
-    changeQuantityProductInCartSchema,
-  [InternalEventTypes.PRODUCT_UPDATED.CHANGE_COLOUR]: colourChangedSchema,
+  [eventTypes.PRODUCT_UPDATED]: productUpdatedSchema,
   [eventTypes.INTERACT_CONTENT]: interactContentSchema,
   [eventTypes.SIGNUP_NEWSLETTER]: signupNewsletterSchema,
 };

--- a/packages/react/src/analytics/integrations/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/__tests__/GA4.test.js
@@ -1224,6 +1224,49 @@ describe('GA4 Integration', () => {
           );
         });
       });
+
+      describe('Interact content events', () => {
+        it('Should map to a page scroll event when the interaction type is scroll and target is document', async () => {
+          ga4Instance = await createGA4InstanceAndLoad(validOptions, loadData);
+
+          const ga4Spy = getWindowGa4Spy();
+          const clonedEvent = cloneDeep(
+            validTrackEvents[eventTypes.INTERACT_CONTENT],
+          );
+
+          clonedEvent.properties.interactionType = interactionTypes.SCROLL;
+          clonedEvent.properties.target = document.body;
+          clonedEvent.properties.percentageScrolled = '25%';
+
+          await ga4Instance.track(clonedEvent);
+
+          expect(ga4Spy.mock.calls).toMatchSnapshot();
+        });
+
+        it('Should not map to a page scroll event when the interaction type is scroll and target is not document', async () => {
+          ga4Instance = await createGA4InstanceAndLoad(validOptions, loadData);
+
+          const ga4Spy = getWindowGa4Spy();
+          const clonedEvent = cloneDeep(
+            validTrackEvents[eventTypes.INTERACT_CONTENT],
+          );
+
+          clonedEvent.properties.interactionType = interactionTypes.SCROLL;
+          clonedEvent.properties.target = document.createElement('ul'); // use other element instead of document
+          clonedEvent.properties.percentageScrolled = '25%';
+
+          await ga4Instance.track(clonedEvent);
+
+          expect(ga4Spy).toHaveBeenCalledWith(
+            'event',
+            'interact_content',
+            expect.objectContaining({
+              percentage_scrolled: '25%',
+              interaction_type: 'Scroll',
+            }),
+          );
+        });
+      });
     });
   });
 });

--- a/packages/react/src/analytics/integrations/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/__tests__/GA4.test.js
@@ -1226,7 +1226,7 @@ describe('GA4 Integration', () => {
       });
 
       describe('Interact content events', () => {
-        it('Should map to a page scroll event when the interaction type is scroll and target is document', async () => {
+        it('Should map to a page scroll event when the interaction type is scroll and target is document.body', async () => {
           ga4Instance = await createGA4InstanceAndLoad(validOptions, loadData);
 
           const ga4Spy = getWindowGa4Spy();
@@ -1236,14 +1236,14 @@ describe('GA4 Integration', () => {
 
           clonedEvent.properties.interactionType = interactionTypes.SCROLL;
           clonedEvent.properties.target = document.body;
-          clonedEvent.properties.percentageScrolled = '25%';
+          clonedEvent.properties.percentageScrolled = 25;
 
           await ga4Instance.track(clonedEvent);
 
           expect(ga4Spy.mock.calls).toMatchSnapshot();
         });
 
-        it('Should not map to a page scroll event when the interaction type is scroll and target is not document', async () => {
+        it('Should not map to a page scroll event when the interaction type is scroll and target is not document.body', async () => {
           ga4Instance = await createGA4InstanceAndLoad(validOptions, loadData);
 
           const ga4Spy = getWindowGa4Spy();
@@ -1253,7 +1253,7 @@ describe('GA4 Integration', () => {
 
           clonedEvent.properties.interactionType = interactionTypes.SCROLL;
           clonedEvent.properties.target = document.createElement('ul'); // use other element instead of document
-          clonedEvent.properties.percentageScrolled = '25%';
+          clonedEvent.properties.percentageScrolled = 25;
 
           await ga4Instance.track(clonedEvent);
 
@@ -1261,7 +1261,7 @@ describe('GA4 Integration', () => {
             'event',
             'interact_content',
             expect.objectContaining({
-              percentage_scrolled: '25%',
+              percentage_scrolled: 25,
               interaction_type: 'Scroll',
             }),
           );

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
@@ -748,7 +748,7 @@ Array [
 ]
 `;
 
-exports[`GA4 Integration GA4 instance When it is instantiated correctly Interact content events Should map to a page scroll event when the interaction type is scroll and target is document 1`] = `
+exports[`GA4 Integration GA4 instance When it is instantiated correctly Interact content events Should map to a page scroll event when the interaction type is scroll and target is document.body 1`] = `
 Array [
   Array [
     "event",

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
@@ -748,6 +748,18 @@ Array [
 ]
 `;
 
+exports[`GA4 Integration GA4 instance When it is instantiated correctly Interact content events Should map to a page scroll event when the interaction type is scroll and target is document 1`] = `
+Array [
+  Array [
+    "event",
+    "scroll",
+    Object {
+      "percent_scrolled": "25%",
+    },
+  ],
+]
+`;
+
 exports[`GA4 Integration GA4 instance When it is instantiated correctly Update Product events Should trigger ga4 change_colour event 1`] = `
 Array [
   Array [


### PR DESCRIPTION
## Description

- This adds mappings for the GA4 custom scroll event. It maps the
`interact_content` event with `scroll` type
and whose `target` is the document.body element.
- Fixes `PRODUCT_UPDATED` event implementation that would not let the user to
specify an override for that event.
- Simplified implementation of the `commands` module in GA4 to avoid
redundancy.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
