### PR TITLE
fix(react): fix interact content payload in GA4

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/GA4.js
+++ b/packages/react/src/analytics/integrations/GA4/GA4.js
@@ -38,15 +38,15 @@ import {
   OPTION_SET_CUSTOM_USER_ID_PROPERTY,
 } from './constants';
 import { validateFields } from './validation/optionsValidator';
-import defaultCommandsBuilder, {
-  commandListSchema,
-  nonInteractionEvents,
-} from './commands';
 import defaultSchemaEventsMap from '../shared/validation/eventSchemas';
 import each from 'lodash/each';
 import eventValidator from '../shared/validation/eventValidator';
 import GA4SchemaEventsMap from './validation/eventSchemas';
 import get from 'lodash/get';
+import getDefaultCommandsBuilder, {
+  commandListSchema,
+  nonInteractionEvents,
+} from './commands';
 import merge from 'lodash/merge';
 
 /**
@@ -517,7 +517,7 @@ class GA4 extends integrations.Integration {
       return commandBuilder;
     }
 
-    return defaultCommandsBuilder;
+    return getDefaultCommandsBuilder(event);
   }
 
   /**

--- a/packages/react/src/analytics/integrations/GA4/commands.js
+++ b/packages/react/src/analytics/integrations/GA4/commands.js
@@ -16,10 +16,6 @@ import ga4EventNameMapping, {
 const genericCommandsBuilder = data => {
   const eventName = ga4EventNameMapping[data.event];
 
-  if (!eventName) {
-    return null;
-  }
-
   return [['event', eventName, getEventProperties(data.event, data)]];
 };
 
@@ -85,18 +81,20 @@ const specializedCommandsBuilderByEvent = {
   [eventTypes.INTERACT_CONTENT]: interactContentEventCommandsBuilder,
 };
 
-const defaultCommandsBuilder = data => {
+export default event => {
   const specializedEventCommandsBuilder =
-    specializedCommandsBuilderByEvent[data.event];
+    specializedCommandsBuilderByEvent[event];
 
   if (specializedEventCommandsBuilder) {
-    return specializedEventCommandsBuilder(data);
+    return specializedEventCommandsBuilder;
   }
 
-  return genericCommandsBuilder(data);
-};
+  if (ga4EventNameMapping[event]) {
+    return genericCommandsBuilder;
+  }
 
-export default defaultCommandsBuilder;
+  return null;
+};
 
 // Schema used to validate the output of command functions
 export const commandListSchema = validationSchemaBuilder

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.js
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.js
@@ -6,6 +6,7 @@ import {
 import { MAX_PRODUCT_CATEGORIES } from './constants';
 import { SignupNewsletterGenderMappings } from '../shared/dataMappings/';
 import get from 'lodash/get';
+import isObject from 'lodash/isObject';
 import snakeCase from 'lodash/snakeCase';
 
 export const InternalEventTypes = {
@@ -378,7 +379,13 @@ const getInteractContentParametersFromEvent = eventProperties => {
   const formattedProperties = {};
 
   Object.keys(eventProperties).forEach(key => {
-    formattedProperties[snakeCase(key)] = eventProperties[key];
+    const value = eventProperties[key];
+
+    if (isObject(value)) {
+      return;
+    }
+
+    formattedProperties[snakeCase(key)] = value;
   });
 
   return formattedProperties;

--- a/packages/react/src/analytics/integrations/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/__tests__/GA4.test.js
@@ -1265,6 +1265,10 @@ describe('GA4 Integration', () => {
               interaction_type: 'Scroll',
             }),
           );
+
+          const eventProperties = ga4Spy.mock.calls[0][2];
+
+          expect(eventProperties).not.toHaveProperty('target');
         });
       });
     });


### PR DESCRIPTION
## Description

- Fixes interact content payload to exclude properties that are objects.
- Fixes unnecessary warnings being logged to the console for events that
are not handled by the default command mapper in GA4.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
