### PR TITLE
feat(core): update order of components and fix ranking on merge strategy for commerce pages

### DIFF
--- a/tests/__fixtures__/contents/commercePages.fixtures.js
+++ b/tests/__fixtures__/contents/commercePages.fixtures.js
@@ -55,9 +55,16 @@ export const mockCommercePages = {
               name: 'test',
               displayOptions: {},
             },
+            content: {
+              type: 'html',
+              name: 'Listing Page Description 1',
+              displayOptions: {},
+              content:
+                '<p>What was once a keepsake from an island getaway has now become a permanent fixture in your jewellery collection thanks to Gigi Clozeau. Browsing her collection of anklets will keep you in the holiday mood all year round, so much so, you&#39;ll want one in every colour for every destination. Crafted from 18K gold, these delicate chains are perfectly accented with the addition of her signature resin beads in a mix of tropical colours. Browse Gigi Clozeau body jewellery below to be <em>vacay</em> ready at all times.</p>',
+            },
           },
-          customType: 'promotions',
-          name: 'promotions',
+          customType: 'article',
+          name: 'article',
           displayOptions: {},
         },
       ],
@@ -89,15 +96,45 @@ export const mockCommercePages = {
       publicationDate: '2021-08-20T15:38:20.6658783Z',
       components: [
         {
-          type: 'text',
-          name: 'Title 2',
+          type: 'custom',
+          fields: {
+            title: {
+              type: 'text',
+              value: 'Commerce Page 2',
+              name: 'test',
+              displayOptions: {},
+            },
+            content: {
+              type: 'html',
+              name: 'Listing Page Description 2',
+              displayOptions: {},
+              content:
+                '<h2>Whitelabel was born out of a deep love of fashion and a profound belief that fashion is an essential expression of individuality and what makes each of us unique.</h2>',
+            },
+          },
+          customType: 'simpleText',
+          name: 'simpleText',
           displayOptions: {},
         },
         {
-          type: 'html',
-          content:
-            '<p>What was once a keepsake from an island getaway has now become a permanent fixture in your jewellery collection thanks to Gigi Clozeau. Browsing her collection of anklets will keep you in the holiday mood all year round, so much so, you&#39;ll want one in every colour for every destination. Crafted from 18K gold, these delicate chains are perfectly accented with the addition of her signature resin beads in a mix of tropical colours. Browse Gigi Clozeau body jewellery below to be <em>vacay</em> ready at all times.</p>',
-          name: 'Listing Page Description 2',
+          type: 'custom',
+          fields: {
+            title: {
+              type: 'text',
+              value: 'Commerce Page 2',
+              name: 'test',
+              displayOptions: {},
+            },
+            content: {
+              type: 'html',
+              name: 'Listing Page Description 2',
+              displayOptions: {},
+              content:
+                '<p>What was once a keepsake from an island getaway has now become a permanent fixture in your jewellery collection thanks to Gigi Clozeau. Browsing her collection of anklets will keep you in the holiday mood all year round, so much so, you&#39;ll want one in every colour for every destination. Crafted from 18K gold, these delicate chains are perfectly accented with the addition of her signature resin beads in a mix of tropical colours. Browse Gigi Clozeau body jewellery below to be <em>vacay</em> ready at all times.</p>',
+            },
+          },
+          customType: 'article',
+          name: 'article',
           displayOptions: {},
         },
       ],
@@ -151,7 +188,7 @@ export const mergeStrategyResult = {
       ...mockCommercePages.entries[0],
       components: [].concat(
         mockCommercePages.entries[0].components,
-        mockCommercePages.entries[1].components,
+        mockCommercePages.entries[1].components[0],
       ),
     },
   ],


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->
A new method to centralize ranking method that gives a list of commerce pages ordered by their rankings, the best one on first.
On default strategy returns the first result of it and on merge, it uses the order of ranked pages to list components based on it.

Mock tests changed to reflect the actual components structure and the merge strategy

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
