### PR TITLE
feat(blackout-core): use previous store data of analytics bag on upda…

### DIFF
--- a/packages/core/src/analytics/redux/middlewares/bag.js
+++ b/packages/core/src/analytics/redux/middlewares/bag.js
@@ -12,6 +12,7 @@ import { getProduct } from '../../../entities/redux/selectors';
 import { logger } from '../../utils';
 import Analytics from '../..';
 import get from 'lodash/get';
+import isNil from 'lodash/isNil';
 
 /**
  * Extends the default action types with the ones passed to the middleware.
@@ -30,6 +31,50 @@ const getActionTypes = customActionTypes => ({
 });
 
 /**
+ * Gets bag item id that corresponds to the product
+ * specified in the action.
+ *
+ * @private
+ *
+ * @param {object} action - The action being executed.
+ * @param {boolean} searchMeta - Flag indicating if the search for the bag item id should look on the action.meta property. This value will be false when there is an update action because the id on the action.meta is not the id of the bag item after the update, as it will be changed by the server.
+ *
+ * @returns The bag item id for the product if available or undefined.
+ */
+const getBagItemIdFromAction = (action, searchMeta = true) => {
+  if (searchMeta) {
+    const bagItemIdInMeta = get(action, 'meta.bagItemId');
+
+    if (!isNil(bagItemIdInMeta)) {
+      return bagItemIdInMeta;
+    }
+  }
+
+  const bagItems = get(action, 'payload.entities.bagItems');
+  const productIdMeta = get(action, 'meta.productId');
+  const merchantIdMeta = get(action, 'meta.merchantId');
+  const sizeIdMeta = get(action, 'meta.size');
+  const sizeScaleMeta = get(action, 'meta.scale');
+
+  if (!bagItems || !productIdMeta) {
+    return;
+  }
+
+  return Object.values(bagItems).find(
+    bagItem =>
+      bagItem.product === productIdMeta &&
+      // Do not consider merchant if it was not passed to the update bag item action
+      bagItem.merchant ===
+        (merchantIdMeta ? merchantIdMeta : bagItem.merchant) &&
+      // Do not consider size id if it was not passed to the update bag item action
+      bagItem.size.id === (sizeIdMeta ? sizeIdMeta : bagItem.size.id) &&
+      // Do not consider scale id if it was not passed to the update bag item action
+      bagItem.size.scale ===
+        (sizeScaleMeta ? sizeScaleMeta : bagItem.size.scale),
+  )?.id;
+};
+
+/**
  * Builds an object with all product data needed for tracking.
  *
  * @private
@@ -41,16 +86,22 @@ const getActionTypes = customActionTypes => ({
  * @returns {object} Product data for analytics.
  */
 const getProductData = async (analyticsInstance, state, action) => {
-  const productIdMeta = get(action, 'meta.productId');
-  const sizeId = get(action, 'meta.size');
-  const merchantId = get(action, 'meta.merchantId');
-  const customAttributes = get(action, 'meta.customAttributes') || '';
-  const sizeScaleId = get(action, 'meta.scale');
+  const actionMetadata = get(action, 'meta', {});
+  const {
+    productId: productIdMeta,
+    size: sizeId,
+    merchantId,
+    scale: sizeScaleId,
+    customAttributes = '',
+  } = actionMetadata;
 
   let bagItemId;
 
-  const bagItemsFromActionPayload =
-    get(action, 'payload.entities.bagItems') || {};
+  const bagItemsFromActionPayload = get(
+    action,
+    'payload.entities.bagItems',
+    {},
+  );
 
   // First we search for the bag item id on the action payload.
   // As the same product can be in different bag items, we need to do an exhaustive
@@ -71,16 +122,16 @@ const getProductData = async (analyticsInstance, state, action) => {
   // This case will happen on a remove bag item success action as the deleted item will
   // not be returned from the server.
   if (!bagItemId) {
-    bagItemId = get(action, 'meta.bagItemId');
+    bagItemId = actionMetadata.bagItemId;
   }
 
   // Now we can safely retrieve the correct bag item data from the store.
   const bagItem = getBagItem(state, bagItemId);
   const id = productIdMeta || get(bagItem, 'product.id'); // If no productId property exists on the action meta, use the id on the bagItem if available
   const product = getProduct(state, id);
-  const sku = get(product, 'sku');
+  const { sku, shortDescription, name: productName } = product || {};
+  const name = shortDescription || productName;
   const category = getCategory(state, product);
-  const name = get(product, 'shortDescription') || get(product, 'name');
   const brand = getBrand(state, product);
   const variant = getVariant(product);
   const priceWithDiscount =
@@ -112,10 +163,8 @@ const getProductData = async (analyticsInstance, state, action) => {
     calculatePriceDiscount(priceWithDiscount, priceWithoutDiscount) +
     promotionDiscountValuePerQuantity;
 
-  const oldQuantity = get(action, 'meta.oldQuantity');
-  const quantity = get(action, 'meta.quantity') || bagItemQuantity;
+  const quantity = actionMetadata.quantity || bagItemQuantity;
   const size = get(bagItem, 'size.name') || getSize(product, sizeId); // size might be defined only on bagItem on a hard-refresh of the bag page
-  const oldSize = get(action, 'meta.oldSize.name');
   const currency = await getCurrency(analyticsInstance);
 
   return {
@@ -127,9 +176,7 @@ const getProductData = async (analyticsInstance, state, action) => {
     name,
     price: priceWithDiscount,
     priceWithoutDiscount,
-    oldQuantity,
     size,
-    oldSize,
     sku,
     quantity,
     variant,
@@ -145,18 +192,16 @@ const getProductData = async (analyticsInstance, state, action) => {
  *
  * @returns {object} Event data for analytics.
  */
-const getBagData = action => {
-  return {
-    affiliation: get(action, 'meta.affiliation'),
-    cartId: get(action, 'payload.result'),
-    coupon: get(action, 'meta.coupon'),
-    from: get(action, 'meta.from'),
-    list: get(action, 'meta.list'),
-    listId: get(action, 'meta.listId'),
-    position: get(action, 'meta.position'),
-    value: get(action, 'meta.value'),
-  };
-};
+const getBagData = action => ({
+  affiliation: get(action, 'meta.affiliation'),
+  cartId: get(action, 'payload.result'),
+  coupon: get(action, 'meta.coupon'),
+  from: get(action, 'meta.from'),
+  list: get(action, 'meta.list'),
+  listId: get(action, 'meta.listId'),
+  position: get(action, 'meta.position'),
+  value: get(action, 'meta.value'),
+});
 
 /**
  * Middleware for @farfetch/blackout-core/bags/redux actions, to call `analyticsInstance.track()` with the correct payload.
@@ -201,6 +246,16 @@ export default (analyticsInstance, customActionTypes) => {
       }
 
       case actionTypes.UPDATE_BAG_ITEM_SUCCESS: {
+        // Get the previous bag item from the store
+
+        const previousStoreState = store.getState();
+        const previousBagItemId = getBagItemIdFromAction(action, true);
+
+        const previousBagItem = getBagItem(
+          previousStoreState,
+          previousBagItemId,
+        );
+
         // Let the action reach the reducers and update the state
         // because we need the state updated in order to calculate
         // discount values correctly.
@@ -210,6 +265,8 @@ export default (analyticsInstance, customActionTypes) => {
 
         data = {
           ...(await getProductData(analyticsInstance, state, action)),
+          oldSize: previousBagItem?.size?.name,
+          oldQuantity: previousBagItem?.quantity,
           ...getBagData(action),
         };
         let eventType = null;
@@ -238,8 +295,8 @@ export default (analyticsInstance, customActionTypes) => {
           eventType = eventTypes.PRODUCT_ADDED_TO_CART;
         }
 
-        data.quantity = Math.abs(data.quantity - data.oldQuantity);
-        analyticsInstance.track(eventType, data);
+        data.quantity = Math.abs(data.quantity - (data.oldQuantity || 0));
+        analyticsInstance.track(eventType, { ...data, oldQuantity: undefined });
 
         return result;
       }


### PR DESCRIPTION
## Description

 - This add support to obtain previous store data from bagitem, when product
 bag are updated, allowing remove parameters oldSize and oldQuantity from meta.

### Dependencies

None.

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
