### PR TITLE
fix(core): unable to manage wishlist of an oos product

### DIFF
--- a/packages/core/src/helpers/adapters/__tests__/adaptAttributes.test.js
+++ b/packages/core/src/helpers/adapters/__tests__/adaptAttributes.test.js
@@ -10,6 +10,10 @@ describe('adaptAttributes()', () => {
     expect(adaptAttributes([])).toEqual({});
   });
 
+  it('should return an empty object when there is only one attribute', () => {
+    expect(adaptAttributes([{ name: 'Size' }])).toEqual({});
+  });
+
   it('should map attributes to the corresponding structure', () => {
     expect(
       adaptAttributes(sizeAttributes, productWithTwoSizes),

--- a/packages/core/src/helpers/adapters/adaptAttributes.js
+++ b/packages/core/src/helpers/adapters/adaptAttributes.js
@@ -13,7 +13,12 @@ import isEmpty from 'lodash/isEmpty';
  * @returns {object} Object with size attributes adapted.
  */
 export default (attributes, sizes) => {
-  if (isEmpty(attributes) && isEmpty(sizes)) {
+  // When a product is added to the wishlist with a size and the it becomes OOS
+  // the API instead of returning empty array of attributes, it returns one
+  // size attribute.
+  // Therefore we need to also return an empty object in this situation because
+  // an OOS product shouldn't have sizes.
+  if ((isEmpty(attributes) && isEmpty(sizes)) || attributes.length < 2) {
     return {};
   }
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

This PR solves the problem regarding a product that is added to the
wishlist with a size and then becomes OOS.
In this situation the API returns a wishlistItem with one size attribute
instead of an empty array so this solution passes by reproducing the same
login for one attribute array as for an empty attribute array.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
