### PR TITLE
chore: add create github release and send email workflows

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -1,0 +1,61 @@
+on:
+  push:
+    tags:
+      - '**'
+
+name: Create Release
+
+jobs:
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Parse semver string
+        id: semver_parser 
+        uses: booxmedialtd/ws-action-parse-semver@v1
+        with:
+         input_string: ${{ github.ref }}  
+         version_extractor_regex: '([0-9]+.[0-9]+.[0-9]+.*)$' # The regexp must contain a capture group containing the version expression, i.e., the parenthesis are needed
+      - name: Use parsed semver # Print parsed semver data for debugging
+        run: |
+            echo "${{ steps.semver_parser.outputs.major }}"
+            echo "${{ steps.semver_parser.outputs.minor }}"
+            echo "${{ steps.semver_parser.outputs.patch }}"
+            echo "${{ steps.semver_parser.outputs.prerelease }}"
+            echo "${{ steps.semver_parser.outputs.build }}"
+            echo "${{ steps.semver_parser.outputs.fullversion }}"
+      - name: Exit early if it is a prerelease # Hack to exit the workflow when it is a prerelease. This is because Github Actions does not allow to abort workflow early
+        if: steps.semver_parser.outputs.prerelease != ''
+        run: exit 1
+      - name: Get package name # Get the package name from the tag so we can find the correct changelog file
+        id: get_package_name
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const regex = /blackout-(.*)@/g;
+            return regex.exec(context.ref)[1];
+      - name: Test package name # Print obtained package name for debugging only 
+        run: |
+            echo "package name is: ${{ steps.get_package_name.outputs.result }}"
+      - name: Extract release notes # This step will retrieve the last entry from the changelog
+        id: extract_release_notes
+        uses: ffurrer2/extract-release-notes@v1
+        with:
+          changelog_file: "./packages/${{ steps.get_package_name.outputs.result }}/CHANGELOG.md"
+      - name: Test release notes # Print the extracted release notes for debugging
+        run: |
+          echo "release notes are: ${{ steps.extract_release_notes.outputs.release_notes }}"
+      - name: Create Release # Create release in github
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: ${{ steps.extract_release_notes.outputs.release_notes }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/SendEmail.yml
+++ b/.github/workflows/SendEmail.yml
@@ -1,0 +1,36 @@
+on:
+  release:
+    types: [published]
+
+name: Send email with release notes
+
+jobs:
+  send_email:
+    name: Send email with release notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send mail
+        uses: dawidd6/action-send-mail@v3
+        with:
+          # Required mail server address:
+          server_address: ${{ secrets.EMAIL_SERVER_ADDRESS }}
+          # Required mail server port:
+          server_port: ${{ secrets.EMAIL_SERVER_PORT }}
+          # Required username
+          username: ${{ secrets.EMAIL_ACCOUNT_USERNAME }}
+          # Required password
+          password: ${{ secrets.EMAIL_ACCOUNT_PASSWORD }}
+          # Required mail subject. Will be the release name.
+          subject: ${{ github.event.release.name }}
+          # Required recipients' addresses:
+          to: ${{ secrets.EMAIL_RECIPIENTS }}
+          # Required sender full name (address can be skipped):
+          from: ${{ secrets.EMAIL_FROM }}
+          # Optional whether this connection use TLS (default is true if server_port is 465)
+          secure: true
+          # Optional HTML body: Body of the release converted to markdown by use of the option 'convert_markdown'.
+          html_body: ${{ github.event.release.body }}
+          # Optional unsigned/invalid certificates allowance:
+          ignore_cert: true
+          # Optional converting Markdown to HTML (set content_type to text/html too):
+          convert_markdown: true


### PR DESCRIPTION
## Description

- This adds create github release and send email workflows to the
  project. The create github release workflow will create a github release
  whenever a tag for a non-prerelease version is pushed. The body of the
  release is composed of the last entry added to the changelog of the package
  indicated by the tag. The send email workflow will send an email containing
  the release notes of the release to the internal distribution list whenever a
  release is published. Note that as lerna might apply several tags depending
  on the released packages, it will generate as many emails as packages
  that were released when there is a merge to `main` branch.


<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

Closes #20 

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
