### PR TITLE
fix: remove condition from `useProductsList`

### DIFF
--- a/packages/react/src/products/hooks/useProductsList.ts
+++ b/packages/react/src/products/hooks/useProductsList.ts
@@ -72,7 +72,7 @@ const useProductsList: UseProductsList = ({
   );
 
   useEffect(() => {
-    if (slug !== undefined && !isFetched) {
+    if (slug !== undefined) {
       dispatch(
         isSetPage
           ? fetchSet(slug, query as SetQuery, { useCache, setProductsListHash })
@@ -82,15 +82,7 @@ const useProductsList: UseProductsList = ({
             }),
       );
     }
-  }, [
-    dispatch,
-    isFetched,
-    isSetPage,
-    query,
-    setProductsListHash,
-    slug,
-    useCache,
-  ]);
+  }, [dispatch, isSetPage, query, setProductsListHash, slug, useCache]);
 
   return {
     /**


### PR DESCRIPTION
## Description
The `useProductsList` hook was calling the fetch list action only if it wasn't fetched before, even
tho this logic might look correct, it isn't. We need to call `fetchListing/fetchSet` anyway because
these actions are responsible for checking if the list is fetched and, if that's the case, just
replace the active "hash" in the store. By not calling any action, the active "hash" was not being
updated and the selectors who use the default "hash" value to get info would return the wrong list's
value. 

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
