### PR TITLE
chore: change lerna publish message

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     # Do not run if the pull request is a draft
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && !contains(github.event.commits[0].message, '[skip build]') }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -89,7 +89,7 @@ jobs:
           (github.event_name == 'pull_request' && startsWith(github.head_ref, 'rc/'))
         env:
           MAKE_RELEASE_COMMIT_MESSAGE: 'chore: make release'
-          PUBLISH_COMMIT_MESSAGE: 'chore: publish [skip ci]'
+          PUBLISH_COMMIT_MESSAGE: 'chore: publish [skip build]'
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.RELEASE_BOT_GIT_NAME }}


### PR DESCRIPTION
## Description

- This changes lerna publish message to replace [skip ci]
with [skip build] in order to allow the create github release workflow
to run. Also, a condition was added to abort any runs for commits that contain
[skip build] message.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
