### PR TITLE
feat(core): add personal id and image endpoints

### DIFF
--- a/packages/core/src/profile/client/__fixtures__/deletePersonalId.fixtures.js
+++ b/packages/core/src/profile/client/__fixtures__/deletePersonalId.fixtures.js
@@ -1,0 +1,25 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: (userId, personalId, response) => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        method: 'delete',
+        response: response,
+        status: 204,
+      },
+    );
+  },
+  failure: (userId, personalId) => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        method: 'delete',
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/core/src/profile/client/__fixtures__/getPersonalId.fixtures.js
+++ b/packages/core/src/profile/client/__fixtures__/getPersonalId.fixtures.js
@@ -1,0 +1,25 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: (userId, personalId, response) => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        method: 'get',
+        response: response,
+        status: 200,
+      },
+    );
+  },
+  failure: (userId, personalId) => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        method: 'get',
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/core/src/profile/client/__fixtures__/patchPersonalId.fixtures.js
+++ b/packages/core/src/profile/client/__fixtures__/patchPersonalId.fixtures.js
@@ -1,0 +1,25 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: (userId, personalId, response) => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        method: 'patch',
+        response: response,
+        status: 200,
+      },
+    );
+  },
+  failure: (userId, personalId) => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        method: 'patch',
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/core/src/profile/client/__fixtures__/postPersonalIdImage.fixtures.js
+++ b/packages/core/src/profile/client/__fixtures__/postPersonalIdImage.fixtures.js
@@ -1,0 +1,25 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: (userId, response) => {
+    moxios.stubRequest(
+      join('/api/account/v1/users/', userId, 'personalIds/images'),
+      {
+        method: 'post',
+        response: response,
+        status: 200,
+      },
+    );
+  },
+  failure: userId => {
+    moxios.stubRequest(
+      join('/api/account/v1/users/', userId, 'personalIds/images'),
+      {
+        method: 'post',
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/core/src/profile/client/__tests__/__snapshots__/deletePersonalId.test.js.snap
+++ b/packages/core/src/profile/client/__tests__/__snapshots__/deletePersonalId.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deletePersonalId should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/profile/client/__tests__/__snapshots__/getPersonalId.test.js.snap
+++ b/packages/core/src/profile/client/__tests__/__snapshots__/getPersonalId.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPersonalId should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/profile/client/__tests__/__snapshots__/patchPersonalId.test.js.snap
+++ b/packages/core/src/profile/client/__tests__/__snapshots__/patchPersonalId.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`patchPersonalId should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/profile/client/__tests__/__snapshots__/postPersonalIdImage.test.js.snap
+++ b/packages/core/src/profile/client/__tests__/__snapshots__/postPersonalIdImage.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`postPersonalIdImage should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/profile/client/__tests__/deletePersonalId.test.js
+++ b/packages/core/src/profile/client/__tests__/deletePersonalId.test.js
@@ -1,0 +1,50 @@
+import * as profileClient from '..';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/deletePersonalId.fixtures';
+import moxios from 'moxios';
+
+describe('deletePersonalId', () => {
+  const expectedConfig = undefined;
+  const id = 123456;
+  const personalId = '123456';
+  const spy = jest.spyOn(client, 'delete');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = 200;
+
+    fixtures.success(id, personalId, response);
+
+    expect.assertions(2);
+
+    await expect(profileClient.deletePersonalId(id, personalId)).resolves.toBe(
+      response,
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${id}/personalIds/${personalId}`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure(id, personalId);
+
+    expect.assertions(2);
+
+    await expect(
+      profileClient.deletePersonalId(id, personalId),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${id}/personalIds/${personalId}`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/profile/client/__tests__/getPersonalId.test.js
+++ b/packages/core/src/profile/client/__tests__/getPersonalId.test.js
@@ -1,0 +1,50 @@
+import * as profileClient from '..';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/getPersonalId.fixtures';
+import moxios from 'moxios';
+
+describe('getPersonalId', () => {
+  const expectedConfig = undefined;
+  const id = 123456;
+  const personalId = '123456';
+  const spy = jest.spyOn(client, 'get');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = {};
+
+    fixtures.success(id, personalId, response);
+
+    expect.assertions(2);
+
+    await expect(profileClient.getPersonalId(id, personalId)).resolves.toBe(
+      response,
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${id}/personalIds/${personalId}`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure(id, personalId);
+
+    expect.assertions(2);
+
+    await expect(
+      profileClient.getPersonalId(id, personalId),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${id}/personalIds/${personalId}`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/profile/client/__tests__/patchPersonalId.test.js
+++ b/packages/core/src/profile/client/__tests__/patchPersonalId.test.js
@@ -1,0 +1,59 @@
+import * as profileClient from '..';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/patchPersonalId.fixtures';
+import moxios from 'moxios';
+
+describe('patchPersonalId', () => {
+  const expectedConfig = undefined;
+  const userId = 123456;
+  const personalId = '123456';
+  const data = {
+    backImageId: 'string',
+    expiryDate: 'string',
+    frontImageId: 'string',
+    idNumber: 'string',
+    name: 'string',
+  };
+  const spy = jest.spyOn(client, 'patch');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = {};
+
+    fixtures.success(userId, personalId, response);
+
+    expect.assertions(2);
+
+    await expect(
+      profileClient.patchPersonalId(userId, personalId, data),
+    ).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${userId}/personalIds/${personalId}`,
+      data,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure(userId, personalId);
+
+    expect.assertions(2);
+
+    await expect(
+      profileClient.patchPersonalId(userId, personalId, data),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${userId}/personalIds/${personalId}`,
+      data,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/profile/client/__tests__/postPersonalIdImage.test.js
+++ b/packages/core/src/profile/client/__tests__/postPersonalIdImage.test.js
@@ -1,0 +1,54 @@
+import * as profileClient from '..';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/postPersonalIdImage.fixtures';
+import moxios from 'moxios';
+
+describe('postPersonalIdImage', () => {
+  const expectedConfig = undefined;
+  const userId = 123456;
+  const data = {
+    file: 'string',
+  };
+  const spy = jest.spyOn(client, 'post');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = {};
+
+    fixtures.success(userId, response);
+
+    expect.assertions(2);
+
+    await expect(profileClient.postPersonalIdImage(userId, data)).resolves.toBe(
+      response,
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${userId}/personalIds/images`,
+      data,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure(userId);
+
+    expect.assertions(2);
+
+    await expect(
+      profileClient.postPersonalIdImage(userId, data),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${userId}/personalIds/images`,
+      data,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/profile/client/deletePersonalId.js
+++ b/packages/core/src/profile/client/deletePersonalId.js
@@ -1,0 +1,27 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * Method responsible for deleting a personal id.
+ *
+ * @function deletePersonalId
+ * @memberof module:profile/client
+ *
+ * @param {number} userId - The user's id.
+ * @param {string} personalId - Alphanumeric identifier of the personal id.
+ * @param {object} config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns {Promise} Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+export default (userId, personalId, config) =>
+  client
+    .delete(
+      join('/account/v1/users', userId, 'personalIds/', personalId),
+      config,
+    )
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/profile/client/getPersonalId.js
+++ b/packages/core/src/profile/client/getPersonalId.js
@@ -1,0 +1,24 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * Gets the personal ids for a specified id.
+ *
+ * @function getPersonalId
+ * @memberof module:profile/client
+ *
+ * @param {number} userId - User identifier.
+ * @param {string} personalId - Alphanumeric identifier of the personal id.
+ * @param {object} config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns {Promise} Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+export default (userId, personalId, config) =>
+  client
+    .get(join('/account/v1/users', userId, 'personalIds/', personalId), config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/profile/client/index.js
+++ b/packages/core/src/profile/client/index.js
@@ -34,3 +34,7 @@ export { default as getPersonalIds } from './getPersonalIds';
 export { default as postPersonalIds } from './postPersonalIds';
 export { default as getDefaultPersonalId } from './getDefaultPersonalId';
 export { default as putDefaultPersonalId } from './putDefaultPersonalId';
+export { default as deletePersonalId } from './deletePersonalId';
+export { default as getPersonalId } from './getPersonalId';
+export { default as patchPersonalId } from './patchPersonalId';
+export { default as postPersonalIdImage } from './postPersonalIdImage';

--- a/packages/core/src/profile/client/patchPersonalId.js
+++ b/packages/core/src/profile/client/patchPersonalId.js
@@ -1,0 +1,29 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * Method responsible for updating a specific personal id.
+ *
+ * @function patchPersonalId
+ * @memberof module:profile/client
+ *
+ * @param {number} userId - User identifier.
+ * @param {string} personalId - Alphanumeric identifier of the personal id.
+ * @param {object} data - Data to update a specific personal id.
+ * @param {object} config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns {Promise} Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+export default (userId, personalId, data, config) =>
+  client
+    .patch(
+      join('/account/v1/users', userId, 'personalIds/', personalId),
+      data,
+      config,
+    )
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/profile/client/postPersonalIdImage.js
+++ b/packages/core/src/profile/client/postPersonalIdImage.js
@@ -1,0 +1,24 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * Method responsible for creating a new personal id image.
+ *
+ * @function postPersonalIdImage
+ * @memberof module:profile/client
+ *
+ * @param {number} userId - User's id to create personal id image.
+ * @param {object} data - Object containing the image.
+ * @param {object} config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns {Promise} Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+export default (userId, data, config) =>
+  client
+    .post(join('/account/v1/users', userId, 'personalIds/images'), data, config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/profile/redux/__fixtures__/personalId.fixtures.js
+++ b/packages/core/src/profile/redux/__fixtures__/personalId.fixtures.js
@@ -1,0 +1,24 @@
+export const mockPostPersonalIdImageResponse = {
+  id: 'string',
+  side: 'FRONT',
+};
+
+export const mockGetPersonalIdResponse = {
+  backImageId: 'string',
+  expiryDate: 'string',
+  frontImageId: 'string',
+  id: 'string',
+  isDefault: true,
+  maskedIdNumber: 'string',
+  maskedName: 'string',
+  verifyLevel: 'UNVERIFIED',
+};
+
+export const mockPatchPersonalIdResponse = {
+  backImageId: 'string',
+  expiryDate: 'string',
+  frontImageId: 'string',
+  id: 'string',
+  idNumber: 'string',
+  name: 'string',
+};

--- a/packages/core/src/profile/redux/actionTypes.js
+++ b/packages/core/src/profile/redux/actionTypes.js
@@ -237,6 +237,7 @@ export const POST_PHONE_TOKEN_VALIDATIONS_REQUEST =
 /** Action type dispatched when the post phone token validations request succeeds. */
 export const POST_PHONE_TOKEN_VALIDATIONS_SUCCESS =
   '@farfetch/blackout-core/POST_PHONE_TOKEN_VALIDATIONS_SUCCESS';
+
 /** Action type dispatched when the get personal ids request fails. */
 export const GET_PERSONAL_IDS_FAILURE =
   '@farfetch/blackout-core/GET_PERSONAL_IDS_FAILURE';
@@ -276,3 +277,42 @@ export const PUT_DEFAULT_PERSONAL_ID_REQUEST =
 /** Action type dispatched when the put default personal id request succeeds. */
 export const PUT_DEFAULT_PERSONAL_ID_SUCCESS =
   '@farfetch/blackout-core/PUT_DEFAULT_PERSONAL_ID_SUCCESS';
+/** Action type dispatched when the post personal id image request fails. */
+export const POST_PERSONAL_ID_IMAGE_FAILURE =
+  '@farfetch/blackout-core/POST_PERSONAL_ID_IMAGE_FAILURE';
+/** Action type dispatched when the post personal id image request starts. */
+export const POST_PERSONAL_ID_IMAGE_REQUEST =
+  '@farfetch/blackout-core/POST_PERSONAL_ID_IMAGE_REQUEST';
+/** Action type dispatched when the post personal id image request succeeds. */
+export const POST_PERSONAL_ID_IMAGE_SUCCESS =
+  '@farfetch/blackout-core/POST_PERSONAL_ID_IMAGE_SUCCESS';
+
+/** Action type dispatched when the get personal id request fails. */
+export const GET_PERSONAL_ID_FAILURE =
+  '@farfetch/blackout-core/GET_PERSONAL_ID_FAILURE';
+/** Action type dispatched when the get personal id request starts. */
+export const GET_PERSONAL_ID_REQUEST =
+  '@farfetch/blackout-core/GET_PERSONAL_ID_REQUEST';
+/** Action type dispatched when the get personal id request succeeds. */
+export const GET_PERSONAL_ID_SUCCESS =
+  '@farfetch/blackout-core/GET_PERSONAL_ID_SUCCESS';
+
+/** Action type dispatched when the patch personal id request fails. */
+export const PATCH_PERSONAL_ID_FAILURE =
+  '@farfetch/blackout-core/PATCH_PERSONAL_ID_FAILURE';
+/** Action type dispatched when the patch personal id request starts. */
+export const PATCH_PERSONAL_ID_REQUEST =
+  '@farfetch/blackout-core/PATCH_PERSONAL_ID_REQUEST';
+/** Action type dispatched when the patch personal id request succeeds. */
+export const PATCH_PERSONAL_ID_SUCCESS =
+  '@farfetch/blackout-core/PATCH_PERSONAL_ID_SUCCESS';
+
+/** Action type dispatched when the delete personal id request fails. */
+export const DELETE_PERSONAL_ID_FAILURE =
+  '@farfetch/blackout-core/DELETE_PERSONAL_ID_FAILURE';
+/** Action type dispatched when the delete personal id request starts. */
+export const DELETE_PERSONAL_ID_REQUEST =
+  '@farfetch/blackout-core/DELETE_PERSONAL_ID_REQUEST';
+/** Action type dispatched when the delete personal id request succeeds. */
+export const DELETE_PERSONAL_ID_SUCCESS =
+  '@farfetch/blackout-core/DELETE_PERSONAL_ID_SUCCESS';

--- a/packages/core/src/profile/redux/actions/__tests__/__snapshots__/doDeletePersonalId.test.js.snap
+++ b/packages/core/src/profile/redux/actions/__tests__/__snapshots__/doDeletePersonalId.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doDeletePersonalId action creator should create the correct actions for when the delete personal id procedure is successful: delete personal id success payload 1`] = `
+Object {
+  "type": "@farfetch/blackout-core/DELETE_PERSONAL_ID_SUCCESS",
+}
+`;

--- a/packages/core/src/profile/redux/actions/__tests__/__snapshots__/doGetPersonalId.test.js.snap
+++ b/packages/core/src/profile/redux/actions/__tests__/__snapshots__/doGetPersonalId.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doGetPersonalId action creator should create the correct actions for when the get personal id procedure is successful: get personal id success payload 1`] = `
+Object {
+  "payload": Object {
+    "backImageId": "string",
+    "expiryDate": "string",
+    "frontImageId": "string",
+    "id": "string",
+    "isDefault": true,
+    "maskedIdNumber": "string",
+    "maskedName": "string",
+    "verifyLevel": "UNVERIFIED",
+  },
+  "type": "@farfetch/blackout-core/GET_PERSONAL_ID_SUCCESS",
+}
+`;

--- a/packages/core/src/profile/redux/actions/__tests__/__snapshots__/doPatchPersonalId.test.js.snap
+++ b/packages/core/src/profile/redux/actions/__tests__/__snapshots__/doPatchPersonalId.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doPatchPersonalId action creator should create the correct actions for when the patch personal id procedure is successful: patch personal id success payload 1`] = `
+Object {
+  "payload": Object {
+    "backImageId": "string",
+    "expiryDate": "string",
+    "frontImageId": "string",
+    "id": "string",
+    "idNumber": "string",
+    "name": "string",
+  },
+  "type": "@farfetch/blackout-core/PATCH_PERSONAL_ID_SUCCESS",
+}
+`;

--- a/packages/core/src/profile/redux/actions/__tests__/__snapshots__/doPostPersonalIdImage.test.js.snap
+++ b/packages/core/src/profile/redux/actions/__tests__/__snapshots__/doPostPersonalIdImage.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doPostPersonalIdImage action creator should create the correct actions for when the post personal id image procedure is successful: post personal id image success payload 1`] = `
+Object {
+  "payload": Object {
+    "id": "string",
+    "side": "FRONT",
+  },
+  "type": "@farfetch/blackout-core/POST_PERSONAL_ID_IMAGE_SUCCESS",
+}
+`;

--- a/packages/core/src/profile/redux/actions/__tests__/doDeletePersonalId.test.js
+++ b/packages/core/src/profile/redux/actions/__tests__/doDeletePersonalId.test.js
@@ -1,0 +1,76 @@
+import { mockStore } from '../../../../../tests';
+import doDeletePersonalId from '../doDeletePersonalId';
+import find from 'lodash/find';
+import reducer, { actionTypes } from '../..';
+
+const profileMockStore = (state = {}) =>
+  mockStore({ profile: reducer() }, state);
+
+const expectedConfig = undefined;
+let store;
+
+describe('doDeletePersonalId action creator', () => {
+  const deletePersonalId = jest.fn();
+  const action = doDeletePersonalId(deletePersonalId);
+  const userId = 123456789;
+  const personalId = '123456';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = profileMockStore();
+  });
+
+  it('should create the correct actions for when the delete personal id procedure fails', async () => {
+    const expectedError = new Error('delete personal id error');
+
+    deletePersonalId.mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(userId, personalId));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(deletePersonalId).toHaveBeenCalledTimes(1);
+      expect(deletePersonalId).toHaveBeenCalledWith(
+        userId,
+        personalId,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.DELETE_PERSONAL_ID_REQUEST },
+          {
+            type: actionTypes.DELETE_PERSONAL_ID_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the delete personal id procedure is successful', async () => {
+    deletePersonalId.mockResolvedValueOnce();
+
+    await store.dispatch(action(userId, personalId, expectedConfig));
+
+    const actionResults = store.getActions();
+
+    expect(deletePersonalId).toHaveBeenCalledTimes(1);
+    expect(deletePersonalId).toHaveBeenCalledWith(
+      userId,
+      personalId,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.DELETE_PERSONAL_ID_REQUEST },
+      {
+        type: actionTypes.DELETE_PERSONAL_ID_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.DELETE_PERSONAL_ID_SUCCESS,
+      }),
+    ).toMatchSnapshot('delete personal id success payload');
+  });
+});

--- a/packages/core/src/profile/redux/actions/__tests__/doGetPersonalId.test.js
+++ b/packages/core/src/profile/redux/actions/__tests__/doGetPersonalId.test.js
@@ -1,0 +1,77 @@
+import { mockGetPersonalIdResponse } from '../../__fixtures__/personalId.fixtures';
+import { mockStore } from '../../../../../tests';
+import doGetPersonalId from '../doGetPersonalId';
+import find from 'lodash/find';
+import reducer, { actionTypes } from '../../';
+
+const profileMockStore = (state = {}) =>
+  mockStore({ profile: reducer() }, state);
+
+describe('doGetPersonalId action creator', () => {
+  let store;
+  const getPersonalId = jest.fn();
+  const action = doGetPersonalId(getPersonalId);
+  const userId = 123456;
+  const personalId = '123456';
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = profileMockStore();
+  });
+
+  it('should create the correct actions for when the get personal id procedure fails', async () => {
+    const expectedError = new Error('get personal id error');
+
+    getPersonalId.mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(userId, personalId));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(getPersonalId).toHaveBeenCalledTimes(1);
+      expect(getPersonalId).toHaveBeenCalledWith(
+        userId,
+        personalId,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.GET_PERSONAL_ID_REQUEST },
+          {
+            type: actionTypes.GET_PERSONAL_ID_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the get personal id procedure is successful', async () => {
+    getPersonalId.mockResolvedValueOnce(mockGetPersonalIdResponse);
+
+    await store.dispatch(action(userId, personalId));
+
+    const actionResults = store.getActions();
+
+    expect(getPersonalId).toHaveBeenCalledTimes(1);
+    expect(getPersonalId).toHaveBeenCalledWith(
+      userId,
+      personalId,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.GET_PERSONAL_ID_REQUEST },
+      {
+        payload: mockGetPersonalIdResponse,
+        type: actionTypes.GET_PERSONAL_ID_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.GET_PERSONAL_ID_SUCCESS,
+      }),
+    ).toMatchSnapshot('get personal id success payload');
+  });
+});

--- a/packages/core/src/profile/redux/actions/__tests__/doPatchPersonalId.test.js
+++ b/packages/core/src/profile/redux/actions/__tests__/doPatchPersonalId.test.js
@@ -1,0 +1,87 @@
+import { mockPatchPersonalIdResponse } from '../../__fixtures__/personalId.fixtures';
+import { mockStore } from '../../../../../tests';
+import doPatchPersonalId from '../doPatchPersonalId';
+import find from 'lodash/find';
+import reducer, { actionTypes } from '../..';
+
+const profileMockStore = (state = {}) =>
+  mockStore({ profile: reducer() }, state);
+
+let store;
+
+describe('doPatchPersonalId action creator', () => {
+  const userId = 123456;
+  const personalId = '123456';
+  const data = {
+    backImageId: 'string',
+    expiryDate: 'string',
+    frontImageId: 'string',
+    idNumber: 'string',
+    name: 'string',
+  };
+  const expectedConfig = undefined;
+  const patchPersonalId = jest.fn();
+  const action = doPatchPersonalId(patchPersonalId);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = profileMockStore();
+  });
+
+  it('should create the correct actions for when the patch personal id procedure fails', async () => {
+    const expectedError = new Error('patch personal id error');
+
+    patchPersonalId.mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(userId, personalId, data));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(patchPersonalId).toHaveBeenCalledTimes(1);
+      expect(patchPersonalId).toHaveBeenCalledWith(
+        userId,
+        personalId,
+        data,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.PATCH_PERSONAL_ID_REQUEST },
+          {
+            type: actionTypes.PATCH_PERSONAL_ID_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the patch personal id procedure is successful', async () => {
+    patchPersonalId.mockResolvedValueOnce(mockPatchPersonalIdResponse);
+
+    await store.dispatch(action(userId, personalId, data));
+
+    const actionResults = store.getActions();
+
+    expect(patchPersonalId).toHaveBeenCalledTimes(1);
+    expect(patchPersonalId).toHaveBeenCalledWith(
+      userId,
+      personalId,
+      data,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.PATCH_PERSONAL_ID_REQUEST },
+      {
+        payload: mockPatchPersonalIdResponse,
+        type: actionTypes.PATCH_PERSONAL_ID_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.PATCH_PERSONAL_ID_SUCCESS,
+      }),
+    ).toMatchSnapshot('patch personal id success payload');
+  });
+});

--- a/packages/core/src/profile/redux/actions/__tests__/doPostPersonalIdImage.test.js
+++ b/packages/core/src/profile/redux/actions/__tests__/doPostPersonalIdImage.test.js
@@ -1,0 +1,79 @@
+import { mockPostPersonalIdImageResponse } from '../../__fixtures__/personalId.fixtures';
+import { mockStore } from '../../../../../tests';
+import doPostPersonalIdImage from '../doPostPersonalIdImage';
+import find from 'lodash/find';
+import reducer, { actionTypes } from '../..';
+
+describe('doPostPersonalIdImage action creator', () => {
+  const profileMockStore = (state = {}) =>
+    mockStore({ profile: reducer() }, state);
+
+  let store;
+  const postPersonalIdImage = jest.fn();
+  const action = doPostPersonalIdImage(postPersonalIdImage);
+  const userId = 12345;
+  const data = {
+    file: 'string',
+  };
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = profileMockStore();
+  });
+
+  it('should create the correct actions for when the post personal id image procedure fails', async () => {
+    const expectedError = new Error('post personal id image error');
+
+    postPersonalIdImage.mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(userId, data));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(postPersonalIdImage).toHaveBeenCalledTimes(1);
+      expect(postPersonalIdImage).toHaveBeenCalledWith(
+        userId,
+        data,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.POST_PERSONAL_ID_IMAGE_REQUEST },
+          {
+            type: actionTypes.POST_PERSONAL_ID_IMAGE_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the post personal id image procedure is successful', async () => {
+    postPersonalIdImage.mockResolvedValueOnce(mockPostPersonalIdImageResponse);
+    await store.dispatch(action(userId, data));
+
+    const actionResults = store.getActions();
+
+    expect(postPersonalIdImage).toHaveBeenCalledTimes(1);
+    expect(postPersonalIdImage).toHaveBeenCalledWith(
+      userId,
+      data,
+      expectedConfig,
+    );
+
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.POST_PERSONAL_ID_IMAGE_REQUEST },
+      {
+        payload: mockPostPersonalIdImageResponse,
+        type: actionTypes.POST_PERSONAL_ID_IMAGE_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.POST_PERSONAL_ID_IMAGE_SUCCESS,
+      }),
+    ).toMatchSnapshot('post personal id image success payload');
+  });
+});

--- a/packages/core/src/profile/redux/actions/doDeletePersonalId.js
+++ b/packages/core/src/profile/redux/actions/doDeletePersonalId.js
@@ -1,0 +1,48 @@
+import {
+  DELETE_PERSONAL_ID_FAILURE,
+  DELETE_PERSONAL_ID_REQUEST,
+  DELETE_PERSONAL_ID_SUCCESS,
+} from '../actionTypes';
+
+/**
+ * @callback DeletePersonalIdThunkFactory
+ * @param {number} userId - The user's id.
+ * @param {string} personalId - Alphanumeric identifier of the personal id.
+ * @param {object} config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Delete a personal id.
+ *
+ * @function doDeletePersonalId
+ * @memberof module:profile/actions
+ *
+ * @param {Function} deletePersonalId - Delete personal id client.
+ *
+ * @returns {DeletePersonalIdThunkFactory} Thunk factory.
+ */
+export default deletePersonalId =>
+  (userId, personalId, config) =>
+  async dispatch => {
+    dispatch({
+      type: DELETE_PERSONAL_ID_REQUEST,
+    });
+
+    try {
+      await deletePersonalId(userId, personalId, config);
+
+      dispatch({
+        type: DELETE_PERSONAL_ID_SUCCESS,
+      });
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: DELETE_PERSONAL_ID_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/core/src/profile/redux/actions/doGetPersonalId.js
+++ b/packages/core/src/profile/redux/actions/doGetPersonalId.js
@@ -1,0 +1,49 @@
+import {
+  GET_PERSONAL_ID_FAILURE,
+  GET_PERSONAL_ID_REQUEST,
+  GET_PERSONAL_ID_SUCCESS,
+} from '../actionTypes';
+
+/**
+ * @callback GetPersonalIdThunkFactory
+ * @param {number} userId - User identifier.
+ * @param {string} personalId - Alphanumeric identifier of the personal id.
+ * @param {object} config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Gets the personal id.
+ *
+ * @function doGetPersonalId
+ * @memberof module:profile/actions
+ *
+ * @param {Function} getPersonalId - Get personal id client.
+ *
+ * @returns {GetPersonalIdThunkFactory} Thunk factory.
+ */
+export default getPersonalId =>
+  (userId, personalId, config) =>
+  async dispatch => {
+    dispatch({
+      type: GET_PERSONAL_ID_REQUEST,
+    });
+
+    try {
+      const result = await getPersonalId(userId, personalId, config);
+
+      dispatch({
+        payload: result,
+        type: GET_PERSONAL_ID_SUCCESS,
+      });
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: GET_PERSONAL_ID_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/core/src/profile/redux/actions/doPatchPersonalId.js
+++ b/packages/core/src/profile/redux/actions/doPatchPersonalId.js
@@ -1,0 +1,50 @@
+import {
+  PATCH_PERSONAL_ID_FAILURE,
+  PATCH_PERSONAL_ID_REQUEST,
+  PATCH_PERSONAL_ID_SUCCESS,
+} from '../actionTypes';
+
+/**
+ * @callback PatchPersonalIdThunkFactory
+ * @param {number} userId - User identifier.
+ * @param {string} personalId - Alphanumeric identifier of the personal id.
+ * @param {object} data - Data to update a specific personal id.
+ * @param {object} config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Updates a specific personal id.
+ *
+ * @function doPatchPersonalId
+ * @memberof module:profile/actions
+ *
+ * @param {Function} patchPersonalId - Patch personal id client.
+ *
+ * @returns {PatchPersonalIdThunkFactory} Thunk factory.
+ */
+export default patchPersonalId =>
+  (userId, personalId, data, config) =>
+  async dispatch => {
+    dispatch({
+      type: PATCH_PERSONAL_ID_REQUEST,
+    });
+
+    try {
+      const result = await patchPersonalId(userId, personalId, data, config);
+
+      dispatch({
+        type: PATCH_PERSONAL_ID_SUCCESS,
+        payload: result,
+      });
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: PATCH_PERSONAL_ID_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/core/src/profile/redux/actions/doPostPersonalIdImage.js
+++ b/packages/core/src/profile/redux/actions/doPostPersonalIdImage.js
@@ -1,0 +1,49 @@
+import {
+  POST_PERSONAL_ID_IMAGE_FAILURE,
+  POST_PERSONAL_ID_IMAGE_REQUEST,
+  POST_PERSONAL_ID_IMAGE_SUCCESS,
+} from '../actionTypes';
+
+/**
+ * @callback PostPersonalIdImageThunkFactory
+ * @param {number} userId - User's id to create personal id image.
+ * @param {object} data - Object containing the image.
+ * @param {object} config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Creates a personal id image.
+ *
+ * @function doPostPersonalIdImage
+ * @memberof module:profile/actions
+ *
+ * @param {Function} postPersonalIdImage - Post personal id image client.
+ *
+ * @returns {PostPersonalIdImageThunkFactory} Thunk factory.
+ */
+export default postPersonalIdImage =>
+  (userId, data, config) =>
+  async dispatch => {
+    dispatch({
+      type: POST_PERSONAL_ID_IMAGE_REQUEST,
+    });
+
+    try {
+      const result = await postPersonalIdImage(userId, data, config);
+
+      dispatch({
+        type: POST_PERSONAL_ID_IMAGE_SUCCESS,
+        payload: result,
+      });
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: POST_PERSONAL_ID_IMAGE_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/core/src/profile/redux/actions/index.js
+++ b/packages/core/src/profile/redux/actions/index.js
@@ -34,3 +34,7 @@ export { default as doGetPersonalIds } from './doGetPersonalIds';
 export { default as doPostPersonalIds } from './doPostPersonalIds';
 export { default as doGetDefaultPersonalId } from './doGetDefaultPersonalId';
 export { default as doPutDefaultPersonalId } from './doPutDefaultPersonalId';
+export { default as doGetPersonalId } from './doGetPersonalId';
+export { default as doPatchPersonalId } from './doPatchPersonalId';
+export { default as doDeletePersonalId } from './doDeletePersonalId';
+export { default as doPostPersonalIdImage } from './doPostPersonalIdImage';


### PR DESCRIPTION
## Description

- Add personal id and image clients and redux actions
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
