### PR TITLE
fix(blackout-core): fix doUpdateUserSubscriptions action

### DIFF
--- a/packages/core/src/subscriptions/client/__tests__/putSubscriptions.test.js
+++ b/packages/core/src/subscriptions/client/__tests__/putSubscriptions.test.js
@@ -33,31 +33,6 @@ describe('putSubscriptions', () => {
       },
     ],
   };
-  const response = {
-    id: '8c2b5c3e3acb4bdd9c26ba46',
-    topics: [
-      {
-        type: 'Latest_News',
-        channels: [
-          {
-            platform: 'email',
-            address: 'user1_test1@acme.com',
-            source: 'My Account',
-          },
-        ],
-      },
-      {
-        type: 'Promotions',
-        channels: [
-          {
-            platform: 'sms',
-            address: '919191919',
-            source: 'My Account',
-          },
-        ],
-      },
-    ],
-  };
   const spy = jest.spyOn(client, 'put');
 
   beforeEach(() => {
@@ -67,9 +42,9 @@ describe('putSubscriptions', () => {
   afterEach(() => moxios.uninstall(client));
 
   it('should handle a client request successfully', async () => {
-    fixtures.success(response);
+    fixtures.success(undefined);
 
-    await expect(putSubscriptions(data)).resolves.toBe(response);
+    await expect(putSubscriptions(data)).resolves.toBe(undefined);
 
     expect(spy).toHaveBeenCalledWith(
       '/marketing/v1/subscriptions',

--- a/packages/core/src/subscriptions/client/putSubscriptions.js
+++ b/packages/core/src/subscriptions/client/putSubscriptions.js
@@ -14,7 +14,7 @@ import client, { adaptError } from '../../helpers/client';
 export default (data, config) =>
   client
     .put('/marketing/v1/subscriptions', data, config)
-    .then(response => response.data)
+    .then(() => undefined)
     .catch(error => {
       throw adaptError(error);
     });

--- a/packages/core/src/subscriptions/redux/__fixtures__/storeSubscriptionsState.fixtures.js
+++ b/packages/core/src/subscriptions/redux/__fixtures__/storeSubscriptionsState.fixtures.js
@@ -67,6 +67,7 @@ export const mockUserSubscriptionsState = {
       success: true,
     },
   },
+  updateSubscriptionsError: null,
 };
 
 export default {

--- a/packages/core/src/subscriptions/redux/__tests__/selectors.test.js
+++ b/packages/core/src/subscriptions/redux/__tests__/selectors.test.js
@@ -30,6 +30,17 @@ describe('Subscriptions redux selectors', () => {
       });
     });
 
+    describe('getUpdateSubscriptionsError() ', () => {
+      it('Should get the update user subscriptions error property', () => {
+        const expectedResult =
+          mockState.subscriptions.user.updateSubscriptionsError;
+
+        expect(selectors.getUpdateSubscriptionsError(mockState)).toBe(
+          expectedResult,
+        );
+      });
+    });
+
     describe('getUserSubscriptions()', () => {
       it('Should get the user subscriptions result property', () => {
         const expectedResult = mockState.subscriptions.user.result;

--- a/packages/core/src/subscriptions/redux/actions/__tests__/doUpdateUserSubscriptions.test.js
+++ b/packages/core/src/subscriptions/redux/actions/__tests__/doUpdateUserSubscriptions.test.js
@@ -55,7 +55,6 @@ describe('Subscriptions redux actions', () => {
         { type: actionTypes.PUT_USER_SUBSCRIPTIONS_REQUEST },
         {
           type: actionTypes.PUT_USER_SUBSCRIPTIONS_SUCCESS,
-          payload: {},
         },
       ];
       const response = {};

--- a/packages/core/src/subscriptions/redux/actions/doUpdateUserSubscriptions.js
+++ b/packages/core/src/subscriptions/redux/actions/doUpdateUserSubscriptions.js
@@ -31,10 +31,9 @@ export default putSubscriptions =>
     });
 
     try {
-      const result = await putSubscriptions(data, config);
+      await putSubscriptions(data, config);
 
       dispatch({
-        payload: result,
         type: actionTypes.PUT_USER_SUBSCRIPTIONS_SUCCESS,
       });
     } catch (error) {

--- a/packages/core/src/subscriptions/redux/reducer/__tests__/user.test.js
+++ b/packages/core/src/subscriptions/redux/reducer/__tests__/user.test.js
@@ -13,6 +13,7 @@ import reducer, {
   getSubscriptionsError,
   getSubscriptionsIsLoading,
   getUnsubscribeRecipientFromTopicRequests,
+  getUpdateSubscriptionsError,
   INITIAL_STATE,
 } from '../user';
 
@@ -71,14 +72,43 @@ describe('User Subscriptions redux reducer', () => {
     });
   });
 
+  describe('updateSubscriptionsError() reducer', () => {
+    it(`should handle ${actionTypes.PUT_USER_SUBSCRIPTIONS_FAILURE} action type`, () => {
+      const expectedResult = 'This is an error';
+
+      expect(
+        reducer(mockUserSubscriptionsState, {
+          type: actionTypes.PUT_USER_SUBSCRIPTIONS_FAILURE,
+          payload: { error: expectedResult },
+        }).updateSubscriptionsError,
+      ).toBe(expectedResult);
+    });
+
+    it(`should handle ${actionTypes.PUT_USER_SUBSCRIPTIONS_REQUEST} action type`, () => {
+      expect(
+        reducer(mockUserSubscriptionsState, {
+          type: actionTypes.PUT_USER_SUBSCRIPTIONS_REQUEST,
+          payload: {},
+        }).updateSubscriptionsError,
+      ).toBe(INITIAL_STATE.updateSubscriptionsError);
+    });
+
+    it('should handle other actions by returning the previous state', () => {
+      const state = { updateSubscriptionsError: 'foo' };
+
+      expect(reducer(state).updateSubscriptionsError).toEqual(
+        state.updateSubscriptionsError,
+      );
+    });
+  });
+
   describe('result() reducer', () => {
     it(`should handle ${actionTypes.PUT_USER_SUBSCRIPTIONS_SUCCESS} action type`, () => {
       expect(
         reducer(mockUserSubscriptionsState, {
           type: actionTypes.PUT_USER_SUBSCRIPTIONS_SUCCESS,
-          payload: mockUserSubscriptionsState.result,
         }).result,
-      ).toEqual(mockUserSubscriptionsState.result);
+      ).toEqual(null);
     });
 
     it(`should handle ${actionTypes.GET_USER_SUBSCRIPTIONS_SUCCESS} action type`, () => {
@@ -488,6 +518,18 @@ describe('User Subscriptions redux reducer', () => {
           unsubscribeRecipientFromTopicRequests,
         }),
       ).toBe(unsubscribeRecipientFromTopicRequests);
+    });
+  });
+
+  describe('getUpdateSubscriptionsError() selector', () => {
+    it('should return updateSubscriptionsError state', () => {
+      const updateSubscriptionsError = {};
+
+      expect(
+        getUpdateSubscriptionsError({
+          updateSubscriptionsError,
+        }),
+      ).toBe(updateSubscriptionsError);
     });
   });
 });

--- a/packages/core/src/subscriptions/redux/reducer/user.js
+++ b/packages/core/src/subscriptions/redux/reducer/user.js
@@ -6,6 +6,7 @@ export const INITIAL_STATE = {
   isLoading: false,
   result: null,
   unsubscribeRecipientFromTopicRequests: {},
+  updateSubscriptionsError: null,
 };
 
 const error = (
@@ -21,6 +22,20 @@ const error = (
     case actionTypes.PUT_USER_SUBSCRIPTIONS_REQUEST:
     case actionTypes.UNSUBSCRIBE_ALL_SUBSCRIPTIONS_REQUEST:
       return INITIAL_STATE.error;
+    default:
+      return state;
+  }
+};
+
+const updateSubscriptionsError = (
+  state = INITIAL_STATE.updateSubscriptionsError,
+  /* istanbul ignore next */ action = {},
+) => {
+  switch (action.type) {
+    case actionTypes.PUT_USER_SUBSCRIPTIONS_FAILURE:
+      return action.payload.error;
+    case actionTypes.PUT_USER_SUBSCRIPTIONS_REQUEST:
+      return INITIAL_STATE.updateSubscriptionsError;
     default:
       return state;
   }
@@ -53,8 +68,9 @@ const result = (
 ) => {
   switch (action.type) {
     case actionTypes.GET_USER_SUBSCRIPTIONS_SUCCESS:
-    case actionTypes.PUT_USER_SUBSCRIPTIONS_SUCCESS:
       return action.payload;
+    case actionTypes.PUT_USER_SUBSCRIPTIONS_SUCCESS:
+      return INITIAL_STATE.result;
     case actionTypes.UNSUBSCRIBE_ALL_SUBSCRIPTIONS_SUCCESS:
       return INITIAL_STATE.result;
     case actionTypes.UNSUBSCRIBE_RECIPIENT_FROM_TOPIC_SUCCESS: {
@@ -214,10 +230,13 @@ export const getSubscriptionsIsLoading = state => state.isLoading;
 export const getSubscriptions = state => state.result;
 export const getUnsubscribeRecipientFromTopicRequests = state =>
   state.unsubscribeRecipientFromTopicRequests;
+export const getUpdateSubscriptionsError = state =>
+  state.updateSubscriptionsError;
 
 export default combineReducers({
   error,
   isLoading,
   result,
   unsubscribeRecipientFromTopicRequests,
+  updateSubscriptionsError,
 });

--- a/packages/core/src/subscriptions/redux/selectors.js
+++ b/packages/core/src/subscriptions/redux/selectors.js
@@ -16,6 +16,7 @@ import {
   getSubscriptionsError,
   getSubscriptionsIsLoading,
   getUnsubscribeRecipientFromTopicRequests as getUnsubscribeRecipientFromTopicRequestsReducer,
+  getUpdateSubscriptionsError as getUpdateSubscriptionsErrorFromReducer,
 } from './reducer/user';
 import defaultTo from 'lodash/defaultTo';
 import get from 'lodash/get';
@@ -31,6 +32,18 @@ import get from 'lodash/get';
  */
 export const getUserSubscriptionsError = state =>
   getSubscriptionsError(state.subscriptions.user);
+
+/**
+ * Returns the error when the update user subscriptions action fails.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {object | undefined} Error for the update subscription action.
+ */
+export const getUpdateSubscriptionsError = state =>
+  getUpdateSubscriptionsErrorFromReducer(state.subscriptions.user);
 
 /**
  * Returns the result of a user subscription.


### PR DESCRIPTION
## Description

This fixes the `doUpdateUserSubscriptions` action in order to reflect
the change made by the backend that changed the result of the put method
used by the action to not return the new subscriptions data and
instead requiring that a new get user subscriptions request be
performed to retrieve the updated data.
Additionally a new state for the error message of the
doGetUpdateUserSubscriptions action was added in order to allow the
consumer to differentiate the case when there was an error updating the
subscriptions and present a different error message.
To provide backwards compatibility, the previous `error` state was
maintained as well.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
