### PR TITLE
fix(blackout-react): ignore unhandled events in ga/ga4

### DIFF
--- a/packages/react/src/analytics/integrations/GA/GA.ts
+++ b/packages/react/src/analytics/integrations/GA/GA.ts
@@ -348,13 +348,8 @@ class GA extends integrations.Integration<GAIntegrationOptions> {
     data: TrackEventData,
     scopeCommands?: ScopeCommands,
     productMappings?: ProductMappings,
-  ): GACommandList {
-    const commandList: GACommandList = [];
+  ): GACommandList | undefined {
     const extraCommands = this.getExtraCommandsForEvent(data, scopeCommands);
-
-    if (extraCommands) {
-      commandList.push(...extraCommands);
-    }
 
     const mainCommands = this.getMainCommandsForEvent(
       data,
@@ -362,11 +357,21 @@ class GA extends integrations.Integration<GAIntegrationOptions> {
       productMappings,
     );
 
-    if (mainCommands) {
-      commandList.push(...mainCommands);
+    if (extraCommands || mainCommands) {
+      const commandList: GACommandList = [];
+
+      if (extraCommands) {
+        commandList.push(...extraCommands);
+      }
+
+      if (mainCommands) {
+        commandList.push(...mainCommands);
+      }
+
+      return commandList;
     }
 
-    return commandList;
+    return undefined;
   }
 
   /**

--- a/packages/react/src/analytics/integrations/GA/__tests__/GA.test.ts
+++ b/packages/react/src/analytics/integrations/GA/__tests__/GA.test.ts
@@ -891,6 +891,32 @@ describe('GA Integration', () => {
 
             expect(gaSpy).not.toHaveBeenCalled();
           });
+
+          it('Should only be called for events that generated commands', async () => {
+            const onPreProcessCommandsMock = jest.fn();
+
+            const options = {
+              ...validOptions,
+              onPreProcessCommands: onPreProcessCommandsMock,
+            };
+
+            gaInstance = await createGAInstanceAndLoad(options);
+
+            expect(onPreProcessCommandsMock).not.toHaveBeenCalled();
+
+            const gaSpy = getWindowGaSpy();
+
+            const nonDefaultSupportedEvent = {
+              ...trackEventsData[eventTypes.PRODUCT_ADDED_TO_CART],
+              event: 'bogus event',
+            };
+
+            await gaInstance.track(nonDefaultSupportedEvent);
+
+            expect(onPreProcessCommandsMock).not.toHaveBeenCalled();
+
+            expect(gaSpy).not.toHaveBeenCalled();
+          });
         });
 
         describe('`productMappings` option', () => {

--- a/packages/react/src/analytics/integrations/GA4/GA4.js
+++ b/packages/react/src/analytics/integrations/GA4/GA4.js
@@ -417,12 +417,7 @@ class GA4 extends integrations.Integration {
    * @returns {Array} The GA4 command list for the event. It will return empty if there is an error or no command builders exist for the event.
    */
   buildCommandListForEvent(data, scopeCommands, productMappings) {
-    const commandList = [];
     const extraCommands = this.getExtraCommandsForEvent(data, scopeCommands);
-
-    if (extraCommands) {
-      commandList.push(...extraCommands);
-    }
 
     const mainCommands = this.getMainCommandsForEvent(
       data,
@@ -430,11 +425,23 @@ class GA4 extends integrations.Integration {
       productMappings,
     );
 
-    if (mainCommands) {
-      commandList.push(...mainCommands);
+    // Only initialize `commandList` if there were any commands generated for the event
+    // If not, return undefined.
+    if (extraCommands || mainCommands) {
+      const commandList = [];
+
+      if (extraCommands) {
+        commandList.push(...extraCommands);
+      }
+
+      if (mainCommands) {
+        commandList.push(...mainCommands);
+      }
+
+      return commandList;
     }
 
-    return commandList;
+    return undefined;
   }
 
   /**

--- a/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.js
@@ -818,6 +818,34 @@ describe('GA4 Integration', () => {
         });
 
         describe(`${OPTION_ON_PRE_PROCESS_COMMANDS} option`, () => {
+          it('Should allow the user to transform the command list generated before sending to gtag instance', async () => {
+            let newCommandList;
+
+            const onPreProcessCommands = commandList => {
+              newCommandList = [
+                ['event', 'new_event', { dummy_prop: 'dummy_value' }],
+                ...commandList,
+              ];
+
+              return newCommandList;
+            };
+
+            const options = {
+              ...validOptions,
+              [OPTION_ON_PRE_PROCESS_COMMANDS]: onPreProcessCommands,
+            };
+
+            ga4Instance = await createGA4InstanceAndLoad(options, loadData);
+
+            const ga4Spy = getWindowGa4Spy();
+
+            await ga4Instance.track(
+              trackEventsData[eventTypes.PRODUCT_ADDED_TO_CART],
+            );
+
+            expect(ga4Spy.mock.calls).toEqual(newCommandList);
+          });
+
           it('Should log an error when the value specified is not a function', () => {
             const options = {
               ...validOptions,
@@ -846,6 +874,32 @@ describe('GA4 Integration', () => {
             );
 
             expect(mockLoggerError).toHaveBeenCalled();
+
+            expect(ga4Spy).not.toHaveBeenCalled();
+          });
+
+          it('Should only be called for events that generated commands', async () => {
+            const onPreProcessCommandsMock = jest.fn();
+
+            const options = {
+              ...validOptions,
+              onPreProcessCommands: onPreProcessCommandsMock,
+            };
+
+            ga4Instance = await createGA4InstanceAndLoad(options, loadData);
+
+            expect(onPreProcessCommandsMock).not.toHaveBeenCalled();
+
+            const ga4Spy = getWindowGa4Spy();
+
+            const nonDefaultSupportedEvent = {
+              ...trackEventsData[eventTypes.PRODUCT_ADDED_TO_CART],
+              event: 'bogus event',
+            };
+
+            await ga4Instance.track(nonDefaultSupportedEvent);
+
+            expect(onPreProcessCommandsMock).not.toHaveBeenCalled();
 
             expect(ga4Spy).not.toHaveBeenCalled();
           });


### PR DESCRIPTION
## Description

- This fixes a problem where tracked events that were
unhandled by GA/GA4 were still being considered for the
`onPreProcessCommand` optional function call. This presented a problem
because the generated command list was an empty array, which would break
the expectation of the consumers.
- Added corresponding tests.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
