### PR TITLE
feat(core): add update and delete order item endpoints

### DIFF
--- a/packages/core/src/checkout/client/__fixtures__/deleteOrderItem.fixtures.js
+++ b/packages/core/src/checkout/client/__fixtures__/deleteOrderItem.fixtures.js
@@ -1,0 +1,24 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: params => {
+    moxios.stubRequest(
+      join('/api/checkout/v1/orders/', params.id, 'items', params.itemId),
+      {
+        method: 'delete',
+        status: 200,
+      },
+    );
+  },
+  failure: params => {
+    moxios.stubRequest(
+      join('/api/checkout/v1/orders/', params.id, 'items', params.itemId),
+      {
+        method: 'delete',
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/core/src/checkout/client/__fixtures__/patchOrderItem.fixtures.js
+++ b/packages/core/src/checkout/client/__fixtures__/patchOrderItem.fixtures.js
@@ -1,0 +1,24 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: params => {
+    moxios.stubRequest(
+      join('/api/checkout/v1/orders/', params.id, 'items', params.itemId),
+      {
+        method: 'patch',
+        status: 200,
+      },
+    );
+  },
+  failure: params => {
+    moxios.stubRequest(
+      join('/api/checkout/v1/orders/', params.id, 'items', params.itemId),
+      {
+        method: 'patch',
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/core/src/checkout/client/__tests__/__snapshots__/deleteOrderItem.test.js.snap
+++ b/packages/core/src/checkout/client/__tests__/__snapshots__/deleteOrderItem.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deleteOrderItem should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/checkout/client/__tests__/__snapshots__/patchOrderItem.test.js.snap
+++ b/packages/core/src/checkout/client/__tests__/__snapshots__/patchOrderItem.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`patchOrderItem should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/checkout/client/__tests__/deleteOrderItem.test.js
+++ b/packages/core/src/checkout/client/__tests__/deleteOrderItem.test.js
@@ -1,0 +1,43 @@
+import * as checkoutClient from '..';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/deleteOrderItem.fixtures';
+import moxios from 'moxios';
+
+describe('deleteOrderItem', () => {
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  const spy = jest.spyOn(client, 'delete');
+  const expectedConfig = undefined;
+  const id = '123456';
+  const itemId = 37445623;
+  const urlToBeCalled = `/checkout/v1/orders/${id}/items/${itemId}`;
+
+  it('should handle a client request successfully', async () => {
+    fixtures.success({
+      id,
+      itemId,
+    });
+
+    expect.assertions(2);
+    await expect(checkoutClient.deleteOrderItem(id, itemId)).resolves.toBe(200);
+    expect(spy).toHaveBeenCalledWith(urlToBeCalled, expectedConfig);
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure({
+      id,
+      itemId,
+    });
+
+    expect.assertions(2);
+    await expect(
+      checkoutClient.deleteOrderItem(id, itemId),
+    ).rejects.toMatchSnapshot();
+    expect(spy).toHaveBeenCalledWith(urlToBeCalled, expectedConfig);
+  });
+});

--- a/packages/core/src/checkout/client/__tests__/patchOrderItem.test.js
+++ b/packages/core/src/checkout/client/__tests__/patchOrderItem.test.js
@@ -1,0 +1,58 @@
+import * as checkoutClient from '..';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/patchOrderItem.fixtures';
+import moxios from 'moxios';
+
+describe('patchOrderItem', () => {
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  const spy = jest.spyOn(client, 'patch');
+  const expectedConfig = undefined;
+  const id = '123456';
+  const itemId = 37445623;
+  const orderItemUpdateData = {
+    quantity: 5,
+  };
+  const urlToBeCalled = `/checkout/v1/orders/${id}/items/${itemId}`;
+
+  it('should handle a client request successfully', async () => {
+    fixtures.success({
+      id,
+      itemId,
+      orderItemUpdateData,
+    });
+
+    expect.assertions(2);
+    await expect(
+      checkoutClient.patchOrderItem(id, itemId, orderItemUpdateData),
+    ).resolves.toBe(200);
+    expect(spy).toHaveBeenCalledWith(
+      urlToBeCalled,
+      orderItemUpdateData,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure({
+      id,
+      itemId,
+      orderItemUpdateData,
+    });
+
+    expect.assertions(2);
+    await expect(
+      checkoutClient.patchOrderItem(id, itemId, orderItemUpdateData),
+    ).rejects.toMatchSnapshot();
+    expect(spy).toHaveBeenCalledWith(
+      urlToBeCalled,
+      orderItemUpdateData,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/checkout/client/deleteOrderItem.js
+++ b/packages/core/src/checkout/client/deleteOrderItem.js
@@ -1,0 +1,21 @@
+import client, { adaptError } from '../../helpers/client';
+
+/**
+ * Deletes order item.
+ *
+ * @function deleteOrderItem
+ * @memberof module:checkout/client
+ * @param {string} id - Identifier of the checkout order.
+ * @param {string} itemId - Identifier of the order item.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ * @returns {Promise} Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+export default (id, itemId, config) =>
+  client
+    .delete(`/checkout/v1/orders/${id}/items/${itemId}`, config)
+    .then(response => response.status)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/checkout/client/index.js
+++ b/packages/core/src/checkout/client/index.js
@@ -6,20 +6,22 @@
  * @subcategory Clients
  */
 
+export { default as deleteOrderItem } from './deleteOrderItem';
+export { default as getCharges } from './getCharges';
 export { default as getCheckout } from './getCheckout';
 export { default as getCheckoutDetails } from './getCheckoutDetails';
 export { default as getCollectPoints } from './getCollectPoints';
 export { default as getDeliveryBundleUpgrades } from './getDeliveryBundleUpgrades.js';
 export { default as getItemDeliveryProvisioning } from './getItemDeliveryProvisioning.js';
-export { default as getOperations } from './getOperations.js';
 export { default as getOperation } from './getOperation.js';
+export { default as getOperations } from './getOperations.js';
 export { default as getUpgradeItemDeliveryProvisioning } from './getUpgradeItemDeliveryProvisioning.js';
 export { default as patchCheckout } from './patchCheckout';
+export { default as patchCheckoutCompletePayment } from './patchCheckoutCompletePayment';
 export { default as patchDeliveryBundleUpgrade } from './patchDeliveryBundleUpgrade.js';
 export { default as patchDeliveryBundleUpgrades } from './patchDeliveryBundleUpgrades.js';
-export { default as patchCheckoutCompletePayment } from './patchCheckoutCompletePayment';
 export { default as patchGiftMessage } from './patchGiftMessage';
-export { default as getCharges } from './getCharges';
+export { default as patchOrderItem } from './patchOrderItem';
 export { default as postCharges } from './postCharges';
 export { default as postCheckout } from './postCheckout';
 export { default as putItemTags } from './putItemTags';

--- a/packages/core/src/checkout/client/patchOrderItem.js
+++ b/packages/core/src/checkout/client/patchOrderItem.js
@@ -1,0 +1,27 @@
+import client, { adaptError } from '../../helpers/client';
+
+/**
+ * Applies updates to order item.
+ *
+ * @function patchOrderItem
+ * @memberof module:checkout/client
+ * @param {string} id - Identifier of the checkout order.
+ * @param {string} itemId - Identifier of the order item.
+ * @param {object} orderItemUpdateData - Data to update order item
+ * For example { "quantity": 2 } to update order item quantity.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ * @returns {Promise} Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+export default (id, itemId, orderItemUpdateData, config) =>
+  client
+    .patch(
+      `/checkout/v1/orders/${id}/items/${itemId}`,
+      orderItemUpdateData,
+      config,
+    )
+    .then(response => response.status)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/checkout/redux/__fixtures__/checkoutSelector.fixtures.js
+++ b/packages/core/src/checkout/redux/__fixtures__/checkoutSelector.fixtures.js
@@ -191,6 +191,10 @@ export default {
       error: null,
       isLoading: false,
     },
+    orderItem: {
+      error: null,
+      isLoading: false,
+    },
   },
   entities: {
     checkout: { [checkoutId]: checkoutEntity },

--- a/packages/core/src/checkout/redux/__tests__/reducer.test.js
+++ b/packages/core/src/checkout/redux/__tests__/reducer.test.js
@@ -860,6 +860,7 @@ describe('checkout reducer', () => {
       upgradeItemDeliveryProvisioning: { ...subAreaResult },
       operations: { ...subAreaResult },
       operation: { ...subAreaResult },
+      orderItem: { ...subAreaResult },
     };
 
     const subAreaNames = [
@@ -876,6 +877,7 @@ describe('checkout reducer', () => {
       'UpgradeItemDeliveryProvisioning',
       'Operations',
       'Operation',
+      'OrderItem',
     ];
 
     it.each(subAreaNames)(

--- a/packages/core/src/checkout/redux/__tests__/selectors.test.js
+++ b/packages/core/src/checkout/redux/__tests__/selectors.test.js
@@ -413,6 +413,7 @@ describe('checkout redux selectors', () => {
       'UpgradeItemDeliveryProvisioning',
       'Operations',
       'Operation',
+      'OrderItem',
     ];
 
     describe('sub-areas loading selectors', () => {

--- a/packages/core/src/checkout/redux/actionTypes.js
+++ b/packages/core/src/checkout/redux/actionTypes.js
@@ -76,6 +76,26 @@ export const GET_OPERATION_REQUEST =
 export const GET_OPERATION_SUCCESS =
   '@farfetch/blackout-core/GET_OPERATION_SUCCESS';
 
+/** Action type dispatched when the update order item request fails. */
+export const UPDATE_ORDER_ITEM_FAILURE =
+  '@farfetch/blackout-core/UPDATE_ORDER_ITEM_FAILURE';
+/** Action type dispatched when the update order item request starts. */
+export const UPDATE_ORDER_ITEM_REQUEST =
+  '@farfetch/blackout-core/UPDATE_ORDER_ITEM_REQUEST';
+/** Action type dispatched when the update order item request succeeds. */
+export const UPDATE_ORDER_ITEM_SUCCESS =
+  '@farfetch/blackout-core/UPDATE_ORDER_ITEM_SUCCESS';
+
+/** Action type dispatched when the delete order item request fails. */
+export const DELETE_ORDER_ITEM_FAILURE =
+  '@farfetch/blackout-core/DELETE_ORDER_ITEM_FAILURE';
+/** Action type dispatched when the delete order item request starts. */
+export const DELETE_ORDER_ITEM_REQUEST =
+  '@farfetch/blackout-core/DELETE_ORDER_ITEM_REQUEST';
+/** Action type dispatched when the delete order item request succeeds. */
+export const DELETE_ORDER_ITEM_SUCCESS =
+  '@farfetch/blackout-core/DELETE_ORDER_ITEM_SUCCESS';
+
 /** Action type dispatched when reseting the checkout. */
 export const RESET_CHECKOUT = '@farfetch/blackout-core/RESET_CHECKOUT';
 

--- a/packages/core/src/checkout/redux/actions/__tests__/__snapshots__/doDeleteOrderItem.test.js.snap
+++ b/packages/core/src/checkout/redux/actions/__tests__/__snapshots__/doDeleteOrderItem.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doDeleteOrderItem() action creator should create the correct actions for when the delete order item procedure is successful: delete order item success payload 1`] = `
+Object {
+  "meta": Object {
+    "itemId": "8234758754",
+  },
+  "type": "@farfetch/blackout-core/DELETE_ORDER_ITEM_SUCCESS",
+}
+`;

--- a/packages/core/src/checkout/redux/actions/__tests__/__snapshots__/doUpdateOrderItem.test.js.snap
+++ b/packages/core/src/checkout/redux/actions/__tests__/__snapshots__/doUpdateOrderItem.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doUpdateOrderItem() action creator should create the correct actions for when the update order item procedure is successful: update order item success payload 1`] = `
+Object {
+  "type": "@farfetch/blackout-core/UPDATE_ORDER_ITEM_SUCCESS",
+}
+`;

--- a/packages/core/src/checkout/redux/actions/__tests__/doDeleteOrderItem.test.js
+++ b/packages/core/src/checkout/redux/actions/__tests__/doDeleteOrderItem.test.js
@@ -1,0 +1,74 @@
+import { checkoutId } from '../../__fixtures__/checkout.fixtures';
+import { mockStore } from '../../../../../tests';
+import doDeleteOrderItem from '../doDeleteOrderItem';
+import find from 'lodash/find';
+import reducer, { actionTypes } from '../..';
+
+describe('doDeleteOrderItem() action creator', () => {
+  const checkoutMockStore = (state = {}) =>
+    mockStore({ checkout: reducer() }, state);
+  const deleteOrderItem = jest.fn();
+  const action = doDeleteOrderItem(deleteOrderItem);
+  const itemId = '8234758754';
+  const expectedConfig = undefined;
+  let store;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = checkoutMockStore();
+  });
+
+  it('should create the correct actions for when the delete order item procedure fails', async () => {
+    const expectedError = new Error('delete order item error');
+
+    deleteOrderItem.mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(checkoutId, itemId));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(deleteOrderItem).toHaveBeenCalledTimes(1);
+      expect(deleteOrderItem).toHaveBeenCalledWith(
+        checkoutId,
+        itemId,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.DELETE_ORDER_ITEM_REQUEST },
+          {
+            type: actionTypes.DELETE_ORDER_ITEM_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the delete order item procedure is successful', async () => {
+    await store.dispatch(action(checkoutId, itemId));
+
+    const actionResults = store.getActions();
+
+    expect.assertions(4);
+    expect(deleteOrderItem).toHaveBeenCalledTimes(1);
+    expect(deleteOrderItem).toHaveBeenCalledWith(
+      checkoutId,
+      itemId,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.DELETE_ORDER_ITEM_REQUEST },
+      {
+        meta: { itemId },
+        type: actionTypes.DELETE_ORDER_ITEM_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.DELETE_ORDER_ITEM_SUCCESS,
+      }),
+    ).toMatchSnapshot('delete order item success payload');
+  });
+});

--- a/packages/core/src/checkout/redux/actions/__tests__/doUpdateOrderItem.test.js
+++ b/packages/core/src/checkout/redux/actions/__tests__/doUpdateOrderItem.test.js
@@ -1,0 +1,79 @@
+import { checkoutId } from '../../__fixtures__/checkout.fixtures';
+import { mockStore } from '../../../../../tests';
+import doUpdateOrderItem from '../doUpdateOrderItem';
+import find from 'lodash/find';
+import reducer, { actionTypes } from '../..';
+
+describe('doUpdateOrderItem() action creator', () => {
+  const checkoutMockStore = (state = {}) =>
+    mockStore({ checkout: reducer() }, state);
+  const patchOrderItem = jest.fn();
+  const action = doUpdateOrderItem(patchOrderItem);
+  const itemId = '8234758754';
+  const orderItemUpdateData = {
+    quantity: 3,
+  };
+
+  const expectedConfig = undefined;
+  let store;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = checkoutMockStore();
+  });
+
+  it('should create the correct actions for when the update order item procedure fails', async () => {
+    const expectedError = new Error('update order item error');
+
+    patchOrderItem.mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(checkoutId, itemId, orderItemUpdateData));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(patchOrderItem).toHaveBeenCalledTimes(1);
+      expect(patchOrderItem).toHaveBeenCalledWith(
+        checkoutId,
+        itemId,
+        orderItemUpdateData,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.UPDATE_ORDER_ITEM_REQUEST },
+          {
+            type: actionTypes.UPDATE_ORDER_ITEM_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the update order item procedure is successful', async () => {
+    await store.dispatch(action(checkoutId, itemId, orderItemUpdateData));
+
+    const actionResults = store.getActions();
+
+    expect.assertions(4);
+    expect(patchOrderItem).toHaveBeenCalledTimes(1);
+    expect(patchOrderItem).toHaveBeenCalledWith(
+      checkoutId,
+      itemId,
+      orderItemUpdateData,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.UPDATE_ORDER_ITEM_REQUEST },
+      {
+        type: actionTypes.UPDATE_ORDER_ITEM_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.UPDATE_ORDER_ITEM_SUCCESS,
+      }),
+    ).toMatchSnapshot('update order item success payload');
+  });
+});

--- a/packages/core/src/checkout/redux/actions/doDeleteOrderItem.js
+++ b/packages/core/src/checkout/redux/actions/doDeleteOrderItem.js
@@ -1,0 +1,47 @@
+import {
+  DELETE_ORDER_ITEM_FAILURE,
+  DELETE_ORDER_ITEM_REQUEST,
+  DELETE_ORDER_ITEM_SUCCESS,
+} from '../actionTypes';
+
+/**
+ * @callback DeleteOrderItemThunkFactory
+ * @param {string} id - Universal identifier of the Checkout.
+ * @param {string} itemId - Identifier of the order item.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Method responsible for delete checkout order item.
+ *
+ * @function doDeleteOrderItem
+ * @memberof module:checkout/actions
+ *
+ * @param {Function} deleteOrderItem - Delete order item client.
+ *
+ * @returns {DeleteOrderItemThunkFactory} Thunk factory.
+ */
+export default deleteOrderItem => (id, itemId, config) => async dispatch => {
+  dispatch({
+    type: DELETE_ORDER_ITEM_REQUEST,
+  });
+
+  try {
+    await deleteOrderItem(id, itemId, config);
+
+    dispatch({
+      meta: { itemId },
+      type: DELETE_ORDER_ITEM_SUCCESS,
+    });
+  } catch (error) {
+    dispatch({
+      payload: { error },
+      type: DELETE_ORDER_ITEM_FAILURE,
+    });
+
+    throw error;
+  }
+};

--- a/packages/core/src/checkout/redux/actions/doUpdateOrderItem.js
+++ b/packages/core/src/checkout/redux/actions/doUpdateOrderItem.js
@@ -1,0 +1,50 @@
+import {
+  UPDATE_ORDER_ITEM_FAILURE,
+  UPDATE_ORDER_ITEM_REQUEST,
+  UPDATE_ORDER_ITEM_SUCCESS,
+} from '../actionTypes';
+
+/**
+ * @callback UpdateOrderItemThunkFactory
+ * @param {string} id - Universal identifier of the Checkout.
+ * @param {string} itemId - Identifier of the order item.
+ * @param {object} orderItemUpdateData - Data to update order item.
+ * For example { "quantity": 2 } to update order item quantity.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Method responsible for update checkout order item.
+ *
+ * @function doUpdateOrderItem
+ * @memberof module:checkout/actions
+ *
+ * @param {Function} patchOrderItem - Update order item client.
+ *
+ * @returns {UpdateOrderItemThunkFactory} Thunk factory.
+ */
+export default patchOrderItem =>
+  (id, itemId, orderItemUpdateData, config) =>
+  async dispatch => {
+    dispatch({
+      type: UPDATE_ORDER_ITEM_REQUEST,
+    });
+
+    try {
+      await patchOrderItem(id, itemId, orderItemUpdateData, config);
+
+      dispatch({
+        type: UPDATE_ORDER_ITEM_SUCCESS,
+      });
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: UPDATE_ORDER_ITEM_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/core/src/checkout/redux/actions/index.js
+++ b/packages/core/src/checkout/redux/actions/index.js
@@ -8,16 +8,16 @@
 
 export { default as doCompletePaymentCheckout } from './doCompletePaymentCheckout';
 export { default as doCreateCheckout } from './doCreateCheckout';
+export { default as doDeleteOrderItem } from './doDeleteOrderItem';
 export { default as doGetCheckout } from './doGetCheckout';
 export { default as doGetCheckoutDetails } from './doGetCheckoutDetails';
 export { default as doGetCollectPoints } from './doGetCollectPoints';
 export { default as doGetDeliveryBundleUpgrades } from './doGetDeliveryBundleUpgrades';
 export { default as doGetItemDeliveryProvisioning } from './doGetItemDeliveryProvisioning';
-export { default as doGetUpgradeItemDeliveryProvisioning } from './doGetUpgradeItemDeliveryProvisioning';
-export { default as doPostCharges } from './doPostCharges';
 export { default as doGetOperation } from './doGetOperation';
 export { default as doGetOperations } from './doGetOperations';
-export { default as reset } from './reset';
+export { default as doGetUpgradeItemDeliveryProvisioning } from './doGetUpgradeItemDeliveryProvisioning';
+export { default as doPostCharges } from './doPostCharges';
 export { default as doSetItemTags } from './doSetItemTags';
 export { default as doSetPromocode } from './doSetPromocode';
 export { default as doSetTags } from './doSetTags';
@@ -25,3 +25,5 @@ export { default as doUpdateCheckout } from './doUpdateCheckout';
 export { default as doUpdateDeliveryBundleUpgrade } from './doUpdateDeliveryBundleUpgrade';
 export { default as doUpdateDeliveryBundleUpgrades } from './doUpdateDeliveryBundleUpgrades';
 export { default as doUpdateGiftMessage } from './doUpdateGiftMessage';
+export { default as doUpdateOrderItem } from './doUpdateOrderItem';
+export { default as reset } from './reset';

--- a/packages/core/src/checkout/redux/reducer.js
+++ b/packages/core/src/checkout/redux/reducer.js
@@ -69,6 +69,10 @@ const INITIAL_STATE = {
     error: null,
     isLoading: false,
   },
+  orderItem: {
+    error: null,
+    isLoading: false,
+  },
 };
 
 const error = (state = INITIAL_STATE.error, action = {}) => {
@@ -396,6 +400,12 @@ export const operation = reducerFactory(
   actionTypes,
 );
 
+export const orderItem = reducerFactory(
+  ['UPDATE_ORDER_ITEM', 'DELETE_ORDER_ITEM'],
+  INITIAL_STATE.orderItem,
+  actionTypes,
+);
+
 export const getError = state => state.error;
 export const getId = state => state.id;
 export const getIsLoading = state => state.isLoading;
@@ -415,6 +425,7 @@ export const getUpgradeItemDeliveryProvisioning = state =>
   state.upgradeItemDeliveryProvisioning;
 export const getOperations = state => state.operations;
 export const getOperation = state => state.operation;
+export const getOrderItem = state => state.orderItem;
 
 /**
  * Reducer for checkout state.
@@ -444,4 +455,5 @@ export default combineReducers({
   upgradeItemDeliveryProvisioning,
   operations,
   operation,
+  orderItem,
 });

--- a/packages/core/src/checkout/redux/selectors.js
+++ b/packages/core/src/checkout/redux/selectors.js
@@ -18,6 +18,7 @@ import {
   getItemTags,
   getOperation,
   getOperations,
+  getOrderItem,
   getCharges as getPaidOrders,
   getPromoCode,
   getTags,
@@ -674,6 +675,29 @@ export const isOperationLoading = state =>
  * @returns {object} Operation error.
  */
 export const getOperationError = state => getOperation(state.checkout).error;
+
+/**
+ * Returns the loading status for the order item.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {boolean} Order Item Loading status.
+ */
+export const isOrderItemLoading = state =>
+  getOrderItem(state.checkout).isLoading;
+
+/**
+ * Returns the error for the order item.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {object} Order Item error.
+ */
+export const getOrderItemError = state => getOrderItem(state.checkout).error;
 
 /**
  * Returns the ISO date for the item delivery options.


### PR DESCRIPTION
## Description

We have added 2 new endpoints for order items:
- Update order item (to update the quantity of the item in the checkout order)
- Delete order item (to delete an item from the checkout order)

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
