### PR TITLE
feat(blackout-react): add support multigender ga4's signup newsletter

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/eventMapping.js
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.js
@@ -457,7 +457,11 @@ const getPlaceOrderStartedParametersFromEvent = eventProperties => {
  */
 const getSearchParametersFromEvent = eventProperties => {
   return {
-    search_term: eventProperties.searchTerm,
+    search_term: get(
+      eventProperties,
+      'searchTerm',
+      get(eventProperties, 'searchQuery'),
+    ),
   };
 };
 
@@ -589,8 +593,18 @@ const getShareParametersFromEvent = eventProperties => ({
  * @returns {object} Parameters formatted for the GA4's sign_up_newsletter event.
  */
 const getSignupNewsletterParametersFromEvent = eventProperties => {
+  const genderArray = (
+    Array.isArray(eventProperties.gender)
+      ? eventProperties.gender
+      : new Array(eventProperties.gender)
+  ).map(
+    gender =>
+      // trying using tenant translation otherwise use custom gender mappings
+      gender.name || SignupNewsletterGenderMappings[gender?.id ?? gender],
+  );
+
   return {
-    newsletter_gender: SignupNewsletterGenderMappings[eventProperties.gender],
+    newsletter_gender: genderArray.reduce((acc, item) => `${acc},${item}`),
   };
 };
 

--- a/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.js
+++ b/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.js
@@ -99,9 +99,16 @@ const purchaseAndRefundSchema = baseCheckoutSchema
   .concat(taxSchema)
   .concat(shippingSchema);
 
-const searchSchema = yup.object({
-  searchTerm: yup.string().required(),
-});
+const searchSchema = yup
+  .object({
+    searchTerm: yup.string(),
+    searchQuery: yup.string(),
+  })
+  .test(
+    'invalid_search_data',
+    'The event, must have at least searchTerm or searchQuery properties.',
+    value => !!value.searchQuery || !!value.searchTerm,
+  );
 
 const selectContentSchema = productIdSchema.concat(
   yup.object({
@@ -238,8 +245,40 @@ const interactContentSchema = yup
     },
   );
 
+const signupNewsletterSchemaGenderValidationList = {
+  basic: yup.string().oneOf(Object.keys(SignupNewsletterGenderMappings)),
+  multiple: yup
+    .array()
+    .of(yup.string().oneOf(Object.keys(SignupNewsletterGenderMappings))),
+  complex: yup.array().of(
+    yup.object({
+      id: yup.string().oneOf(Object.keys(SignupNewsletterGenderMappings)),
+      name: yup.string().notRequired(),
+    }),
+  ),
+};
+
 const signupNewsletterSchema = yup.object({
-  gender: yup.string().oneOf(Object.keys(SignupNewsletterGenderMappings)),
+  gender: yup
+    .mixed()
+    .test(
+      'gender_invalid_parameter',
+      "invalid 'gender' parameter for 'sign_up newsletter' event type. It accepts string or array of strings, but only if one is of Gender Mappings valid value.",
+      value => {
+        const validationResult = schema => {
+          try {
+            schema.validateSync(value);
+            return true;
+          } catch (e) {
+            return false;
+          }
+        };
+
+        return Object.values(signupNewsletterSchemaGenderValidationList).some(
+          validationResult,
+        );
+      },
+    ),
 });
 
 export default {

--- a/packages/react/src/analytics/integrations/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/__tests__/GA4.test.js
@@ -1119,6 +1119,156 @@ describe('GA4 Integration', () => {
           });
         });
 
+        describe('Newsletter events', () => {
+          const defaultEvent = {
+            ...validTrackEvents[eventTypes.SIGNUP_NEWSLETTER],
+          };
+
+          it('should track single gender event', async () => {
+            ga4Instance = await createGA4InstanceAndLoad(
+              validOptions,
+              loadData,
+            );
+            const ga4Spy = getWindowGa4Spy();
+
+            const singleGenderEvent = {
+              ...defaultEvent,
+              properties: {
+                ...defaultEvent.properties,
+                gender: '0',
+              },
+            };
+
+            await ga4Instance.track(singleGenderEvent);
+
+            expect(ga4Spy.mock.calls).toMatchSnapshot();
+          });
+
+          it('should track multiple gender event', async () => {
+            ga4Instance = await createGA4InstanceAndLoad(
+              validOptions,
+              loadData,
+            );
+            const ga4Spy = getWindowGa4Spy();
+
+            const getGenderData = genderData => ({
+              ...defaultEvent,
+              properties: {
+                ...defaultEvent.properties,
+                gender: genderData,
+              },
+            });
+
+            await ga4Instance.track(getGenderData(['0', '1']));
+
+            await ga4Instance.track(
+              getGenderData([
+                { id: '0', name: 'WOMAN' },
+                { id: '1', name: 'MAN' },
+              ]),
+            );
+
+            await ga4Instance.track(getGenderData([{ id: '0' }, { id: '1' }]));
+
+            expect(ga4Spy.mock.calls).toMatchSnapshot();
+          });
+
+          it('should not track signup_newsletter event with invalid gender data', async () => {
+            ga4Instance = await createGA4InstanceAndLoad(
+              validOptions,
+              loadData,
+            );
+            const ga4Spy = getWindowGa4Spy();
+
+            const multipleGenderEventWithInvalidGender = {
+              ...defaultEvent,
+              properties: {
+                ...defaultEvent.properties,
+                gender: ['10', '1'],
+              },
+            };
+
+            await ga4Instance.track(multipleGenderEventWithInvalidGender);
+
+            const singleGenderEventWithInvalidGender = {
+              ...defaultEvent,
+              properties: {
+                ...defaultEvent.properties,
+                gender: '10',
+              },
+            };
+
+            await ga4Instance.track(singleGenderEventWithInvalidGender);
+
+            expect(ga4Spy).not.toHaveBeenCalled();
+          });
+        });
+        describe('Search events', () => {
+          const defaultEvent = {
+            ...validTrackEvents[pageTypes.SEARCH],
+          };
+          it('should not track search event with invalid search term or query, only page event.', async () => {
+            ga4Instance = await createGA4InstanceAndLoad(
+              validOptions,
+              loadData,
+            );
+            const ga4Spy = getWindowGa4Spy();
+
+            const data = {
+              ...defaultEvent,
+              properties: {
+                ...defaultEvent.properties,
+                searchTerm: undefined,
+              },
+            };
+
+            await ga4Instance.track(data);
+
+            expect(ga4Spy.mock.calls[0]).toMatchSnapshot();
+          });
+
+          it('should track search event search term instead of search query.', async () => {
+            ga4Instance = await createGA4InstanceAndLoad(
+              validOptions,
+              loadData,
+            );
+            const ga4Spy = getWindowGa4Spy();
+
+            const data = {
+              ...defaultEvent,
+              properties: {
+                ...defaultEvent.properties,
+                searchTerm: 'term',
+                searchQuery: 'query',
+              },
+            };
+
+            await ga4Instance.track(data);
+
+            expect(ga4Spy.mock.calls[0]).toMatchSnapshot();
+          });
+
+          it('should track search event search without search term but with search query instead.', async () => {
+            ga4Instance = await createGA4InstanceAndLoad(
+              validOptions,
+              loadData,
+            );
+            const ga4Spy = getWindowGa4Spy();
+
+            const data = {
+              ...defaultEvent,
+              properties: {
+                ...defaultEvent.properties,
+                searchTerm: undefined,
+                searchQuery: 'query',
+              },
+            };
+
+            await ga4Instance.track(data);
+
+            expect(ga4Spy.mock.calls[0]).toMatchSnapshot();
+          });
+        });
         describe('Navigation events', () => {
           describe('Interact Content event', () => {
             it('Should allow to track the interact_content transforming camelCase to snake_case', async () => {

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
@@ -1,5 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Newsletter events should track multiple gender event 1`] = `
+Array [
+  Array [
+    "event",
+    "sign_up_newsletter",
+    Object {
+      "newsletter_gender": "Woman,Man",
+    },
+  ],
+  Array [
+    "event",
+    "sign_up_newsletter",
+    Object {
+      "newsletter_gender": "WOMAN,MAN",
+    },
+  ],
+  Array [
+    "event",
+    "sign_up_newsletter",
+    Object {
+      "newsletter_gender": "Woman,Man",
+    },
+  ],
+]
+`;
+
+exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Newsletter events should track single gender event 1`] = `
+Array [
+  Array [
+    "event",
+    "sign_up_newsletter",
+    Object {
+      "newsletter_gender": "Woman",
+    },
+  ],
+]
+`;
+
+exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Search events should not track search event with invalid search term or query, only page event. 1`] = `
+Array [
+  "config",
+  "GA-123456-12",
+  Object {
+    "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+    "path_clean": "/pt/",
+  },
+]
+`;
+
+exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Search events should track search event search term instead of search query. 1`] = `
+Array [
+  "event",
+  "search",
+  Object {
+    "search_term": "term",
+  },
+]
+`;
+
+exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Search events should track search event search without search term but with search query instead. 1`] = `
+Array [
+  "event",
+  "search",
+  Object {
+    "search_term": "query",
+  },
+]
+`;
+
 exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Should map the Address Info Added event correctly 1`] = `
 Array [
   Array [


### PR DESCRIPTION
## Description

- adds support for multiple gender on ga4 signup newsletter track.
- change ga4 search event, to use property searchQuery instead of seachTerm.

### Dependencies

None.

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
