### PR TITLE
fix(redux): add missing reducers and selectors for activities endpoint on next

### DIFF
--- a/packages/redux/src/orders/__tests__/selectors.test.ts
+++ b/packages/redux/src/orders/__tests__/selectors.test.ts
@@ -170,6 +170,54 @@ describe('orders redux selectors', () => {
     });
   });
 
+  describe('isAvailableItemsActivitiesLoading()', () => {
+    it('should get the orderAvailableItemsActivities isLoading property from state', () => {
+      const spy = jest.spyOn(fromOrders, 'getOrderAvailableItemsActivities');
+
+      expect(selectors.isAvailableItemsActivitiesLoading(mockState)).toEqual(
+        false,
+      );
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getAvailableItemsActivitiesError()', () => {
+    it('should get the orderAvailableItemsActivities error property from state', () => {
+      const expectedResult =
+        mockState.orders.orderAvailableItemsActivities.error;
+      const spy = jest.spyOn(fromOrders, 'getOrderAvailableItemsActivities');
+
+      expect(selectors.getAvailableItemsActivitiesError(mockState)).toBe(
+        expectedResult,
+      );
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('isOrderItemAvailableActivitiesLoading()', () => {
+    it('should get the orderAvailableItemsActivities isLoading property from state', () => {
+      const spy = jest.spyOn(fromOrders, 'getOrderItemAvailableActivities');
+
+      expect(
+        selectors.isOrderItemAvailableActivitiesLoading(mockState),
+      ).toEqual(false);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getOrderItemAvailableActivitiesError()', () => {
+    it('should get the orderAvailableItemsActivities error property from state', () => {
+      const expectedResult =
+        mockState.orders.orderAvailableItemsActivities.error;
+      const spy = jest.spyOn(fromOrders, 'getOrderItemAvailableActivities');
+
+      expect(selectors.getOrderItemAvailableActivitiesError(mockState)).toBe(
+        expectedResult,
+      );
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('getOrders()', () => {
     it('should get the orders from state', () => {
       const expectedResult = mockState.entities.orders;

--- a/packages/redux/src/orders/reducer.ts
+++ b/packages/redux/src/orders/reducer.ts
@@ -39,6 +39,14 @@ export const INITIAL_STATE: T.State = {
     error: null,
     isLoading: false,
   },
+  orderAvailableItemsActivities: {
+    error: null,
+    isLoading: false,
+  },
+  orderItemAvailableActivities: {
+    error: null,
+    isLoading: false,
+  },
 };
 
 const error = (
@@ -52,6 +60,8 @@ const error = (
     | T.FetchOrdersRequestAction
     | T.FetchTrackingsFailureAction
     | T.FetchTrackingsRequestAction
+    | T.FetchOrderAvailableItemsActivitiesAction
+    | T.FetchOrderItemAvailableActivitiesAction
     | T.ResetOrdersAction,
 ) => {
   switch (action.type) {
@@ -59,11 +69,15 @@ const error = (
     case actionTypes.FETCH_ORDER_RETURN_OPTIONS_FAILURE:
     case actionTypes.FETCH_ORDERS_FAILURE:
     case actionTypes.FETCH_TRACKINGS_FAILURE:
+    case actionTypes.FETCH_ORDER_AVAILABLE_ITEMS_ACTIVITIES_FAILURE:
+    case actionTypes.FETCH_ORDER_ITEM_AVAILABLE_ACTIVITIES_FAILURE:
       return action.payload.error;
     case actionTypes.FETCH_ORDER_DETAILS_REQUEST:
     case actionTypes.FETCH_ORDER_RETURN_OPTIONS_REQUEST:
     case actionTypes.FETCH_ORDERS_REQUEST:
     case actionTypes.FETCH_TRACKINGS_REQUEST:
+    case actionTypes.FETCH_ORDER_AVAILABLE_ITEMS_ACTIVITIES_REQUEST:
+    case actionTypes.FETCH_ORDER_ITEM_AVAILABLE_ACTIVITIES_REQUEST:
     case actionTypes.RESET_ORDERS:
       return INITIAL_STATE.error;
     default:
@@ -78,6 +92,8 @@ const isLoading = (
     | T.FetchOrderDetailsAction
     | T.FetchOrderReturnOptionsAction
     | T.FetchTrackingsAction
+    | T.FetchOrderItemAvailableActivitiesAction
+    | T.FetchOrderAvailableItemsActivitiesAction
     | T.ResetOrdersAction,
 ) => {
   switch (action.type) {
@@ -85,6 +101,8 @@ const isLoading = (
     case actionTypes.FETCH_ORDER_DETAILS_REQUEST:
     case actionTypes.FETCH_ORDER_RETURN_OPTIONS_REQUEST:
     case actionTypes.FETCH_TRACKINGS_REQUEST:
+    case actionTypes.FETCH_ORDER_AVAILABLE_ITEMS_ACTIVITIES_REQUEST:
+    case actionTypes.FETCH_ORDER_ITEM_AVAILABLE_ACTIVITIES_REQUEST:
       return true;
     case actionTypes.FETCH_ORDERS_FAILURE:
     case actionTypes.FETCH_ORDERS_SUCCESS:
@@ -94,6 +112,10 @@ const isLoading = (
     case actionTypes.FETCH_ORDER_RETURN_OPTIONS_SUCCESS:
     case actionTypes.FETCH_TRACKINGS_FAILURE:
     case actionTypes.FETCH_TRACKINGS_SUCCESS:
+    case actionTypes.FETCH_ORDER_AVAILABLE_ITEMS_ACTIVITIES_FAILURE:
+    case actionTypes.FETCH_ORDER_AVAILABLE_ITEMS_ACTIVITIES_SUCCESS:
+    case actionTypes.FETCH_ORDER_ITEM_AVAILABLE_ACTIVITIES_FAILURE:
+    case actionTypes.FETCH_ORDER_ITEM_AVAILABLE_ACTIVITIES_SUCCESS:
     case actionTypes.RESET_ORDERS:
       return INITIAL_STATE.isLoading;
     default:
@@ -375,6 +397,18 @@ export const documents = reducerFactory(
   actionTypes,
 );
 
+export const orderAvailableItemsActivities = reducerFactory(
+  'FETCH_ORDER_AVAILABLE_ITEMS_ACTIVITIES',
+  INITIAL_STATE.orderAvailableItemsActivities,
+  actionTypes,
+);
+
+export const orderItemAvailableActivities = reducerFactory(
+  ['FETCH_ORDER_ITEM_AVAILABLE_ACTIVITIES', 'ADD_ORDER_ITEM_ACTIVITIES'],
+  INITIAL_STATE.orderItemAvailableActivities,
+  actionTypes,
+);
+
 const result = (
   state = INITIAL_STATE.result,
   action: T.FetchOrdersSuccessAction,
@@ -402,6 +436,14 @@ export const getTrackings = (state: T.State): T.State['trackings'] =>
   state.trackings;
 export const getDocuments = (state: T.State): T.State['documents'] =>
   state.documents;
+export const getOrderAvailableItemsActivities = (
+  state: T.State,
+): T.State['orderAvailableItemsActivities'] =>
+  state.orderAvailableItemsActivities;
+export const getOrderItemAvailableActivities = (
+  state: T.State,
+): T.State['orderItemAvailableActivities'] =>
+  state.orderItemAvailableActivities;
 
 const reducer = combineReducers({
   error,
@@ -412,6 +454,8 @@ const reducer = combineReducers({
   orderReturnOptions,
   trackings,
   documents,
+  orderAvailableItemsActivities,
+  orderItemAvailableActivities,
 });
 
 /**

--- a/packages/redux/src/orders/selectors.ts
+++ b/packages/redux/src/orders/selectors.ts
@@ -9,7 +9,9 @@ import {
   getDocuments,
   getError,
   getIsLoading,
+  getOrderAvailableItemsActivities,
   getOrderDetails,
+  getOrderItemAvailableActivities,
   getOrderReturnOptions,
   getOrdersList,
   getResult,
@@ -519,3 +521,53 @@ export const isDocumentsLoading = (state: StoreState): boolean =>
  */
 export const getDocumentsError = (state: StoreState): Error =>
   getDocuments(state.orders).error;
+
+/**
+ * Returns the loading status for the available items activities operations.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {boolean} Tracking Loading status.
+ */
+export const isAvailableItemsActivitiesLoading = (state: StoreState): boolean =>
+  getOrderAvailableItemsActivities(state.orders).isLoading;
+
+/**
+ * Returns the error for the available items activities operations.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {object} Trackings operation error.
+ */
+export const getAvailableItemsActivitiesError = (state: StoreState): Error =>
+  getOrderAvailableItemsActivities(state.orders).error;
+
+/**
+ * Returns the loading status for the order item available activities operations.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {boolean} Tracking Loading status.
+ */
+export const isOrderItemAvailableActivitiesLoading = (
+  state: StoreState,
+): boolean => getOrderItemAvailableActivities(state.orders).isLoading;
+
+/**
+ * Returns the error for the order item available activities operations.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {object} Trackings operation error.
+ */
+export const getOrderItemAvailableActivitiesError = (
+  state: StoreState,
+): Error => getOrderItemAvailableActivities(state.orders).error;

--- a/packages/redux/src/orders/types/actions.types.ts
+++ b/packages/redux/src/orders/types/actions.types.ts
@@ -165,3 +165,42 @@ export interface ResetOrdersAction extends Action {
 export interface LogoutAction extends Action {
   type: typeof LOGOUT_SUCCESS;
 }
+
+/** Actions dispatched when the fetch order available items activities request is made. */
+export type FetchOrderAvailableItemsActivitiesAction =
+  | FetchOrderAvailableItemsActivitiesRequestAction
+  | FetchOrderAvailableItemsActivitiesSuccessAction
+  | FetchOrderAvailableItemsActivitiesFailureAction;
+
+export interface FetchOrderAvailableItemsActivitiesRequestAction
+  extends Action {
+  type: typeof actionTypes.FETCH_ORDER_AVAILABLE_ITEMS_ACTIVITIES_REQUEST;
+}
+export interface FetchOrderAvailableItemsActivitiesSuccessAction
+  extends Action {
+  type: typeof actionTypes.FETCH_ORDER_AVAILABLE_ITEMS_ACTIVITIES_SUCCESS;
+  payload: Payload;
+}
+export interface FetchOrderAvailableItemsActivitiesFailureAction
+  extends Action {
+  type: typeof actionTypes.FETCH_ORDER_AVAILABLE_ITEMS_ACTIVITIES_FAILURE;
+  payload: { error: Error };
+}
+
+/** Actions dispatched when the fetch order available items activities request is made. */
+export type FetchOrderItemAvailableActivitiesAction =
+  | FetchOrderItemAvailableActivitiesRequestAction
+  | FetchOrderItemAvailableActivitiesSuccessAction
+  | FetchOrderItemAvailableActivitiesFailureAction;
+
+export interface FetchOrderItemAvailableActivitiesRequestAction extends Action {
+  type: typeof actionTypes.FETCH_ORDER_ITEM_AVAILABLE_ACTIVITIES_REQUEST;
+}
+export interface FetchOrderItemAvailableActivitiesSuccessAction extends Action {
+  type: typeof actionTypes.FETCH_ORDER_ITEM_AVAILABLE_ACTIVITIES_SUCCESS;
+  payload: Payload;
+}
+export interface FetchOrderItemAvailableActivitiesFailureAction extends Action {
+  type: typeof actionTypes.FETCH_ORDER_ITEM_AVAILABLE_ACTIVITIES_FAILURE;
+  payload: { error: Error };
+}

--- a/packages/redux/src/orders/types/state.types.ts
+++ b/packages/redux/src/orders/types/state.types.ts
@@ -20,5 +20,7 @@ export type State = CombinedState<{
   ordersList: StateWithoutResult;
   trackings: StateWithoutResult;
   documents: StateWithoutResult;
+  orderAvailableItemsActivities: StateWithoutResult;
+  orderItemAvailableActivities: StateWithoutResult;
   [k: string]: unknown;
 }>;

--- a/tests/__fixtures__/orders/orders.fixtures.ts
+++ b/tests/__fixtures__/orders/orders.fixtures.ts
@@ -1732,6 +1732,14 @@ export const mockState = {
       error: null,
       isLoading: false,
     },
+    orderAvailableItemsActivities: {
+      error: null,
+      isLoading: false,
+    },
+    orderItemAvailableActivities: {
+      error: null,
+      isLoading: false,
+    },
   },
   entities: {
     courier: {


### PR DESCRIPTION
## Description
This adds missing reducers and selectors for activities endpoints on next

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
