### PR TITLE
fix(core): implement fallback commerce page metadata string

### DIFF
--- a/packages/core/src/contents/__tests__/utils.test.js
+++ b/packages/core/src/contents/__tests__/utils.test.js
@@ -44,6 +44,22 @@ describe('getPageRanking', () => {
 
     expect(ranking).toBe(expectedRanking);
   });
+
+  it('should correctly construct a ranking number for a specific metadata with custom as string', () => {
+    const metadata = {
+      custom: JSON.stringify({
+        gender: '1',
+        brand: '2450',
+        category: '',
+        priceType: '',
+        id: '',
+      }),
+    };
+    const expectedRanking = 110;
+    const ranking = getPageRanking(metadata);
+
+    expect(ranking).toBe(expectedRanking);
+  });
 });
 
 describe('getDefaultStrategy', () => {
@@ -71,6 +87,20 @@ describe('getRankedCommercePage', () => {
     const mergeStrategy = getRankedCommercePage(mockCommercePages, 'merge');
 
     expect(mergeStrategy).toMatchObject(mergeStrategyResult);
+  });
+
+  it('should warn user that content is legacy if custom metadata is string', () => {
+    console.warn = jest.fn();
+    const commercePages = mockCommercePages;
+    const metadataCustom = JSON.stringify(
+      commercePages.entries[0].metadata.custom,
+    );
+    commercePages.entries[0].metadata.custom = metadataCustom;
+    getRankedCommercePage(commercePages);
+
+    expect(console.warn)
+      .toHaveBeenCalledWith(`[Commerce Pages]: Seems you are trying to fetch legacy commerce page.
+      Try to republish the commerce page to update data.`);
   });
 });
 

--- a/packages/core/src/contents/utils.js
+++ b/packages/core/src/contents/utils.js
@@ -56,7 +56,11 @@ export const PRICETYPE = {
  */
 export const getPageRanking = metadata => {
   let ranking = 0;
-  const { gender, brand, category, priceType, id } = metadata.custom;
+  const metadataObj =
+    typeof metadata.custom === 'string'
+      ? JSON.parse(metadata.custom)
+      : metadata.custom;
+  const { gender, brand, category, priceType, id } = metadataObj;
 
   // Return default ranking number when no data was returned from each commerce property.
   // We can't only check if it's empty from 'metadata.custom' because it could have other properties inside.
@@ -70,7 +74,7 @@ export const getPageRanking = metadata => {
   const rankingPriceType = 1000000000;
   const rankingId = 10000000000;
 
-  Object.entries(metadata.custom).forEach(entry => {
+  Object.entries(metadataObj).forEach(entry => {
     const [key, value] = entry;
 
     switch (key) {
@@ -194,6 +198,13 @@ export const getMergeStrategy = result => {
  * Result of rankedPage === { entries: [...mergedPages] };
  */
 export const getRankedCommercePage = (result, strategy) => {
+  result.entries.map(commerce => {
+    if (typeof commerce?.metadata?.custom === 'string') {
+      console.warn(`[Commerce Pages]: Seems you are trying to fetch legacy commerce page.
+      Try to republish the commerce page to update data.`);
+    }
+  });
+
   switch (strategy) {
     case 'merge':
       return getMergeStrategy(result);


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->
When commerce page metadata custom is a string, warn the developer to republish content.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
