### PR TITLE
fix(blackout-client): fix logout in axios interceptor

### DIFF
--- a/packages/client/src/helpers/client/interceptors/authentication/AxiosAuthenticationTokenManager.js
+++ b/packages/client/src/helpers/client/interceptors/authentication/AxiosAuthenticationTokenManager.js
@@ -705,7 +705,8 @@ class AxiosAuthenticationTokenManager {
     // return success. The token might already have been deleted.
     if (
       config[AuthenticationConfigOptions.IsLogoutRequest] &&
-      ((responseStatus === 400 && error.response.code === '17') ||
+      ((responseStatus === 400 &&
+        error.response?.data?.errors?.[0]?.code === '17') ||
         responseStatus === 404)
     ) {
       this.selectGuestTokenProvider();

--- a/packages/react/src/authentication/hooks/__tests__/useAuthentication.test.tsx
+++ b/packages/react/src/authentication/hooks/__tests__/useAuthentication.test.tsx
@@ -443,7 +443,9 @@ describe('useAuthentication', () => {
     moxios.stubRequest(`/authentication/v1/tokens/${accessToken}`, {
       method: 'delete',
       status: 400,
-      code: '17',
+      response: {
+        errors: [{ code: '17' }],
+      },
     });
 
     await act(async () => {


### PR DESCRIPTION
## Description

- This fixes a bug with logout interceptor where the `code` property
was being looked at the incorrect path when the logout request fails,
which prevented the logout of an user when the token does not exist.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
