### PR TITLE
fix(redux): add missing reducers and selectors for activities endpoints

### DIFF
--- a/packages/core/src/orders/redux/__tests__/selectors.test.js
+++ b/packages/core/src/orders/redux/__tests__/selectors.test.js
@@ -131,6 +131,14 @@ describe('orders redux selectors', () => {
         error: null,
         isLoading: false,
       },
+      orderAvailableItemsActivities: {
+        error: null,
+        isLoading: false,
+      },
+      orderItemAvailableActivities: {
+        error: null,
+        isLoading: false,
+      },
     },
     entities: {
       courier: {
@@ -300,6 +308,54 @@ describe('orders redux selectors', () => {
       const spy = jest.spyOn(fromOrders, 'getDocuments');
 
       expect(selectors.getDocumentsError(mockState)).toBe(expectedResult);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('isAvailableItemsActivitiesLoading()', () => {
+    it('should get the orderAvailableItemsActivities isLoading property from state', () => {
+      const spy = jest.spyOn(fromOrders, 'getOrderAvailableItemsActivities');
+
+      expect(selectors.isAvailableItemsActivitiesLoading(mockState)).toEqual(
+        false,
+      );
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getAvailableItemsActivitiesError()', () => {
+    it('should get the orderAvailableItemsActivities error property from state', () => {
+      const expectedResult =
+        mockState.orders.orderAvailableItemsActivities.error;
+      const spy = jest.spyOn(fromOrders, 'getOrderAvailableItemsActivities');
+
+      expect(selectors.getAvailableItemsActivitiesError(mockState)).toBe(
+        expectedResult,
+      );
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('isOrderItemAvailableActivitiesLoading()', () => {
+    it('should get the orderAvailableItemsActivities isLoading property from state', () => {
+      const spy = jest.spyOn(fromOrders, 'getOrderItemAvailableActivities');
+
+      expect(
+        selectors.isOrderItemAvailableActivitiesLoading(mockState),
+      ).toEqual(false);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getOrderItemAvailableActivitiesError()', () => {
+    it('should get the orderAvailableItemsActivities error property from state', () => {
+      const expectedResult =
+        mockState.orders.orderAvailableItemsActivities.error;
+      const spy = jest.spyOn(fromOrders, 'getOrderItemAvailableActivities');
+
+      expect(selectors.getOrderItemAvailableActivitiesError(mockState)).toBe(
+        expectedResult,
+      );
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/core/src/orders/redux/reducer.js
+++ b/packages/core/src/orders/redux/reducer.js
@@ -37,6 +37,14 @@ const INITIAL_STATE = {
     error: null,
     isLoading: false,
   },
+  orderAvailableItemsActivities: {
+    error: null,
+    isLoading: false,
+  },
+  orderItemAvailableActivities: {
+    error: null,
+    isLoading: false,
+  },
 };
 
 const error = (state = INITIAL_STATE.error, action = {}) => {
@@ -45,11 +53,15 @@ const error = (state = INITIAL_STATE.error, action = {}) => {
     case actionTypes.GET_ORDER_RETURN_OPTIONS_FAILURE:
     case actionTypes.GET_ORDERS_FAILURE:
     case actionTypes.GET_TRACKINGS_FAILURE:
+    case actionTypes.GET_ORDER_AVAILABLE_ITEMS_ACTIVITIES_FAILURE:
+    case actionTypes.GET_ORDER_ITEM_AVAILABLE_ACTIVITIES_FAILURE:
       return action.payload.error;
     case actionTypes.GET_ORDER_DETAILS_REQUEST:
     case actionTypes.GET_ORDER_RETURN_OPTIONS_REQUEST:
     case actionTypes.GET_ORDERS_REQUEST:
     case actionTypes.GET_TRACKINGS_REQUEST:
+    case actionTypes.GET_ORDER_AVAILABLE_ITEMS_ACTIVITIES_REQUEST:
+    case actionTypes.GET_ORDER_ITEM_AVAILABLE_ACTIVITIES_REQUEST:
     case actionTypes.RESET_ORDERS:
       return INITIAL_STATE.error;
     default:
@@ -63,6 +75,8 @@ const isLoading = (state = INITIAL_STATE.isLoading, action = {}) => {
     case actionTypes.GET_ORDER_DETAILS_REQUEST:
     case actionTypes.GET_ORDER_RETURN_OPTIONS_REQUEST:
     case actionTypes.GET_TRACKINGS_REQUEST:
+    case actionTypes.GET_ORDER_AVAILABLE_ITEMS_ACTIVITIES_REQUEST:
+    case actionTypes.GET_ORDER_ITEM_AVAILABLE_ACTIVITIES_REQUEST:
       return true;
     case actionTypes.GET_ORDERS_FAILURE:
     case actionTypes.GET_ORDERS_SUCCESS:
@@ -72,6 +86,10 @@ const isLoading = (state = INITIAL_STATE.isLoading, action = {}) => {
     case actionTypes.GET_ORDER_RETURN_OPTIONS_SUCCESS:
     case actionTypes.GET_TRACKINGS_FAILURE:
     case actionTypes.GET_TRACKINGS_SUCCESS:
+    case actionTypes.GET_ORDER_AVAILABLE_ITEMS_ACTIVITIES_FAILURE:
+    case actionTypes.GET_ORDER_AVAILABLE_ITEMS_ACTIVITIES_SUCCESS:
+    case actionTypes.GET_ORDER_ITEM_AVAILABLE_ACTIVITIES_FAILURE:
+    case actionTypes.GET_ORDER_ITEM_AVAILABLE_ACTIVITIES_SUCCESS:
     case actionTypes.RESET_ORDERS:
       return INITIAL_STATE.isLoading;
     default:
@@ -361,6 +379,18 @@ export const documents = reducerFactory(
   actionTypes,
 );
 
+export const orderAvailableItemsActivities = reducerFactory(
+  'GET_ORDER_AVAILABLE_ITEMS_ACTIVITIES',
+  INITIAL_STATE.orderAvailableItemsActivities,
+  actionTypes,
+);
+
+export const orderItemAvailableActivities = reducerFactory(
+  ['GET_ORDER_ITEM_AVAILABLE_ACTIVITIES', 'POST_ORDER_ITEM_ACTIVITIES'],
+  INITIAL_STATE.orderItemAvailableActivities,
+  actionTypes,
+);
+
 const result = (state = INITIAL_STATE.result, action = {}) => {
   switch (action.type) {
     case actionTypes.GET_ORDERS_SUCCESS:
@@ -378,6 +408,10 @@ export const getOrderDetails = state => state.orderDetails;
 export const getOrderReturnOptions = state => state.orderReturnOptions;
 export const getTrackings = state => state.trackings;
 export const getDocuments = state => state.documents;
+export const getOrderAvailableItemsActivities = state =>
+  state.orderAvailableItemsActivities;
+export const getOrderItemAvailableActivities = state =>
+  state.orderItemAvailableActivities;
 
 /**
  * Reducer for orders state.
@@ -399,4 +433,6 @@ export default combineReducers({
   orderReturnOptions,
   trackings,
   documents,
+  orderAvailableItemsActivities,
+  orderItemAvailableActivities,
 });

--- a/packages/core/src/orders/redux/selectors.js
+++ b/packages/core/src/orders/redux/selectors.js
@@ -9,7 +9,9 @@ import {
   getDocuments,
   getError,
   getIsLoading,
+  getOrderAvailableItemsActivities,
   getOrderDetails,
+  getOrderItemAvailableActivities,
   getOrderReturnOptions,
   getOrdersList,
   getResult,
@@ -523,3 +525,51 @@ export const isDocumentsLoading = state => getDocuments(state.orders).isLoading;
  * @returns {object} Trackings operation error.
  */
 export const getDocumentsError = state => getDocuments(state.orders).error;
+
+/**
+ * Returns the loading status for the available items activities operations.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {boolean} Tracking Loading status.
+ */
+export const isAvailableItemsActivitiesLoading = state =>
+  getOrderAvailableItemsActivities(state.orders).isLoading;
+
+/**
+ * Returns the error for the available items activities operations.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {object} Trackings operation error.
+ */
+export const getAvailableItemsActivitiesError = state =>
+  getOrderAvailableItemsActivities(state.orders).error;
+
+/**
+ * Returns the loading status for the order item available activities operations.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {boolean} Tracking Loading status.
+ */
+export const isOrderItemAvailableActivitiesLoading = state =>
+  getOrderItemAvailableActivities(state.orders).isLoading;
+
+/**
+ * Returns the error for the order item available activities operations.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {object} Trackings operation error.
+ */
+export const getOrderItemAvailableActivitiesError = state =>
+  getOrderItemAvailableActivities(state.orders).error;


### PR DESCRIPTION
## Description
This adds missing reducers and selectors for activities endpoints

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
