### PR TITLE
fix(core): add `groupsOn` to the sizes facet's entity id

### DIFF
--- a/packages/redux/src/entities/schemas/facet.ts
+++ b/packages/redux/src/entities/schemas/facet.ts
@@ -5,8 +5,8 @@ const getId = (
   { description, type: parentType }: any,
 ) =>
   `${description.toLowerCase()}_${value}${
-    // Special scenario when the facet type is "size by category"
-    parentType === 24 ? `_${groupsOn}` : ''
+    // Special scenario when the facet type is "sizes" or "size by category"
+    parentType === 9 || parentType === 24 ? `_${groupsOn}` : ''
   }${valueUpperBound > 0 ? `_${valueUpperBound}` : ''}`;
 
 export default new schema.Entity(


### PR DESCRIPTION
## Description

This adds the `groupsOn` value to the facet entity id for sizes, which fixes a bug of
having wrong descriptions of sizes. Since each size facet can have different descriptions
according to what category it belongs to (hence the `groupsOn`, which has a category id as its
value), there is the need to add the `groupsOn` to turn the entity id unique, despite of the
facet id.

For example, the the entity `sizes_17` could have both the values `36` or `XS`,
depending on the listing the user is. This would result in a bug when navigating between cached
listings, where the previous value for a given entity was kept, displaying the wrong descriptions
(like keeping `XS` for shoes). With this change, the entity id is now `sizes_17_<groupsOn>`, just
like the "sizes by category" already does.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
