### PR TITLE
fix(blackout-react): fix missing ga4 sort option schema

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.js
+++ b/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.js
@@ -20,7 +20,6 @@ import {
   quantitySchema,
   shippingSchema,
   sizeSchema,
-  sortOptionSchema,
   taxSchema,
   totalRequiredSchema,
   totalSchema,
@@ -119,6 +118,10 @@ const imageCountSchema = yup.object({
 
 const errorSchema = yup.object({
   error: yup.string().notRequired(),
+});
+
+const sortOptionSchema = yup.object({
+  sortOption: yup.string().notRequired(),
 });
 
 const viewItemSchema = fullProductSchema.concat(imageCountSchema);


### PR DESCRIPTION
## Description

- Remove wrong import and place missing schema on internal ga4 validation schemas.

### Dependencies

None.

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
