### PR TITLE
fix(blackout-client|blackout-redux): fix updateUserSubscriptions action

### DIFF
--- a/packages/client/src/subscriptions/__fixtures__/putSubscriptions.fixtures.ts
+++ b/packages/client/src/subscriptions/__fixtures__/putSubscriptions.fixtures.ts
@@ -1,7 +1,7 @@
 import moxios from 'moxios';
 
 export default {
-  success: response => {
+  success: (response: unknown) => {
     moxios.stubRequest('/api/marketing/v1/subscriptions', {
       method: 'put',
       status: 200,

--- a/packages/client/src/subscriptions/__tests__/putSubscriptions.test.ts
+++ b/packages/client/src/subscriptions/__tests__/putSubscriptions.test.ts
@@ -14,10 +14,10 @@ describe('putSubscriptions', () => {
   afterEach(() => moxios.uninstall(client));
 
   it('should handle a client request successfully', async () => {
-    moxiosFixtures.success(mockPutSubscriptions.response);
+    moxiosFixtures.success(undefined);
 
     await expect(putSubscriptions(mockPutSubscriptions.data)).resolves.toBe(
-      mockPutSubscriptions.response,
+      undefined,
     );
 
     expect(spy).toHaveBeenCalledWith(

--- a/packages/client/src/subscriptions/deleteRecipientFromTopic.ts
+++ b/packages/client/src/subscriptions/deleteRecipientFromTopic.ts
@@ -5,9 +5,6 @@ import type { DeleteRecipientFromTopic } from './types';
 /**
  * Method responsible for sending a request to remove a recipient from a subscription topic to the MKT API.
  *
- * @function deleteRecipientFromTopic
- * @memberof module:subscriptions
- *
  * @param subscriptionId - Id of the subscription to be affected.
  * @param topicId - Id of topic to remove the recipient from.
  * @param recipientId - The id of the recipient to be removed.

--- a/packages/client/src/subscriptions/deleteSubscription.ts
+++ b/packages/client/src/subscriptions/deleteSubscription.ts
@@ -5,9 +5,6 @@ import type { DeleteSubscription } from './types';
 /**
  * Method responsible for sending a delete all subscriptions request to MKT API containing the subscription id and email hash of the user to be unsubscribed.
  *
- * @function deleteSubscription
- * @memberof module:subscriptions/client
- *
  * @param query - Query object.
  * @param config - Custom configurations to send to the client instance (axios).
  *

--- a/packages/client/src/subscriptions/getSubscriptionPackages.ts
+++ b/packages/client/src/subscriptions/getSubscriptionPackages.ts
@@ -5,9 +5,6 @@ import type { GetSubscriptionPackages } from './types';
 /**
  * Method responsible for retrieving all topics configured for the current tenant from the subscription packages endpoint on MKT API.
  *
- * @function getSubscriptionPackages
- * @memberof module:subscriptions
- *
  * @param query - Query parameters to apply.
  * @param config - Custom configurations to send to the client instance (axios).
  *

--- a/packages/client/src/subscriptions/getSubscriptions.ts
+++ b/packages/client/src/subscriptions/getSubscriptions.ts
@@ -5,9 +5,6 @@ import type { GetSubscriptions } from './types';
 /**
  * Method responsible for retrieving data from subscriptions endpoint on MKT API.
  *
- * @function getSubscriptions
- * @memberof module:subscriptions
- *
  * @param query - Query parameters to apply.
  * @param config - Custom configurations to send to the client instance (axios).
  *

--- a/packages/client/src/subscriptions/index.ts
+++ b/packages/client/src/subscriptions/index.ts
@@ -1,10 +1,3 @@
-/**
- * Subscriptions clients.
- *
- * @module subscriptions
- * @category Subscriptions
- */
-
 export { default as putSubscriptions } from './putSubscriptions';
 export { default as getSubscriptions } from './getSubscriptions';
 export { default as getSubscriptionPackages } from './getSubscriptionPackages';

--- a/packages/client/src/subscriptions/putSubscriptions.ts
+++ b/packages/client/src/subscriptions/putSubscriptions.ts
@@ -4,9 +4,6 @@ import type { PutSubscriptions } from './types';
 /**
  * Method responsible for putting data to subscriptions endpoint on MKT API.
  *
- * @function putSubscriptions
- * @memberof module:subscriptions
- *
  * @param data - Payload to be sent on the body of the put request.
  * @param config - Custom configurations to send to the client instance (axios).
  *
@@ -15,7 +12,7 @@ import type { PutSubscriptions } from './types';
 const putSubscriptions: PutSubscriptions = (data, config) => {
   return client
     .put('/marketing/v1/subscriptions', data, config)
-    .then(response => response.data)
+    .then(() => undefined)
     .catch(error => {
       throw adaptError(error);
     });

--- a/packages/client/src/subscriptions/types/putSubscriptions.types.ts
+++ b/packages/client/src/subscriptions/types/putSubscriptions.types.ts
@@ -1,7 +1,26 @@
 import type { Config } from '../../types';
-import type { Subscription } from '.';
+import type {
+  Subscription,
+  SubscriptionTopic,
+  SubscriptionTopicChannel,
+} from '.';
+
+type SubscriptionTopicChannelsWithoutId = Omit<SubscriptionTopicChannel, 'id'>;
+
+type SubscriptionTopicWithoutId = Omit<SubscriptionTopic, 'id'>;
+
+export type PutSubscriptionTopic = Omit<
+  SubscriptionTopicWithoutId,
+  'channels'
+> & {
+  channels: SubscriptionTopicChannelsWithoutId[];
+};
+
+export type PutSubscriptionsData = Omit<Subscription, 'topics'> & {
+  topics: PutSubscriptionTopic[];
+};
 
 export type PutSubscriptions = (
-  data: Subscription,
+  data: PutSubscriptionsData,
   config?: Config,
-) => Promise<Subscription[]>;
+) => Promise<void>;

--- a/packages/redux/src/entities/selectors/__tests__/entity.test.ts
+++ b/packages/redux/src/entities/selectors/__tests__/entity.test.ts
@@ -25,9 +25,10 @@ const state = {
 
 describe('getEntities()', () => {
   it('should throw an error if there is no valid state', () => {
+    // @ts-expect-error
     expect(getEntities(null, 'random')).toBeUndefined();
+    // @ts-expect-error
     expect(getEntities(undefined, 'random')).toBeUndefined();
-    // @ts-expect-error Need an invalid state to assert throwing the error
     expect(() => getEntities({}, 'random')).toThrow();
   });
 

--- a/packages/redux/src/subscriptions/__tests__/selectors.test.ts
+++ b/packages/redux/src/subscriptions/__tests__/selectors.test.ts
@@ -23,6 +23,17 @@ describe('Subscriptions redux selectors', () => {
       });
     });
 
+    describe('getUpdateSubscriptionsError() ', () => {
+      it('Should get the update user subscriptions error property', () => {
+        const expectedResult =
+          mockState.subscriptions.user.updateSubscriptionsError;
+
+        expect(selectors.getUpdateSubscriptionsError(mockState)).toBe(
+          expectedResult,
+        );
+      });
+    });
+
     describe('getSubscriptionPackagesError() ', () => {
       it('Should get the subscription packages error property', () => {
         expect(

--- a/packages/redux/src/subscriptions/actions/__tests__/__snapshots__/updateUserSubscriptions.test.ts.snap
+++ b/packages/redux/src/subscriptions/actions/__tests__/__snapshots__/updateUserSubscriptions.test.ts.snap
@@ -2,31 +2,6 @@
 
 exports[`Subscriptions redux actions updateUserSubscriptions() action creator Should create the correct actions when the user subscriptions' put request is successful: Update subscriptions success payload 1`] = `
 Object {
-  "payload": Object {
-    "id": "8c2b5c3e3acb4bdd9c26ba46",
-    "topics": Array [
-      Object {
-        "channels": Array [
-          Object {
-            "address": "user1_test1@acme.com",
-            "platform": "email",
-            "source": "My Account",
-          },
-        ],
-        "type": "Latest_News",
-      },
-      Object {
-        "channels": Array [
-          Object {
-            "address": "919191919",
-            "platform": "sms",
-            "source": "My Account",
-          },
-        ],
-        "type": "Promotions",
-      },
-    ],
-  },
   "type": "@farfetch/blackout-redux/UPDATE_USER_SUBSCRIPTIONS_SUCCESS",
 }
 `;

--- a/packages/redux/src/subscriptions/actions/__tests__/updateUserSubscriptions.test.ts
+++ b/packages/redux/src/subscriptions/actions/__tests__/updateUserSubscriptions.test.ts
@@ -51,8 +51,6 @@ describe('Subscriptions redux actions', () => {
     });
 
     it("Should create the correct actions when the user subscriptions' put request is successful", async () => {
-      putSubscriptions.mockResolvedValueOnce(mockPutSubscriptions.response);
-
       await store
         .dispatch(updateUserSubscriptions(mockPutSubscriptions.data))
         .then(clientResult => {
@@ -70,7 +68,6 @@ describe('Subscriptions redux actions', () => {
         { type: actionTypes.UPDATE_USER_SUBSCRIPTIONS_REQUEST },
         {
           type: actionTypes.UPDATE_USER_SUBSCRIPTIONS_SUCCESS,
-          payload: expect.any(Object),
         },
       ]);
       expect(

--- a/packages/redux/src/subscriptions/actions/factories/updateUserSubscriptionsFactory.ts
+++ b/packages/redux/src/subscriptions/actions/factories/updateUserSubscriptionsFactory.ts
@@ -20,13 +20,11 @@ const updateUserSubscriptionsFactory: UpdateUserSubscriptionsFactory<
   });
 
   try {
-    const result = await putSubscriptions(data, config);
+    await putSubscriptions(data, config);
 
     dispatch({
-      payload: result,
       type: actionTypes.UPDATE_USER_SUBSCRIPTIONS_SUCCESS,
     });
-    return result;
   } catch (error) {
     dispatch({
       payload: { error },

--- a/packages/redux/src/subscriptions/reducer/__tests__/user.test.ts
+++ b/packages/redux/src/subscriptions/reducer/__tests__/user.test.ts
@@ -24,17 +24,6 @@ describe('User Subscriptions redux reducer', () => {
   });
 
   describe('error() reducer', () => {
-    it(`should handle ${actionTypes.UPDATE_USER_SUBSCRIPTIONS_FAILURE} action type`, () => {
-      const expectedResult = 'This is an error';
-
-      expect(
-        reducer(mockUserSubscriptionsState, {
-          type: actionTypes.UPDATE_USER_SUBSCRIPTIONS_FAILURE,
-          payload: { error: expectedResult },
-        }).error,
-      ).toBe(expectedResult);
-    });
-
     it(`should handle ${actionTypes.FETCH_USER_SUBSCRIPTIONS_REQUEST} action type`, () => {
       expect(
         reducer(mockUserSubscriptionsState, {
@@ -76,14 +65,46 @@ describe('User Subscriptions redux reducer', () => {
     });
   });
 
+  describe('updateSubscriptionsError() reducer', () => {
+    it(`should handle ${actionTypes.UPDATE_USER_SUBSCRIPTIONS_FAILURE} action type`, () => {
+      const expectedResult = 'This is an error';
+
+      expect(
+        reducer(mockUserSubscriptionsState, {
+          type: actionTypes.UPDATE_USER_SUBSCRIPTIONS_FAILURE,
+          payload: { error: expectedResult },
+        }).updateSubscriptionsError,
+      ).toBe(expectedResult);
+    });
+
+    it(`should handle ${actionTypes.UPDATE_USER_SUBSCRIPTIONS_REQUEST} action type`, () => {
+      expect(
+        reducer(mockUserSubscriptionsState, {
+          type: actionTypes.UPDATE_USER_SUBSCRIPTIONS_REQUEST,
+          payload: {},
+        }).updateSubscriptionsError,
+      ).toBe(initialState.updateSubscriptionsError);
+    });
+
+    it('should handle other actions by returning the previous state', () => {
+      const state = {
+        ...mockUserSubscriptionsState,
+        updateSubscriptionsError: new Error('foo'),
+      };
+
+      expect(reducer(state, randomAction).updateSubscriptionsError).toEqual(
+        state.updateSubscriptionsError,
+      );
+    });
+  });
+
   describe('result() reducer', () => {
     it(`should handle ${actionTypes.UPDATE_USER_SUBSCRIPTIONS_SUCCESS} action type`, () => {
       expect(
         reducer(mockUserSubscriptionsState, {
           type: actionTypes.UPDATE_USER_SUBSCRIPTIONS_SUCCESS,
-          payload: mockUserSubscriptionsState.result,
         }).result,
-      ).toEqual(mockUserSubscriptionsState.result);
+      ).toEqual(initialState.result);
     });
 
     it(`should handle ${actionTypes.FETCH_USER_SUBSCRIPTIONS_SUCCESS} action type`, () => {
@@ -496,6 +517,19 @@ describe('User Subscriptions redux reducer', () => {
           unsubscribeRecipientFromTopicRequests,
         }),
       ).toBe(unsubscribeRecipientFromTopicRequests);
+    });
+  });
+
+  describe('getUpdateSubscriptionsError() selector', () => {
+    it('should return updateSubscriptionsError state', () => {
+      const updateSubscriptionsError = {};
+
+      expect(
+        userReducer.getUpdateSubscriptionsError({
+          ...initialState,
+          updateSubscriptionsError,
+        }),
+      ).toBe(updateSubscriptionsError);
     });
   });
 });

--- a/packages/redux/src/subscriptions/reducer/user.ts
+++ b/packages/redux/src/subscriptions/reducer/user.ts
@@ -12,18 +12,31 @@ export const INITIAL_STATE: UserState = {
   isLoading: false,
   result: [],
   unsubscribeRecipientFromTopicRequests: {},
+  updateSubscriptionsError: null,
 };
 
 const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_USER_SUBSCRIPTIONS_FAILURE:
-    case actionTypes.UPDATE_USER_SUBSCRIPTIONS_FAILURE:
     case actionTypes.UNSUBSCRIBE_FROM_SUBSCRIPTION_FAILURE:
       return action.payload.error;
     case actionTypes.FETCH_USER_SUBSCRIPTIONS_REQUEST:
-    case actionTypes.UPDATE_USER_SUBSCRIPTIONS_REQUEST:
     case actionTypes.UNSUBSCRIBE_FROM_SUBSCRIPTION_REQUEST:
       return INITIAL_STATE.error;
+    default:
+      return state;
+  }
+};
+
+const updateSubscriptionsError = (
+  state = INITIAL_STATE.updateSubscriptionsError,
+  action: AnyAction,
+) => {
+  switch (action.type) {
+    case actionTypes.UPDATE_USER_SUBSCRIPTIONS_FAILURE:
+      return action.payload.error;
+    case actionTypes.UPDATE_USER_SUBSCRIPTIONS_REQUEST:
+      return INITIAL_STATE.updateSubscriptionsError;
     default:
       return state;
   }
@@ -50,8 +63,8 @@ const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
 const result = (state = INITIAL_STATE.result, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_USER_SUBSCRIPTIONS_SUCCESS:
-    case actionTypes.UPDATE_USER_SUBSCRIPTIONS_SUCCESS:
       return action.payload;
+    case actionTypes.UPDATE_USER_SUBSCRIPTIONS_SUCCESS:
     case actionTypes.UNSUBSCRIBE_FROM_SUBSCRIPTION_SUCCESS:
       return INITIAL_STATE.result;
     case actionTypes.UNSUBSCRIBE_RECIPIENT_FROM_TOPIC_SUCCESS: {
@@ -218,25 +231,23 @@ const unsubscribeRecipientFromTopicRequests = (
   }
 };
 
-export const getSubscriptionsError = (
-  state: UserState | undefined,
-): UserState['error'] | undefined => state?.error;
-export const getSubscriptionsIsLoading = (
-  state: UserState | undefined,
-): UserState['isLoading'] | undefined => state?.isLoading;
-export const getSubscriptions = (
-  state: UserState | undefined,
-): UserState['result'] | undefined => state?.result;
+export const getSubscriptionsError = (state: UserState | undefined) =>
+  state?.error;
+export const getSubscriptionsIsLoading = (state: UserState | undefined) =>
+  state?.isLoading;
+export const getSubscriptions = (state: UserState | undefined) => state?.result;
 export const getUnsubscribeRecipientFromTopicRequests = (
   state: UserState | undefined,
-): UserState['unsubscribeRecipientFromTopicRequests'] | undefined =>
-  state?.unsubscribeRecipientFromTopicRequests;
+) => state?.unsubscribeRecipientFromTopicRequests;
+export const getUpdateSubscriptionsError = (state: UserState | undefined) =>
+  state?.updateSubscriptionsError;
 
 const reducers = combineReducers({
   error,
   isLoading,
   result,
   unsubscribeRecipientFromTopicRequests,
+  updateSubscriptionsError,
 });
 
 /**

--- a/packages/redux/src/subscriptions/selectors.ts
+++ b/packages/redux/src/subscriptions/selectors.ts
@@ -1,9 +1,3 @@
-/**
- * @module subscriptions/selectors
- * @category Subscriptions
- * @subcategory Selectors
- */
-
 import { createSelector } from 'reselect';
 import { getEntities } from '../entities';
 import {
@@ -16,43 +10,42 @@ import {
   getSubscriptionsError,
   getSubscriptionsIsLoading,
   getUnsubscribeRecipientFromTopicRequests as getUnsubscribeRecipientFromTopicRequestsReducer,
+  getUpdateSubscriptionsError as getUpdateSubscriptionsErrorFromReducer,
 } from './reducer/user';
 import defaultTo from 'lodash/defaultTo';
 import get from 'lodash/get';
-import type {
-  PackagesState,
-  UnsubscribeRecipientFromTopicType,
-  UserState,
-} from './types';
+import type { PackagesState, UserState } from './types';
 import type { StoreState } from '../types';
 import type { SubscriptionTopic } from '@farfetch/blackout-client/subscriptions/types';
 
 /**
  * Returns the error given a user subscription action.
  *
- * @function
- *
  * @param state - Application state.
  *
  * @returns User subscription error.
  */
-export const getUserSubscriptionsError = (
-  state: StoreState,
-): UserState['error'] | undefined =>
+export const getUserSubscriptionsError = (state: StoreState) =>
   getSubscriptionsError(state.subscriptions?.user);
 
 /**
- * Returns the result of a user subscription.
+ * Returns the error when the update user subscriptions action fails.
  *
- * @function
+ * @param state - Application state.
+ *
+ * @returns Error for the update subscription action.
+ */
+export const getUpdateSubscriptionsError = (state: StoreState) =>
+  getUpdateSubscriptionsErrorFromReducer(state.subscriptions?.user);
+
+/**
+ * Returns the result of a user subscription.
  *
  * @param state - Application state.
  *
  * @returns User subscription result.
  */
-export const getUserSubscriptions = (
-  state: StoreState,
-): UserState['result'] | undefined =>
+export const getUserSubscriptions = (state: StoreState) =>
   getSubscriptions(state.subscriptions?.user);
 
 // Default user subscriptions value for the following selectors.
@@ -61,8 +54,6 @@ const DEFAULT_USER_SUBSCRIPTIONS_VALUE: UserState['result'] = [];
 
 /**
  * Returns the user subscribed topics for the specified platform.
- *
- * @function
  *
  * @param state - Application state.
  * @param platform - Platform to filter the subscriptions.
@@ -98,8 +89,6 @@ export const getUserSubscribedTopicsForPlatform = createSelector(
 /**
  * Returns the user subscribed topics for the specified address.
  *
- * @function
- *
  * @param state - Application state.
  * @param address - Address to filter the subscriptions.
  *
@@ -132,21 +121,15 @@ export const getUserSubscribedTopicsForAddress = createSelector(
 /**
  * Returns the loading status of a user subscription.
  *
- * @function
- *
  * @param state - Application state.
  *
  * @returns User subscription loading status.
  */
-export const isUserSubscriptionsLoading = (
-  state: StoreState,
-): UserState['isLoading'] | undefined =>
+export const isUserSubscriptionsLoading = (state: StoreState) =>
   getSubscriptionsIsLoading(state.subscriptions?.user);
 
 /**
  * Returns the error given a subscription package action.
- *
- * @function
  *
  * @param state - Application state.
  *
@@ -159,8 +142,6 @@ export const getSubscriptionPackagesError = (
 
 /**
  * Returns the result of a subscription package.
- *
- * @function
  *
  * @param state - Application state.
  *
@@ -182,11 +163,9 @@ export const getSubscriptionPackages = createSelector(
 /**
  * Returns the loading status of a subscription package.
  *
- * @function
+ * @param state - Application state.
  *
- * @param {object} state - Application state.
- *
- * @returns {boolean} Subscription package loading status.
+ * @returns Subscription package loading status.
  */
 export const isSubscriptionPackagesLoading = (
   state: StoreState,
@@ -196,15 +175,11 @@ export const isSubscriptionPackagesLoading = (
 /**
  * Returns the supported delivery channels for all subscription packages.
  *
- * @function
- *
  * @param state - Application state.
  *
  * @returns The supported delivery channels.
  */
-export const getSupportedChannels = (
-  state: StoreState,
-): string[] | undefined => {
+export const getSupportedChannels = (state: StoreState) => {
   const result = getPackages(state.subscriptions?.packages);
 
   return (result && result.supportedChannels) || undefined;
@@ -212,8 +187,6 @@ export const getSupportedChannels = (
 
 /**
  * Returns a specific unsubscribe recipient from topic request state from the redux store.
- *
- * @function
  *
  * @param state - Application state.
  * @param recipientId - Id of the recipient (address) to get the unsubscribe request state.
@@ -223,7 +196,7 @@ export const getSupportedChannels = (
 export const getUnsubscribeRecipientFromTopicRequest = (
   state: StoreState,
   recipientId: string,
-): UnsubscribeRecipientFromTopicType | undefined => {
+) => {
   const unsubscribeRecipientFromTopicRequests =
     getUnsubscribeRecipientFromTopicRequestsReducer(state.subscriptions?.user);
 
@@ -232,8 +205,6 @@ export const getUnsubscribeRecipientFromTopicRequest = (
 
 /**
  * Returns all unsubscribe recipient from topic requests state from the redux store.
- *
- * @function
  *
  * @param state - Application state.
  *

--- a/packages/redux/src/subscriptions/types/action.types.ts
+++ b/packages/redux/src/subscriptions/types/action.types.ts
@@ -98,7 +98,6 @@ interface UpdateUserSubscriptionsRequestAction extends Action {
 
 interface UpdateUserSubscriptionsSuccessAction extends Action {
   type: typeof actionTypes.UPDATE_USER_SUBSCRIPTIONS_SUCCESS;
-  payload: Subscription[];
 }
 
 interface UpdateUserSubscriptionsFailureAction extends Action {

--- a/packages/redux/src/subscriptions/types/state.types.ts
+++ b/packages/redux/src/subscriptions/types/state.types.ts
@@ -15,6 +15,7 @@ export type UserState = CombinedState<{
     string,
     UnsubscribeRecipientFromTopicType
   >;
+  updateSubscriptionsError: Error | undefined | null;
 }>;
 
 export type UnsubscribeRecipientFromTopicType = {

--- a/packages/redux/src/wishlists/selectors/wishlists.ts
+++ b/packages/redux/src/wishlists/selectors/wishlists.ts
@@ -80,11 +80,7 @@ export const getWishlist = (state: StoreState): State['result'] =>
 export const getWishlistItem = createSelector(
   [
     (state: StoreState, wishlistItemId: WishlistItem['id']) =>
-      getEntityById(
-        state,
-        'wishlistItems',
-        wishlistItemId,
-      ) as WishlistItemEntity,
+      getEntityById(state, 'wishlistItems', wishlistItemId),
     (state: StoreState, wishlistItemId: WishlistItem['id']) => {
       const wishlistItem = getEntityById(
         state,

--- a/tests/__fixtures__/subscriptions/state.fixtures.ts
+++ b/tests/__fixtures__/subscriptions/state.fixtures.ts
@@ -67,6 +67,7 @@ export const mockUserSubscriptionsState = {
       success: true,
     },
   },
+  updateSubscriptionsError: null,
 };
 
 export const mockState = {

--- a/tests/__fixtures__/subscriptions/subscriptions.fixtures.ts
+++ b/tests/__fixtures__/subscriptions/subscriptions.fixtures.ts
@@ -96,30 +96,4 @@ export const mockPutSubscriptions = {
       },
     ],
   },
-
-  response: {
-    id: '8c2b5c3e3acb4bdd9c26ba46',
-    topics: [
-      {
-        type: 'Latest_News',
-        channels: [
-          {
-            platform: 'email',
-            address: 'user1_test1@acme.com',
-            source: 'My Account',
-          },
-        ],
-      },
-      {
-        type: 'Promotions',
-        channels: [
-          {
-            platform: 'sms',
-            address: '919191919',
-            source: 'My Account',
-          },
-        ],
-      },
-    ],
-  },
 };


### PR DESCRIPTION
## Description

- This fixes the `updateUserSubscriptions` action in order to reflect
the change made by the backend that changed the result of the put method
used by the action to not return the new subscriptions data and
instead requiring that a new get user subscriptions request be
performed to retrieve the updated data.
Additionally a breaking change was added with the
`getUserSubscriptionsError` selector that will not return an error when
the error was from the update subscriptions action.
To get the update error, a new selector was introduced.
This was in order to better differentiate which kind of error occurred
with the subscriptions state and enable the developer
to show alternative UIs in that case.
- Some fixes in typescript typings for `entities` and `subscriptions` slices.

BREAKING CHANGE: The `getUserSubscriptionsError` selector will
not return the error when there is an error
for the `updateUserSubscriptions`
action. To check if there was an error
for that action, you will need to use the
`getUpdateSubscriptionsError` selector as the following example shows:

```
// Previously

import {
    getUserSubscriptionsError,
} from '@farfetch/blackout-redux/subscriptions';

const mapStateToProps = state => {
    return {
      // errorLoadingUserSubscriptions would return all errors
      errorLoadingUserSubscriptions: getUserSubscriptionsError(state),
    };
};

// Change to

import {
    getUserSubscriptionsError,
    getUpdateSubscriptionsError,
} from '@farfetch/blackout-redux/subscriptions';

const mapStateToProps = state => {
    return {
      // Now getUserSubscriptionsError will return errors for loading / deleting actions
      errorLoadingUserSubscriptions: getUserSubscriptionsError(state),
      // getUpdateSubscriptionsError will return the error for the update action
      errorUpdatingUserSubscriptions: getUpdateSubscriptionsError(state)
   };
};
```

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
