### PR TITLE
feat: add `useSearchSuggestions` hook

### DIFF
--- a/packages/react/src/search/hooks/__tests__/useSearchSuggestions.test.tsx
+++ b/packages/react/src/search/hooks/__tests__/useSearchSuggestions.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup } from '@testing-library/react';
+import { mockSearchSuggestionsState } from 'tests/__fixtures__/search';
+import { mockStore } from '../../../../tests/helpers';
+import { Provider } from 'react-redux';
+import { renderHook } from '@testing-library/react-hooks';
+import { UseSearchSuggestionsReturn } from '../types';
+import React from 'react';
+import useSearchSuggestions from '../useSearchSuggestions';
+
+jest.mock('@farfetch/blackout-redux/search', () => ({
+  ...jest.requireActual('@farfetch/blackout-redux/search'),
+  fetchSearchSuggestions: jest.fn(() => ({ type: 'fetch' })),
+  resetSearchSuggestions: jest.fn(() => ({ type: 'reset' })),
+}));
+
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+const getRenderedHook = (
+  state = mockSearchSuggestionsState,
+): UseSearchSuggestionsReturn => {
+  const {
+    result: { current },
+  } = renderHook(() => useSearchSuggestions(), {
+    wrapper: props => <Provider store={mockStore(state)} {...props} />,
+  });
+
+  return current;
+};
+
+describe('useSearchSuggestions', () => {
+  beforeEach(jest.clearAllMocks);
+  afterEach(cleanup);
+
+  it('should return values correctly with initial state', () => {
+    const current = getRenderedHook();
+
+    expect(current).toStrictEqual({
+      error: expect.any(Object),
+      fetchSearchSuggestions: expect.any(Function),
+      isLoading: expect.any(Boolean),
+      resetSearchSuggestions: expect.any(Function),
+      suggestions: expect.any(Array),
+    });
+  });
+
+  it('should render in error state', () => {
+    const mockError = mockSearchSuggestionsState.search.suggestions.error;
+    const { error } = getRenderedHook(mockSearchSuggestionsState);
+
+    expect(error).toEqual(mockError);
+  });
+
+  it('should render in loading state', () => {
+    const { isLoading } = getRenderedHook({
+      search: {
+        suggestions: {
+          ...mockSearchSuggestionsState.search.suggestions,
+          isLoading: true,
+        },
+      },
+    });
+
+    expect(isLoading).toEqual(true);
+  });
+
+  describe('actions', () => {
+    it('should call `fetchSearchSuggestions` action', () => {
+      const { fetchSearchSuggestions } = getRenderedHook();
+
+      fetchSearchSuggestions({ query: 'query' });
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'fetch' });
+    });
+
+    it('should call `resetSearchSuggestions` action', () => {
+      const { resetSearchSuggestions } = getRenderedHook();
+
+      resetSearchSuggestions();
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'reset' });
+    });
+  });
+});

--- a/packages/react/src/search/hooks/types/index.ts
+++ b/packages/react/src/search/hooks/types/index.ts
@@ -1,1 +1,2 @@
 export * from './useSearchIntents.types';
+export * from './useSearchSuggestions.types';

--- a/packages/react/src/search/hooks/types/useSearchSuggestions.types.ts
+++ b/packages/react/src/search/hooks/types/useSearchSuggestions.types.ts
@@ -1,0 +1,18 @@
+import type { Error } from '@farfetch/blackout-client/types';
+import type {
+  SearchSuggestion,
+  SearchSuggestionsQuery,
+} from '@farfetch/blackout-client/search/types';
+
+export type UseSearchSuggestionsReturn = {
+  error: Error | null;
+  fetchSearchSuggestions: (
+    query: SearchSuggestionsQuery,
+    config?: Record<string, unknown>,
+  ) => Promise<SearchSuggestion[]>;
+  isLoading: boolean;
+  resetSearchSuggestions: () => void;
+  suggestions: SearchSuggestion[] | null;
+};
+
+export type UseSearchSuggestions = () => UseSearchSuggestionsReturn;

--- a/packages/react/src/search/hooks/useSearchSuggestions.ts
+++ b/packages/react/src/search/hooks/useSearchSuggestions.ts
@@ -1,0 +1,53 @@
+/**
+ * @remarks
+ * Hook to provide all kinds of data for the business logic attached to the
+ * search suggestions functionality.
+ *
+ */
+import {
+  areSearchSuggestionsLoading,
+  fetchSearchSuggestions as fetchSearchSuggestionsAction,
+  getSearchSuggestionsError,
+  getSearchSuggestionsResult,
+  resetSearchSuggestions as resetSearchSuggestionsAction,
+} from '@farfetch/blackout-redux/search';
+import { useAction } from '../../helpers';
+import { useSelector } from 'react-redux';
+import type { UseSearchSuggestions } from './types';
+
+/**
+ * @returns All the selectors and actions needed to manage search suggestions
+ */
+const useSearchSuggestions: UseSearchSuggestions = () => {
+  const error = useSelector(getSearchSuggestionsError);
+  const isLoading = useSelector(areSearchSuggestionsLoading);
+  const suggestions = useSelector(getSearchSuggestionsResult);
+  // Actions
+  const fetchSearchSuggestions = useAction(fetchSearchSuggestionsAction);
+  const resetSearchSuggestions = useAction(resetSearchSuggestionsAction);
+
+  return {
+    /**
+     * Search suggestions error.
+     */
+    error,
+    /**
+     * Gets the search suggestions.
+     */
+    fetchSearchSuggestions,
+    /**
+     * Whether the search suggestions request is loading.
+     */
+    isLoading,
+    /**
+     * Resets the search suggestions result.
+     */
+    resetSearchSuggestions,
+    /**
+     * Search suggestions result received.
+     */
+    suggestions,
+  };
+};
+
+export default useSearchSuggestions;

--- a/tests/__fixtures__/search/searchSuggestions.fixtures.ts
+++ b/tests/__fixtures__/search/searchSuggestions.fixtures.ts
@@ -30,7 +30,7 @@ export const mockSearchSuggestionsResponse = [
 export const mockSearchSuggestionsState = {
   search: {
     suggestions: {
-      error: 'Error - Search request.',
+      error: { message: 'Error - Search request.' },
       isLoading: false,
       query: mockSearchSuggestionsQuery,
       result: mockSearchSuggestionsResponse,


### PR DESCRIPTION
## Description

This adds the `useSearchSuggestions` hook to the react package to facilitate
the use of selectors and actions for search suggestions.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
