### PR TITLE
feat(core): add new mapper on omnitracking integration to calculate parameters from data object - next

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -1,6 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Omnitracking definitions \`pageDefinitions\` should match snapshot 1`] = `
+exports[`Omnitracking track events definitions \`Checkout Step Viewed\` return should match the snapshot 1`] = `
+Object {
+  "tid": 10097,
+  "val": "{\\"type\\":\\"SUBMIT\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
+}
+`;
+
+exports[`Omnitracking track events definitions \`Logout\` return should match the snapshot 1`] = `
+Object {
+  "tid": 431,
+}
+`;
+
+exports[`Omnitracking track events definitions \`Place Order Started\` return should match the snapshot 1`] = `
+Array [
+  Object {
+    "tid": 10097,
+    "val": "{\\"type\\":\\"TRANSACTION\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
+  },
+  Object {
+    "tid": 188,
+    "val": "{\\"type\\":\\"TRANSACTION\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
+  },
+]
+`;
+
+exports[`Omnitracking track events definitions \`Product Added to Cart\` return should match the snapshot 1`] = `
+Object {
+  "tid": 16,
+  "val": "507f1f77bcf86cd799439011",
+}
+`;
+
+exports[`Omnitracking track events definitions \`Product Added to Wishlist\` return should match the snapshot 1`] = `
+Object {
+  "tid": 35,
+  "val": "507f1f77bcf86cd799439011",
+}
+`;
+
+exports[`Omnitracking track events definitions \`Sign-up Form Viewed\` return should match the snapshot 1`] = `
+Object {
+  "tid": 10097,
+  "val": "{\\"type\\":\\"REGISTER\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
+}
+`;
+
+exports[`Omnitracking track events definitions \`pageDefinitions\` should match snapshot 1`] = `
 Object {
   "CheckoutPageVisited": Array [
     "abTests",
@@ -444,7 +491,7 @@ Object {
 }
 `;
 
-exports[`Omnitracking definitions \`pageEventsFilter\` should match snapshot 1`] = `
+exports[`Omnitracking track events definitions \`pageEventsFilter\` should match snapshot 1`] = `
 Object {
   "CheckoutPageVisited": Array [
     "checkout",
@@ -472,7 +519,7 @@ Object {
 }
 `;
 
-exports[`Omnitracking definitions \`trackDefinitions\` should match snapshot 1`] = `
+exports[`Omnitracking track events definitions \`trackDefinitions\` should match snapshot 1`] = `
 Array [
   "accessTier",
   "actionArea",
@@ -563,27 +610,4 @@ Array [
   "val",
   "tid",
 ]
-`;
-
-exports[`Omnitracking definitions \`trackEventsMapper\` should match snapshot 1`] = `
-Object {
-  "Checkout Step Viewed": Object {
-    "tid": 10097,
-    "type": "SUBMIT",
-  },
-  "Place Order Started": Object {
-    "tid": 10097,
-    "type": "TRANSACTION",
-  },
-  "Product Added to Cart": Object {
-    "tid": 16,
-  },
-  "Product Added to Wishlist": Object {
-    "tid": 35,
-  },
-  "Sign-up Form Viewed": Object {
-    "tid": 10097,
-    "type": "REGISTER",
-  },
-}
 `;

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
@@ -1,9 +1,9 @@
 import {
-  getEventValForEventData,
+  generatePaymentAttemptReferenceId,
   getPageEventFromLocation,
   getPlatformSpecificParameters,
+  getValParameterForEvent,
 } from '../omnitracking-helper';
-import eventTypes from '../../../types/eventTypes';
 import platformTypes from '../../../types/platformTypes';
 import trackTypes from '../../../types/trackTypes';
 
@@ -17,9 +17,25 @@ describe('getPageEventFromLocation', () => {
   });
 });
 
-describe('getEventValForEventData', () => {
-  it('should return null for an event that is not considered', () => {
-    expect(getEventValForEventData(eventTypes.SELECT_CONTENT)).toBe(null);
+describe('getValParameterForEvent', () => {
+  it('should return a stringified object', () => {
+    expect(getValParameterForEvent()).toBe('{}');
+    expect(getValParameterForEvent({ foo: 'bar' })).toBe('{"foo":"bar"}');
+  });
+});
+
+describe('generatePaymentAttemptReferenceId', () => {
+  it('Should return a string with the generated payment attempt reference ID', () => {
+    const mockPaymentAttemptReferenceId = '12345_123456789';
+
+    expect(
+      generatePaymentAttemptReferenceId({
+        user: {
+          localId: '12345',
+        },
+        timestamp: 123456789,
+      }),
+    ).toEqual(mockPaymentAttemptReferenceId);
   });
 });
 


### PR DESCRIPTION
## Description
Refactored the integration and combined two different mappers into one, so we can calculate parameters based on the event data object in a single point.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
