### PR TITLE
chore(react): memoize queryCommerce and queryContent and improve fetchCommerce callback

### DIFF
--- a/packages/react/src/content/hooks/useCommercePage.js
+++ b/packages/react/src/content/hooks/useCommercePage.js
@@ -7,7 +7,7 @@ import {
 } from '@farfetch/blackout-core/contents/redux';
 import { getCommercePages as getCommerceClient } from '@farfetch/blackout-core/contents/client';
 import { useAction } from '../../utils';
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
@@ -35,32 +35,54 @@ import { useSelector } from 'react-redux';
  * @returns {object} - Returns actions and selectors for commerce page data.
  */
 export default (slug, params, pageIndex, pageSize, strategy = 'default') => {
-  const queryCommerce = {
-    type: params.type,
-    id: params?.id,
-    gender: params?.gender,
-    brand: params?.brand,
-    category: params?.category,
-    priceType: params?.priceType,
-    sku: params?.sku,
-    pageSize,
-    pageIndex,
-  };
-  const queryContent = {
-    codes: slug,
-    contentTypeCode: 'commerce_pages',
-    pageIndex,
-    pageSize,
-  };
+  const queryCommerce = useMemo(() => {
+    if (!params) {
+      return null;
+    }
+
+    return {
+      type: params.type,
+      id: params?.id,
+      gender: params?.gender,
+      brand: params?.brand,
+      category: params?.category,
+      priceType: params?.priceType,
+      sku: params?.sku,
+      pageSize,
+      pageIndex,
+    };
+  }, [pageIndex, pageSize, params]);
+
+  const queryContent = useMemo(() => {
+    if (!slug) {
+      return null;
+    }
+
+    return {
+      codes: slug,
+      contentTypeCode: 'commerce_pages',
+      pageIndex,
+      pageSize,
+    };
+  }, [pageIndex, pageSize, slug]);
+
   const error = useSelector(state => getContentError(state, queryContent));
   const isLoading = useSelector(state => isContentLoading(state, queryContent));
   const commercePage = useSelector(state => getContents(state, queryContent));
   const action = useAction(doGetCommercePages(getCommerceClient));
-  const fetchCommerce = () => action(queryCommerce, slug, strategy);
   const resetContent = useAction(resetContents);
+
+  const fetchCommerce = useCallback(() => {
+    if (!queryCommerce) {
+      return null;
+    }
+
+    return action(queryCommerce, slug, strategy);
+  }, [action, queryCommerce, slug, strategy]);
 
   useEffect(() => {
     !commercePage && fetchCommerce();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [commercePage, slug]);
 
   return {


### PR DESCRIPTION
## Description

- created because this PR was closed https://github.com/Farfetch/blackout/pull/221
- Memoized queryCommerce and queryContent constants to improve performance.
- Improved fetchCommerce callback with queryCommerce validation.

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
