### PR TITLE
feat(core): refactored mapper on omnitracking integration to calculate parameters from data object

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
@@ -26,11 +26,14 @@ import {
   OPTION_TRANSFORM_PAYLOAD,
 } from './constants';
 import { postTrackings } from './client';
-import { userGenderValuesMapper } from './definitions';
+import { trackEventsMapper, userGenderValuesMapper } from './definitions';
 import { v4 as uuidv4 } from 'uuid';
 import analyticsTrackTypes from '../../types/trackTypes';
 import get from 'lodash/get';
 import Integration from '../Integration';
+import isArray from 'lodash/isArray';
+import isFunction from 'lodash/isFunction';
+import isObject from 'lodash/isObject';
 import logger from '../../utils/logger';
 import platformTypes from '../../types/platformTypes';
 
@@ -215,24 +218,54 @@ class Omnitracking extends Integration {
         );
       }
       case analyticsTrackTypes.TRACK: {
-        precalculatedParameters = this.getPrecalculatedParametersForEvent(data);
+        const eventMapperFn = trackEventsMapper[data.event];
 
-        if (!this.validateTrackingRequisites()) {
-          logger.warn(
-            `[Omnitracking] - Event ${data.event} tried to track without an unique view id.
-                Consider tracking an event only after a page event.
-                This behaviour is not recommended and will not be supported in upcoming versions`,
+        if (eventMapperFn && !isFunction(eventMapperFn)) {
+          throw new Error(
+            '[Omnitracking] - The event mapper did not return a valid function. Please make sure the event is correctly mapped.',
           );
         }
 
-        return await this.postTracking(
-          formatTrackEvent(data, precalculatedParameters),
-          data,
-        );
+        if (eventMapperFn) {
+          const mappedEvents = eventMapperFn(data);
+
+          if (isArray(mappedEvents)) {
+            await Promise.all(
+              mappedEvents.map(async mappedEventData => {
+                await this.processTrackEvents(data, mappedEventData);
+              }),
+            );
+          }
+
+          if (isObject(mappedEvents)) {
+            return await this.processTrackEvents(data, mappedEvents);
+          }
+        }
+
+        return await this.processTrackEvents(data);
       }
       default:
         break;
     }
+  }
+
+  async processTrackEvents(data, mappedEventData) {
+    const precalculatedParameters =
+      this.getPrecalculatedParametersForEvent(data);
+    const formattedEventData = formatTrackEvent(data, {
+      ...precalculatedParameters,
+      ...mappedEventData,
+    });
+
+    if (!this.validateTrackingRequisites()) {
+      logger.warn(
+        `[Omnitracking] - Event ${data.event} tried to track without an unique view id.
+                Consider tracking an event only after a page event.
+                This behaviour is not recommended and will not be supported in upcoming versions`,
+      );
+    }
+
+    return await this.postTracking(formattedEventData, data);
   }
 
   /**

--- a/packages/core/src/analytics/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
@@ -1,9 +1,9 @@
 import {
-  getEventValForEventData,
+  generatePaymentAttemptReferenceId,
   getPageEventFromLocation,
   getPlatformSpecificParameters,
+  getValParameterForEvent,
 } from '../omnitracking-helper';
-import eventTypes from '../../../types/eventTypes';
 import platformTypes from '../../../types/platformTypes';
 import trackTypes from '../../../types/trackTypes';
 
@@ -17,9 +17,25 @@ describe('getPageEventFromLocation', () => {
   });
 });
 
-describe('getEventValForEventData', () => {
-  it('should return null for an event that is not considered', () => {
-    expect(getEventValForEventData(eventTypes.SELECT_CONTENT)).toBe(null);
+describe('getValParameterForEvent', () => {
+  it('should return a stringified object', () => {
+    expect(getValParameterForEvent()).toBe('{}');
+    expect(getValParameterForEvent({ foo: 'bar' })).toBe('{"foo":"bar"}');
+  });
+});
+
+describe('generatePaymentAttemptReferenceId', () => {
+  it('Should return a string with the generated payment attempt reference ID', () => {
+    const mockPaymentAttemptReferenceId = '12345_123456789';
+
+    expect(
+      generatePaymentAttemptReferenceId({
+        user: {
+          localId: '12345',
+        },
+        timestamp: 123456789,
+      }),
+    ).toEqual(mockPaymentAttemptReferenceId);
   });
 });
 

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -9,6 +9,7 @@ import {
 import { utils } from '../../';
 import analyticsTrackTypes from '../../types/trackTypes';
 import eventTypes from '../../types/eventTypes';
+import fromParameterTypes from '../../types/fromParameterTypes';
 import merge from 'lodash/merge';
 import mockedPageData, {
   expectedPagePayloadMobile,
@@ -352,9 +353,10 @@ describe('Omnitracking', () => {
     });
     describe('Should send track events when', () => {
       it('event is `Place Order Started`', async () => {
-        const tid = 10097;
+        const tid1 = 10097;
+        const tid2 = 188;
 
-        const data = generateTrackMockData({
+        let data = generateTrackMockData({
           event: eventTypes.PLACE_ORDER_STARTED,
         });
 
@@ -364,7 +366,7 @@ describe('Omnitracking', () => {
           ...expectedTrackPayload,
           parameters: {
             ...expectedTrackPayload.parameters,
-            tid,
+            tid: tid1,
             val: JSON.stringify({
               type: 'TRANSACTION',
               paymentAttemptReferenceId: `${localIdMock}_${mockedTrackData.timestamp}`,
@@ -372,7 +374,19 @@ describe('Omnitracking', () => {
           },
         };
 
-        expect(postTrackingsSpy).toHaveBeenCalledWith(expectedPayload);
+        expect(postTrackingsSpy).toHaveBeenCalledTimes(2);
+        expect(postTrackingsSpy.mock.calls).toEqual([
+          [expectedPayload],
+          [
+            {
+              ...expectedPayload,
+              parameters: {
+                ...expectedPayload.parameters,
+                tid: tid2,
+              },
+            },
+          ],
+        ]);
       });
 
       it('event is `Sign-up Form Viewed`', async () => {
@@ -429,7 +443,7 @@ describe('Omnitracking', () => {
         expect(postTrackingsSpy).toHaveBeenCalledWith(expectedPayload);
       });
 
-      it('event is `Product Added to Cart`', async () => {
+      it('event is `Product Added to Cart` without from parameter', async () => {
         const productId = 10000;
         const tid = 16;
 
@@ -454,7 +468,33 @@ describe('Omnitracking', () => {
         expect(postTrackingsSpy).toHaveBeenCalledWith(expectedPayload);
       });
 
-      it('event is `Product Added to Wishlist`', async () => {
+      it('event is `Product Added to Cart` from PDP', async () => {
+        const productId = 10000;
+        const tid = 598;
+
+        const data = generateTrackMockData({
+          event: eventTypes.PRODUCT_ADDED_TO_CART,
+          properties: {
+            [definitions.PRODUCT_ID_PARAMETER_FROM_BAG_WISHLIST]: productId, // Here we simulate the event being dispatched by the bag middleware
+            from: fromParameterTypes.PDP,
+          },
+        });
+
+        await omnitracking.track(data);
+
+        const expectedPayload = {
+          ...expectedTrackPayload,
+          parameters: {
+            ...expectedTrackPayload.parameters,
+            tid,
+            val: productId,
+          },
+        };
+
+        expect(postTrackingsSpy).toHaveBeenCalledWith(expectedPayload);
+      });
+
+      it('event is `Product Added to Wishlist` without from parameter', async () => {
         const productId = 10000;
         const tid = 35;
 
@@ -481,6 +521,114 @@ describe('Omnitracking', () => {
       });
     });
 
+    it('event is `Product Added to Wishlist` from PDP', async () => {
+      const productId = 10000;
+      const tid = 35;
+
+      const data = generateTrackMockData({
+        event: eventTypes.PRODUCT_ADDED_TO_WISHLIST,
+        properties: {
+          [definitions.PRODUCT_ID_PARAMETER]: productId,
+          from: fromParameterTypes.PDP,
+        },
+      });
+
+      await omnitracking.track(data);
+
+      const expectedPayload = {
+        ...expectedTrackPayload,
+        parameters: {
+          ...expectedTrackPayload.parameters,
+          productId,
+          tid,
+          val: productId,
+        },
+      };
+
+      expect(postTrackingsSpy).toHaveBeenCalledWith(expectedPayload);
+    });
+
+    it('event is `Product Added to Wishlist` from BAG', async () => {
+      const productId = 10000;
+      const tid = 135;
+
+      const data = generateTrackMockData({
+        event: eventTypes.PRODUCT_ADDED_TO_WISHLIST,
+        properties: {
+          [definitions.PRODUCT_ID_PARAMETER]: productId,
+          from: fromParameterTypes.BAG,
+        },
+      });
+
+      await omnitracking.track(data);
+
+      const expectedPayload = {
+        ...expectedTrackPayload,
+        parameters: {
+          ...expectedTrackPayload.parameters,
+          productId,
+          tid,
+          val: productId,
+        },
+      };
+
+      expect(postTrackingsSpy).toHaveBeenCalledWith(expectedPayload);
+    });
+
+    it('event is `Product Added to Wishlist` from RECOMMENDATIONS', async () => {
+      const productId = 10000;
+      const tid = 531;
+
+      const data = generateTrackMockData({
+        event: eventTypes.PRODUCT_ADDED_TO_WISHLIST,
+        properties: {
+          [definitions.PRODUCT_ID_PARAMETER]: productId,
+          from: fromParameterTypes.RECOMMENDATIONS,
+        },
+      });
+
+      await omnitracking.track(data);
+
+      const expectedPayload = {
+        ...expectedTrackPayload,
+        parameters: {
+          ...expectedTrackPayload.parameters,
+          productId,
+          tid,
+          val: productId,
+        },
+      };
+
+      expect(postTrackingsSpy).toHaveBeenCalledWith(expectedPayload);
+    });
+
+    it('event is `Product Added to Wishlist` from RECENTLY_VIEWED', async () => {
+      const productId = 10000;
+      const tid = 532;
+
+      const data = generateTrackMockData({
+        event: eventTypes.PRODUCT_ADDED_TO_WISHLIST,
+        properties: {
+          [definitions.PRODUCT_ID_PARAMETER]: productId,
+          from: fromParameterTypes.RECENTLY_VIEWED,
+        },
+      });
+
+      await omnitracking.track(data);
+
+      const expectedPayload = {
+        ...expectedTrackPayload,
+        parameters: {
+          ...expectedTrackPayload.parameters,
+          productId,
+          tid,
+          val: productId,
+        },
+      };
+
+      expect(postTrackingsSpy).toHaveBeenCalledWith(expectedPayload);
+    });
+
     it('Should not send track events for any other of the predefined events by default', async () => {
       const data = generateTrackMockData({
         event: 'My custom Event',
@@ -505,9 +653,15 @@ describe('Omnitracking', () => {
       expect(definitions.pageEventsFilter).toMatchSnapshot();
     });
 
-    it('`trackEventsMapper` should match snapshot', () => {
-      expect(definitions.trackEventsMapper).toMatchSnapshot();
-    });
+    // test the trackEventsMapper globally with all default scenarios
+    it.each(Object.keys(definitions.trackEventsMapper))(
+      '`%s` return should match the snapshot',
+      eventMapperKey => {
+        expect(
+          definitions.trackEventsMapper[eventMapperKey](mockedTrackData),
+        ).toMatchSnapshot();
+      },
+    );
   });
 
   describe('options', () => {

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Omnitracking definitions \`Checkout Step Viewed\` return should match the snapshot 1`] = `
+Object {
+  "tid": 10097,
+  "val": "{\\"type\\":\\"SUBMIT\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
+}
+`;
+
+exports[`Omnitracking definitions \`Logout\` return should match the snapshot 1`] = `
+Object {
+  "tid": 431,
+}
+`;
+
+exports[`Omnitracking definitions \`Place Order Started\` return should match the snapshot 1`] = `
+Array [
+  Object {
+    "tid": 10097,
+    "val": "{\\"type\\":\\"TRANSACTION\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
+  },
+  Object {
+    "tid": 188,
+    "val": "{\\"type\\":\\"TRANSACTION\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
+  },
+]
+`;
+
+exports[`Omnitracking definitions \`Product Added to Cart\` return should match the snapshot 1`] = `
+Object {
+  "tid": 16,
+  "val": null,
+}
+`;
+
+exports[`Omnitracking definitions \`Product Added to Wishlist\` return should match the snapshot 1`] = `
+Object {
+  "tid": 35,
+  "val": null,
+}
+`;
+
+exports[`Omnitracking definitions \`Sign-up Form Viewed\` return should match the snapshot 1`] = `
+Object {
+  "tid": 10097,
+  "val": "{\\"type\\":\\"REGISTER\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
+}
+`;
+
 exports[`Omnitracking definitions \`pageDefinitions\` should match snapshot 1`] = `
 Object {
   "CheckoutPageVisited": Array [
@@ -563,27 +610,4 @@ Array [
   "val",
   "tid",
 ]
-`;
-
-exports[`Omnitracking definitions \`trackEventsMapper\` should match snapshot 1`] = `
-Object {
-  "Checkout Step Viewed": Object {
-    "tid": 10097,
-    "type": "SUBMIT",
-  },
-  "Place Order Started": Object {
-    "tid": 10097,
-    "type": "TRANSACTION",
-  },
-  "Product Added to Cart": Object {
-    "tid": 16,
-  },
-  "Product Added to Wishlist": Object {
-    "tid": 35,
-  },
-  "Sign-up Form Viewed": Object {
-    "tid": 10097,
-    "type": "REGISTER",
-  },
-}
 `;


### PR DESCRIPTION
## Description
Refactored the integration and combined two different mappers into one, so we can calculate parameters based on the event data object in a single point.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
