### PR TITLE
feat(react): expose Vitorino network option

### DIFF
--- a/packages/react/src/analytics/integrations/Vitorino/Vitorino.js
+++ b/packages/react/src/analytics/integrations/Vitorino/Vitorino.js
@@ -39,7 +39,7 @@ import isArray from 'lodash/isArray';
  */
 export default class Vitorino extends integrations.Integration {
   /**
-   * This integration is required, so it must be loaded indenpendently of user consent.
+   * This integration is required, so it must be loaded independently of user consent.
    *
    * @returns {boolean} If the integration should load or not.
    */
@@ -220,7 +220,7 @@ export default class Vitorino extends integrations.Integration {
       customerId: getCustomerIdFromUser(data.user),
       environment: getEnvironmentFromOptions(this.options),
       fields: this.getFieldsFromOptions(this.options),
-      network: {
+      network: this.options.network || {
         proxy: origin,
         path: `${MARKETING_API_PREFIX}${POST_TRACKINGS_PATHNAME}`,
       },
@@ -259,11 +259,11 @@ export default class Vitorino extends integrations.Integration {
   }
 
   /**
-   * Returns the correspondant Vitorino page type for the event.
+   * Returns the correspondent Vitorino page type for the event.
    *
    * @param {string} event - The analytics event to filter by.
-
-   * @returns {string | Array} - The correspondant Vitorino's page view(s).
+   
+   * @returns {string | Array} - The correspondent Vitorino's page view(s).
    */
   getPageTypeFromEvent(event) {
     const mapper = this.getEventsMapper();

--- a/packages/react/src/analytics/integrations/Vitorino/__tests__/Vitorino.test.js
+++ b/packages/react/src/analytics/integrations/Vitorino/__tests__/Vitorino.test.js
@@ -189,6 +189,23 @@ describe('Vitorino', () => {
       });
     });
 
+    describe('Network option', () => {
+      it('Should allow to pass a "network" object to pass a custom proxy to Vitorino', async () => {
+        const customNetworkProxy = {
+          proxy: 'https://johndoe.com',
+          path: '/api',
+        };
+        await getIntegrationInstance({
+          network: customNetworkProxy,
+        });
+
+        expect(window.Vitorino.track).toHaveBeenCalledWith({
+          ...generateMockVitorinoPayload(),
+          network: customNetworkProxy,
+        });
+      });
+    });
+
     describe('Script', () => {
       it('Should log an error if the development script is not present if the environment is dev', async () => {
         try {
@@ -220,7 +237,7 @@ describe('Vitorino', () => {
         // clean the body
         document.body.innerHTML = '';
 
-        // test the dev script with the implicit environment option without relying on the default behaviour
+        // test the dev script with the implicit environment option without relying on the default behavior
         const devScriptSource = 'https://google.com/';
 
         await getIntegrationInstance({


### PR DESCRIPTION
## Description
This PR exposes the network option of Vitorino integration, so we can use it on specific applications that need other endpoints as the marketing proxy.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
