### PR TITLE
fix(blackout-core): fix `getWishlistItemIdFromAction` function next

### DIFF
--- a/packages/redux/src/analytics/middlewares/wishlist.js
+++ b/packages/redux/src/analytics/middlewares/wishlist.js
@@ -71,10 +71,15 @@ const getWishlistItemIdFromAction = (action, searchMeta = true) => {
   return Object.values(wishlistItems).find(
     wishlistItem =>
       wishlistItem.product === productIdMeta &&
+      // Do not consider merchant if it was not passed to the update wishlist item action
       wishlistItem.merchant ===
         (merchantIdMeta ? merchantIdMeta : wishlistItem.merchant) &&
-      wishlistItem.size.id === sizeIdMeta &&
-      wishlistItem.size.scale === sizeScaleMeta,
+      // Do not consider size id if it was not passed to the update wishlist item action
+      wishlistItem.size.id ===
+        (sizeIdMeta ? sizeIdMeta : wishlistItem.size.id) &&
+      // Do not consider scale id if it was not passed to the update wishlist item action
+      wishlistItem.size.scale ===
+        (sizeScaleMeta ? sizeScaleMeta : wishlistItem.size.scale),
   )?.id;
 };
 


### PR DESCRIPTION
## Description

- This fixes the `getWishlistItemIdFromAction` from the analytics wishlist
middleware which was not considering the optional parameters when searching for
the updated wishlistItem in the action payload, which would prevent from
obtaining the correct item.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
