### PR TITLE
feat(client|redux): add personal id and image endpoints

### DIFF
--- a/packages/client/src/users/__fixtures__/deletePersonalId.fixtures.ts
+++ b/packages/client/src/users/__fixtures__/deletePersonalId.fixtures.ts
@@ -1,0 +1,23 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: (userId: number, personalId: string, response: number): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        response: response,
+        status: 200,
+      },
+    );
+  },
+  failure: (userId: number, personalId: string): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/client/src/users/__fixtures__/getPersonalId.fixtures.ts
+++ b/packages/client/src/users/__fixtures__/getPersonalId.fixtures.ts
@@ -1,0 +1,31 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+import type { PersonalIdResponse } from '../types';
+
+/**
+ * Response payloads.
+ */
+export default {
+  success: (
+    userId: number,
+    personalId: string,
+    response: PersonalIdResponse,
+  ): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        response: response,
+        status: 200,
+      },
+    );
+  },
+  failure: (userId: number, personalId: string): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/client/src/users/__fixtures__/patchPersonalId.fixtures.ts
+++ b/packages/client/src/users/__fixtures__/patchPersonalId.fixtures.ts
@@ -1,0 +1,28 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+import type { PatchPersonalIdResponse } from '../types';
+
+export default {
+  success: (
+    userId: number,
+    personalId: string,
+    response: PatchPersonalIdResponse,
+  ): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        response: response,
+        status: 200,
+      },
+    );
+  },
+  failure: (userId: number, personalId: string): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', userId, 'personalIds/', personalId),
+      {
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/client/src/users/__fixtures__/postPersonalIdImage.fixtures.ts
+++ b/packages/client/src/users/__fixtures__/postPersonalIdImage.fixtures.ts
@@ -1,0 +1,24 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+import type { PostPersonalIdImageResponse } from '../types';
+
+export default {
+  success: (userId: number, response: PostPersonalIdImageResponse): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/users/', userId, 'personalIds/images'),
+      {
+        response: response,
+        status: 200,
+      },
+    );
+  },
+  failure: (userId: number): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/users/', userId, 'personalIds/images'),
+      {
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/client/src/users/__tests__/__snapshots__/deletePersonalId.test.ts.snap
+++ b/packages/client/src/users/__tests__/__snapshots__/deletePersonalId.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deletePersonalId should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/client/src/users/__tests__/__snapshots__/getPersonalId.test.ts.snap
+++ b/packages/client/src/users/__tests__/__snapshots__/getPersonalId.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPersonalId should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/client/src/users/__tests__/__snapshots__/patchPersonalId.test.ts.snap
+++ b/packages/client/src/users/__tests__/__snapshots__/patchPersonalId.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`patchPersonalId should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/client/src/users/__tests__/__snapshots__/postPersonalIdImage.test.ts.snap
+++ b/packages/client/src/users/__tests__/__snapshots__/postPersonalIdImage.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`postPersonalIdImage should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/client/src/users/__tests__/deletePersonalId.test.ts
+++ b/packages/client/src/users/__tests__/deletePersonalId.test.ts
@@ -1,0 +1,55 @@
+import * as profileClient from '..';
+import client from '../../helpers/client';
+import fixtures from '../__fixtures__/deletePersonalId.fixtures';
+import moxios from 'moxios';
+
+describe('deletePersonalId', () => {
+  const expectedConfig = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const id = 123456;
+  const personalId = '123456';
+  const config = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const spy = jest.spyOn(client, 'delete');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = 200;
+
+    fixtures.success(id, personalId, response);
+
+    expect.assertions(2);
+
+    await expect(
+      profileClient.deletePersonalId(id, personalId, config),
+    ).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${id}/personalIds/${personalId}`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure(id, personalId);
+
+    expect.assertions(2);
+
+    await expect(
+      profileClient.deletePersonalId(id, personalId, config),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${id}/personalIds/${personalId}`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/client/src/users/__tests__/getPersonalId.test.ts
+++ b/packages/client/src/users/__tests__/getPersonalId.test.ts
@@ -1,0 +1,54 @@
+import { getPersonalId } from '..';
+import { mockPersonalIdResponse } from 'tests/__fixtures__/users';
+import client from '../../helpers/client';
+import fixtures from '../__fixtures__/getPersonalId.fixtures';
+import moxios from 'moxios';
+
+describe('getPersonalId', () => {
+  const expectedConfig = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const id = 123456;
+  const personalId = '123456';
+  const config = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const spy = jest.spyOn(client, 'get');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = mockPersonalIdResponse;
+
+    fixtures.success(id, personalId, response);
+
+    expect.assertions(2);
+
+    await expect(getPersonalId(id, personalId, config)).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${id}/personalIds/${personalId}`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure(id, personalId);
+
+    expect.assertions(2);
+
+    await expect(
+      getPersonalId(id, personalId, config),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${id}/personalIds/${personalId}`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/client/src/users/__tests__/patchPersonalId.test.ts
+++ b/packages/client/src/users/__tests__/patchPersonalId.test.ts
@@ -1,0 +1,65 @@
+import { mockPatchPersonalIdResponse } from 'tests/__fixtures__/users';
+import { patchPersonalId } from '..';
+import client from '../../helpers/client';
+import fixtures from '../__fixtures__/patchPersonalId.fixtures';
+import moxios from 'moxios';
+
+describe('patchPersonalId', () => {
+  const expectedConfig = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const userId = 123456;
+  const personalId = '123456';
+  const data = {
+    backImageId: 'string',
+    expiryDate: 'string',
+    frontImageId: 'string',
+    idNumber: 'string',
+    name: 'string',
+  };
+  const config = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const spy = jest.spyOn(client, 'patch');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = mockPatchPersonalIdResponse;
+
+    fixtures.success(userId, personalId, response);
+
+    expect.assertions(2);
+
+    await expect(
+      patchPersonalId(userId, personalId, data, config),
+    ).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${userId}/personalIds/${personalId}`,
+      data,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure(userId, personalId);
+
+    expect.assertions(2);
+
+    await expect(
+      patchPersonalId(userId, personalId, data, config),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${userId}/personalIds/${personalId}`,
+      data,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/client/src/users/__tests__/postPersonalIdImage.test.ts
+++ b/packages/client/src/users/__tests__/postPersonalIdImage.test.ts
@@ -1,0 +1,60 @@
+import { mockPostPersonalIdImageResponse } from 'tests/__fixtures__/users';
+import { postPersonalIdImage } from '..';
+import client from '../../helpers/client';
+import fixtures from '../__fixtures__/postPersonalIdImage.fixtures';
+import moxios from 'moxios';
+
+describe('postPersonalIdImage', () => {
+  const expectedConfig = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const userId = 123456;
+  const data = {
+    file: 'string',
+  };
+  const config = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const spy = jest.spyOn(client, 'post');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = mockPostPersonalIdImageResponse;
+
+    fixtures.success(userId, response);
+
+    expect.assertions(2);
+
+    await expect(postPersonalIdImage(userId, data, config)).resolves.toBe(
+      response,
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${userId}/personalIds/images`,
+      data,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure(userId);
+
+    expect.assertions(2);
+
+    await expect(
+      postPersonalIdImage(userId, data, config),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${userId}/personalIds/images`,
+      data,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/client/src/users/deletePersonalId.ts
+++ b/packages/client/src/users/deletePersonalId.ts
@@ -1,0 +1,27 @@
+import client, { adaptError } from '../helpers/client';
+import join from 'proper-url-join';
+import type { DeletePersonalId } from './types';
+
+/**
+ * Method responsible for deleting a personal id.
+ *
+ * @param userId - The user's id.
+ * @param personalId - The personal identifier.
+ * @param config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+const deletePersonalId: DeletePersonalId = (userId, personalId, config) =>
+  client
+    .delete(
+      join('/account/v1/users', userId, 'personalIds/', personalId),
+      config,
+    )
+    .then(response => response.status)
+    .catch(error => {
+      throw adaptError(error);
+    });
+
+export default deletePersonalId;

--- a/packages/client/src/users/getPersonalId.ts
+++ b/packages/client/src/users/getPersonalId.ts
@@ -1,0 +1,25 @@
+import client, { adaptError } from '../helpers/client';
+import join from 'proper-url-join';
+import type { GetPersonalId } from './types';
+
+/**
+ * Method responsible for getting a personal id.
+ *
+ * @param userId - The user's id.
+ * @param personalId - Personal identifier.
+ * @param config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+
+const getPersonalId: GetPersonalId = (userId, personalId, config) =>
+  client
+    .get(join('/account/v1/users', userId, 'personalIds/', personalId), config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });
+
+export default getPersonalId;

--- a/packages/client/src/users/index.ts
+++ b/packages/client/src/users/index.ts
@@ -34,3 +34,7 @@ export { default as getPersonalIds } from './getPersonalIds';
 export { default as postPersonalIds } from './postPersonalIds';
 export { default as getDefaultPersonalId } from './getDefaultPersonalId';
 export { default as putDefaultPersonalId } from './putDefaultPersonalId';
+export { default as postPersonalIdImage } from './postPersonalIdImage';
+export { default as deletePersonalId } from './deletePersonalId';
+export { default as getPersonalId } from './getPersonalId';
+export { default as patchPersonalId } from './patchPersonalId';

--- a/packages/client/src/users/patchPersonalId.ts
+++ b/packages/client/src/users/patchPersonalId.ts
@@ -1,0 +1,29 @@
+import client, { adaptError } from '../helpers/client';
+import join from 'proper-url-join';
+import type { PatchPersonalId } from './types';
+
+/**
+ * Method responsible for updating specific personal id.
+ *
+ * @param userId - User identifier.
+ * @param personalId - Personal identifier.
+ * @param data - Personal id data.
+ * @param config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+const patchPersonalId: PatchPersonalId = (userId, personalId, data, config) =>
+  client
+    .patch(
+      join('/account/v1/users', userId, 'personalIds/', personalId),
+      data,
+      config,
+    )
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });
+
+export default patchPersonalId;

--- a/packages/client/src/users/postPersonalIdImage.ts
+++ b/packages/client/src/users/postPersonalIdImage.ts
@@ -1,0 +1,24 @@
+import client, { adaptError } from '../helpers/client';
+import join from 'proper-url-join';
+import type { PostPersonalIdImage } from './types';
+
+/**
+ * Method responsible for creating personal id image.
+ *
+ * @param userId - User's id to set personal id image.
+ * @param data - Personal id image object.
+ * @param config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+const postPersonalIdImage: PostPersonalIdImage = (userId, data, config) =>
+  client
+    .post(join('/account/v1/users', userId, 'personalIds/images'), data, config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });
+
+export default postPersonalIdImage;

--- a/packages/client/src/users/types/deletePersonalId.types.ts
+++ b/packages/client/src/users/types/deletePersonalId.types.ts
@@ -1,0 +1,7 @@
+import type { Config } from '../../types';
+
+export type DeletePersonalId = (
+  userId: number,
+  personalId: string,
+  config: Config,
+) => Promise<number>;

--- a/packages/client/src/users/types/getPersonalId.types.ts
+++ b/packages/client/src/users/types/getPersonalId.types.ts
@@ -1,0 +1,8 @@
+import type { Config } from '../../types';
+import type { PersonalIdResponse } from './personalId.types';
+
+export type GetPersonalId = (
+  userId: number,
+  personalId: string,
+  config: Config,
+) => Promise<PersonalIdResponse>;

--- a/packages/client/src/users/types/index.ts
+++ b/packages/client/src/users/types/index.ts
@@ -33,4 +33,8 @@ export * from './getPersonalIds.types';
 export * from './postPersonalIds.types';
 export * from './getDefaultPersonalId.types';
 export * from './putDefaultPersonalId.types';
+export * from './postPersonalIdImage.types';
+export * from './deletePersonalId.types';
+export * from './getPersonalId.types';
+export * from './patchPersonalId.types';
 export * from './personalId.types';

--- a/packages/client/src/users/types/patchPersonalId.types.ts
+++ b/packages/client/src/users/types/patchPersonalId.types.ts
@@ -1,0 +1,12 @@
+import type { Config } from '../../types';
+import type {
+  PatchPersonalIdData,
+  PatchPersonalIdResponse,
+} from './personalId.types';
+
+export type PatchPersonalId = (
+  userId: number,
+  personalId: string,
+  data: PatchPersonalIdData,
+  config: Config,
+) => Promise<PatchPersonalIdResponse>;

--- a/packages/client/src/users/types/personalId.types.ts
+++ b/packages/client/src/users/types/personalId.types.ts
@@ -5,6 +5,23 @@ export enum VerifyLevel {
   INVALID,
 }
 
+export enum Side {
+  FRONT,
+  BACK,
+  UNKNOWN,
+}
+
+export type PersonalIdResponse = {
+  backImageId: string;
+  expiryDate: string;
+  frontImageId: string;
+  id: string;
+  isDefault: boolean;
+  maskedIdNumber: string;
+  maskedName: string;
+  verifyLevel: VerifyLevel;
+};
+
 export type DefaultPersonalIdResponse = {
   backImageId: string;
   expiryDate: string;
@@ -45,4 +62,30 @@ export type PutDefaultPersonalIdResponse = {
   maskedIdNumber: string;
   maskedName: string;
   verifyLevel: VerifyLevel;
+};
+
+export type PatchPersonalIdResponse = {
+  backImageId: string;
+  expiryDate: string;
+  frontImageId: string;
+  id: string;
+  idNumber: string;
+  name: string;
+};
+
+export type PostPersonalIdImageResponse = {
+  id: string;
+  side: Side;
+};
+
+export type PatchPersonalIdData = {
+  backImageId: string;
+  expiryDate: string;
+  frontImageId: string;
+  idNumber: string;
+  name: string;
+};
+
+export type PostPersonalIdImageData = {
+  file: string;
 };

--- a/packages/client/src/users/types/postPersonalIdImage.types.ts
+++ b/packages/client/src/users/types/postPersonalIdImage.types.ts
@@ -1,0 +1,11 @@
+import type { Config } from '../../types';
+import type {
+  PostPersonalIdImageData,
+  PostPersonalIdImageResponse,
+} from './personalId.types';
+
+export type PostPersonalIdImage = (
+  userId: number,
+  data: PostPersonalIdImageData,
+  config: Config,
+) => Promise<PostPersonalIdImageResponse>;

--- a/packages/redux/src/users/actionTypes.ts
+++ b/packages/redux/src/users/actionTypes.ts
@@ -283,3 +283,43 @@ export const SET_DEFAULT_PERSONAL_ID_REQUEST =
 /** Action type dispatched when the set default personal id request succeeds. */
 export const SET_DEFAULT_PERSONAL_ID_SUCCESS =
   '@farfetch/blackout-client/SET_DEFAULT_PERSONAL_ID_SUCCESS';
+
+/** Action type disupdateed when the create personal id image request fails. */
+export const CREATE_PERSONAL_ID_IMAGE_FAILURE =
+  '@farfetch/blackout-client/CREATE_PERSONAL_ID_IMAGE_FAILURE';
+/** Action type disupdateed when the create personal id image request starts. */
+export const CREATE_PERSONAL_ID_IMAGE_REQUEST =
+  '@farfetch/blackout-client/CREATE_PERSONAL_ID_IMAGE_REQUEST';
+/** Action type disupdateed when the create personal id image request succeeds. */
+export const CREATE_PERSONAL_ID_IMAGE_SUCCESS =
+  '@farfetch/blackout-client/CREATE_PERSONAL_ID_IMAGE_SUCCESS';
+
+/** Action type disupdateed when the fetch personal id request fails. */
+export const FETCH_PERSONAL_ID_FAILURE =
+  '@farfetch/blackout-client/FETCH_PERSONAL_ID_FAILURE';
+/** Action type disupdateed when the fetch personal id request starts. */
+export const FETCH_PERSONAL_ID_REQUEST =
+  '@farfetch/blackout-client/FETCH_PERSONAL_ID_REQUEST';
+/** Action type disupdateed when the fetch personal id request succeeds. */
+export const FETCH_PERSONAL_ID_SUCCESS =
+  '@farfetch/blackout-client/FETCH_PERSONAL_ID_SUCCESS';
+
+/** Action type disupdateed when the update personal id request fails. */
+export const UPDATE_PERSONAL_ID_FAILURE =
+  '@farfetch/blackout-client/UPDATE_PERSONAL_ID_FAILURE';
+/** Action type disupdateed when the update personal id request starts. */
+export const UPDATE_PERSONAL_ID_REQUEST =
+  '@farfetch/blackout-client/UPDATE_PERSONAL_ID_REQUEST';
+/** Action type disupdateed when the update personal id request succeeds. */
+export const UPDATE_PERSONAL_ID_SUCCESS =
+  '@farfetch/blackout-client/UPDATE_PERSONAL_ID_SUCCESS';
+
+/** Action type dispatched when the remove personal id request fails. */
+export const REMOVE_PERSONAL_ID_FAILURE =
+  '@farfetch/blackout-client/REMOVE_PERSONAL_ID_FAILURE';
+/** Action type dispatched when the remove personal id request starts. */
+export const REMOVE_PERSONAL_ID_REQUEST =
+  '@farfetch/blackout-client/REMOVE_PERSONAL_ID_REQUEST';
+/** Action type dispatched when the remove personal id request succeeds. */
+export const REMOVE_PERSONAL_ID_SUCCESS =
+  '@farfetch/blackout-client/REMOVE_PERSONAL_ID_SUCCESS';

--- a/packages/redux/src/users/actions/__tests__/__snapshots__/createPersonalIdImage.test.ts.snap
+++ b/packages/redux/src/users/actions/__tests__/__snapshots__/createPersonalIdImage.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createPersonalIdImage action creator should create the correct actions for when the create personal id image procedure is successful: create personal id image success payload 1`] = `
+Object {
+  "payload": Object {
+    "backImageId": "",
+    "expiryDate": "",
+    "frontImageId": "",
+    "id": "",
+    "isDefault": true,
+    "maskedIdNumber": "",
+    "maskedName": "",
+    "verifyLevel": 1,
+  },
+  "type": "@farfetch/blackout-client/CREATE_PERSONAL_ID_IMAGE_SUCCESS",
+}
+`;

--- a/packages/redux/src/users/actions/__tests__/__snapshots__/fetchPersonalId.test.ts.snap
+++ b/packages/redux/src/users/actions/__tests__/__snapshots__/fetchPersonalId.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fetchPersonalId action creator should create the correct actions for when the fetch personal id procedure is successful: fetch personal id success payload 1`] = `
+Object {
+  "payload": Object {
+    "backImageId": "",
+    "expiryDate": "",
+    "frontImageId": "",
+    "id": "",
+    "isDefault": true,
+    "maskedIdNumber": "",
+    "maskedName": "",
+    "verifyLevel": 1,
+  },
+  "type": "@farfetch/blackout-client/FETCH_PERSONAL_ID_SUCCESS",
+}
+`;

--- a/packages/redux/src/users/actions/__tests__/__snapshots__/removePersonalId.test.ts.snap
+++ b/packages/redux/src/users/actions/__tests__/__snapshots__/removePersonalId.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`removePersonalId action creator should create the correct actions for when the remove personal id procedure is successful: remove personal id success payload 1`] = `
+Object {
+  "payload": Object {
+    "backImageId": "",
+    "expiryDate": "",
+    "frontImageId": "",
+    "id": "",
+    "isDefault": true,
+    "maskedIdNumber": "",
+    "maskedName": "",
+    "verifyLevel": 1,
+  },
+  "type": "@farfetch/blackout-client/REMOVE_PERSONAL_ID_SUCCESS",
+}
+`;

--- a/packages/redux/src/users/actions/__tests__/__snapshots__/updatePersonalId.test.ts.snap
+++ b/packages/redux/src/users/actions/__tests__/__snapshots__/updatePersonalId.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`updatePersonalId action creator should create the correct actions for when the update personal id procedure is successful: update personal id success payload 1`] = `
+Object {
+  "payload": Object {
+    "backImageId": "",
+    "expiryDate": "",
+    "frontImageId": "",
+    "id": "",
+    "isDefault": true,
+    "maskedIdNumber": "",
+    "maskedName": "",
+    "verifyLevel": 1,
+  },
+  "type": "@farfetch/blackout-client/UPDATE_PERSONAL_ID_SUCCESS",
+}
+`;

--- a/packages/redux/src/users/actions/__tests__/createPersonalIdImage.test.ts
+++ b/packages/redux/src/users/actions/__tests__/createPersonalIdImage.test.ts
@@ -1,0 +1,91 @@
+import { actionTypes } from '../..';
+import { createPersonalIdImage } from '../';
+import { INITIAL_STATE } from '../../reducer';
+import { mockPersonalIdResponse } from 'tests/__fixtures__/users';
+import { mockStore } from '../../../../tests';
+import { postPersonalIdImage } from '@farfetch/blackout-client/users';
+import find from 'lodash/find';
+
+jest.mock('@farfetch/blackout-client/users', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/users'),
+  postPersonalIdImage: jest.fn(),
+}));
+
+const usersMockStore = (state = {}) =>
+  mockStore({ users: INITIAL_STATE }, state);
+
+describe('createPersonalIdImage action creator', () => {
+  let store = usersMockStore();
+  const userId = 12345;
+  const data = {
+    file: 'string',
+  };
+  const config = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const expectedConfig = {
+    'X-SUMMER-RequestId': 'test',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = usersMockStore();
+  });
+
+  it('should create the correct actions for when the create personal id image procedure fails', async () => {
+    const expectedError = new Error('create personal id image error');
+
+    (postPersonalIdImage as jest.Mock).mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(createPersonalIdImage(userId, data, config));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(postPersonalIdImage).toHaveBeenCalledTimes(1);
+      expect(postPersonalIdImage).toHaveBeenCalledWith(
+        userId,
+        data,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.CREATE_PERSONAL_ID_IMAGE_REQUEST },
+          {
+            type: actionTypes.CREATE_PERSONAL_ID_IMAGE_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the create personal id image procedure is successful', async () => {
+    (postPersonalIdImage as jest.Mock).mockResolvedValueOnce(
+      mockPersonalIdResponse,
+    );
+    await store.dispatch(createPersonalIdImage(userId, data, config));
+
+    const actionResults = store.getActions();
+
+    expect(postPersonalIdImage).toHaveBeenCalledTimes(1);
+    expect(postPersonalIdImage).toHaveBeenCalledWith(
+      userId,
+      data,
+      expectedConfig,
+    );
+
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.CREATE_PERSONAL_ID_IMAGE_REQUEST },
+      {
+        payload: mockPersonalIdResponse,
+        type: actionTypes.CREATE_PERSONAL_ID_IMAGE_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.CREATE_PERSONAL_ID_IMAGE_SUCCESS,
+      }),
+    ).toMatchSnapshot('create personal id image success payload');
+  });
+});

--- a/packages/redux/src/users/actions/__tests__/fetchPersonalId.test.ts
+++ b/packages/redux/src/users/actions/__tests__/fetchPersonalId.test.ts
@@ -1,0 +1,87 @@
+import { actionTypes } from '../..';
+import { fetchPersonalId } from '../';
+import { getPersonalId } from '@farfetch/blackout-client/users';
+import { INITIAL_STATE } from '../../reducer';
+import { mockPersonalIdResponse } from 'tests/__fixtures__/users';
+import { mockStore } from '../../../../tests';
+import find from 'lodash/find';
+
+jest.mock('@farfetch/blackout-client/users', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/users'),
+  getPersonalId: jest.fn(),
+}));
+
+const usersMockStore = (state = {}) =>
+  mockStore({ users: INITIAL_STATE }, state);
+
+describe('fetchPersonalId action creator', () => {
+  let store = usersMockStore();
+  const userId = 123456789;
+  const personalId = '123456';
+  const config = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const expectedConfig = {
+    'X-SUMMER-RequestId': 'test',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = usersMockStore();
+  });
+
+  it('should create the correct actions for when the fetch personal id procedure fails', async () => {
+    const expectedError = new Error('fetch personal id error');
+
+    (getPersonalId as jest.Mock).mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(fetchPersonalId(userId, personalId, config));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(getPersonalId).toHaveBeenCalledTimes(1);
+      expect(getPersonalId).toHaveBeenCalledWith(
+        userId,
+        personalId,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.FETCH_PERSONAL_ID_REQUEST },
+          {
+            type: actionTypes.FETCH_PERSONAL_ID_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the fetch personal id procedure is successful', async () => {
+    (getPersonalId as jest.Mock).mockResolvedValueOnce(mockPersonalIdResponse);
+
+    await store.dispatch(fetchPersonalId(userId, personalId, config));
+
+    const actionResults = store.getActions();
+
+    expect(getPersonalId).toHaveBeenCalledTimes(1);
+    expect(getPersonalId).toHaveBeenCalledWith(
+      userId,
+      personalId,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.FETCH_PERSONAL_ID_REQUEST },
+      {
+        payload: mockPersonalIdResponse,
+        type: actionTypes.FETCH_PERSONAL_ID_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.FETCH_PERSONAL_ID_SUCCESS,
+      }),
+    ).toMatchSnapshot('fetch personal id success payload');
+  });
+});

--- a/packages/redux/src/users/actions/__tests__/removePersonalId.test.ts
+++ b/packages/redux/src/users/actions/__tests__/removePersonalId.test.ts
@@ -1,0 +1,89 @@
+import { actionTypes } from '../..';
+import { deletePersonalId } from '@farfetch/blackout-client/users';
+import { INITIAL_STATE } from '../../reducer';
+import { mockPersonalIdResponse } from 'tests/__fixtures__/users';
+import { mockStore } from '../../../../tests';
+import { removePersonalId } from '../';
+import find from 'lodash/find';
+
+jest.mock('@farfetch/blackout-client/users', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/users'),
+  deletePersonalId: jest.fn(),
+}));
+
+const usersMockStore = (state = {}) =>
+  mockStore({ users: INITIAL_STATE }, state);
+
+describe('removePersonalId action creator', () => {
+  let store = usersMockStore();
+  const userId = 123456789;
+  const personalId = '123456';
+  const config = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const expectedConfig = {
+    'X-SUMMER-RequestId': 'test',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = usersMockStore();
+  });
+
+  it('should create the correct actions for when the remove personal id procedure fails', async () => {
+    const expectedError = new Error('remove personal id error');
+
+    (deletePersonalId as jest.Mock).mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(removePersonalId(userId, personalId, config));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(deletePersonalId).toHaveBeenCalledTimes(1);
+      expect(deletePersonalId).toHaveBeenCalledWith(
+        userId,
+        personalId,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.REMOVE_PERSONAL_ID_REQUEST },
+          {
+            type: actionTypes.REMOVE_PERSONAL_ID_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the remove personal id procedure is successful', async () => {
+    (deletePersonalId as jest.Mock).mockResolvedValueOnce(
+      mockPersonalIdResponse,
+    );
+
+    await store.dispatch(removePersonalId(userId, personalId, config));
+
+    const actionResults = store.getActions();
+
+    expect(deletePersonalId).toHaveBeenCalledTimes(1);
+    expect(deletePersonalId).toHaveBeenCalledWith(
+      userId,
+      personalId,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.REMOVE_PERSONAL_ID_REQUEST },
+      {
+        payload: mockPersonalIdResponse,
+        type: actionTypes.REMOVE_PERSONAL_ID_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.REMOVE_PERSONAL_ID_SUCCESS,
+      }),
+    ).toMatchSnapshot('remove personal id success payload');
+  });
+});

--- a/packages/redux/src/users/actions/__tests__/updatePersonalId.test.ts
+++ b/packages/redux/src/users/actions/__tests__/updatePersonalId.test.ts
@@ -1,0 +1,98 @@
+import { actionTypes } from '../..';
+import { INITIAL_STATE } from '../../reducer';
+import { mockPersonalIdResponse } from 'tests/__fixtures__/users';
+import { mockStore } from '../../../../tests';
+import { patchPersonalId } from '@farfetch/blackout-client/users';
+import { updatePersonalId } from '../';
+import find from 'lodash/find';
+
+jest.mock('@farfetch/blackout-client/users', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/users'),
+  patchPersonalId: jest.fn(),
+}));
+
+const usersMockStore = (state = {}) =>
+  mockStore({ users: INITIAL_STATE }, state);
+
+describe('updatePersonalId action creator', () => {
+  let store = usersMockStore();
+  const userId = 123456;
+  const personalId = '123456';
+  const data = {
+    backImageId: 'string',
+    expiryDate: 'string',
+    frontImageId: 'string',
+    idNumber: 'string',
+    name: 'string',
+  };
+  const config = {
+    'X-SUMMER-RequestId': 'test',
+  };
+  const expectedConfig = {
+    'X-SUMMER-RequestId': 'test',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = usersMockStore();
+  });
+
+  it('should create the correct actions for when the update personal id procedure fails', async () => {
+    const expectedError = new Error('update personal id error');
+
+    (patchPersonalId as jest.Mock).mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(updatePersonalId(userId, personalId, data, config));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(patchPersonalId).toHaveBeenCalledTimes(1);
+      expect(patchPersonalId).toHaveBeenCalledWith(
+        userId,
+        personalId,
+        data,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.UPDATE_PERSONAL_ID_REQUEST },
+          {
+            type: actionTypes.UPDATE_PERSONAL_ID_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the update personal id procedure is successful', async () => {
+    (patchPersonalId as jest.Mock).mockResolvedValueOnce(
+      mockPersonalIdResponse,
+    );
+
+    await store.dispatch(updatePersonalId(userId, personalId, data, config));
+
+    const actionResults = store.getActions();
+
+    expect(patchPersonalId).toHaveBeenCalledTimes(1);
+    expect(patchPersonalId).toHaveBeenCalledWith(
+      userId,
+      personalId,
+      data,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.UPDATE_PERSONAL_ID_REQUEST },
+      {
+        payload: mockPersonalIdResponse,
+        type: actionTypes.UPDATE_PERSONAL_ID_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.UPDATE_PERSONAL_ID_SUCCESS,
+      }),
+    ).toMatchSnapshot('update personal id success payload');
+  });
+});

--- a/packages/redux/src/users/actions/createPersonalIdImage.ts
+++ b/packages/redux/src/users/actions/createPersonalIdImage.ts
@@ -1,0 +1,7 @@
+import { createPersonalIdImageFactory } from './factories';
+import { postPersonalIdImage } from '@farfetch/blackout-client/users';
+
+/**
+ * Create personal id image.
+ */
+export default createPersonalIdImageFactory(postPersonalIdImage);

--- a/packages/redux/src/users/actions/factories/createPersonalIdImageFactory.ts
+++ b/packages/redux/src/users/actions/factories/createPersonalIdImageFactory.ts
@@ -1,0 +1,57 @@
+import {
+  CREATE_PERSONAL_ID_IMAGE_FAILURE,
+  CREATE_PERSONAL_ID_IMAGE_REQUEST,
+  CREATE_PERSONAL_ID_IMAGE_SUCCESS,
+} from '../../actionTypes';
+import type { Config } from '@farfetch/blackout-client/types';
+import type { Dispatch } from 'redux';
+import type {
+  PostPersonalIdImage,
+  PostPersonalIdImageData,
+  PostPersonalIdImageResponse,
+} from '@farfetch/blackout-client/users/types';
+
+/**
+ * @param userId - User id.
+ * @param data - Personal id image object.
+ * @param config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Method responsible for creating a personal id image.
+ *
+ * @param postPersonalIdImage - Post user attribute client.
+ *
+ * @returns Thunk factory.
+ */
+const createPersonalIdImageFactory =
+  (postPersonalIdImage: PostPersonalIdImage) =>
+  (userId: number, data: PostPersonalIdImageData, config: Config) =>
+  async (dispatch: Dispatch): Promise<PostPersonalIdImageResponse> => {
+    dispatch({
+      type: CREATE_PERSONAL_ID_IMAGE_REQUEST,
+    });
+
+    try {
+      const result = await postPersonalIdImage(userId, data, config);
+
+      dispatch({
+        type: CREATE_PERSONAL_ID_IMAGE_SUCCESS,
+        payload: result,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: CREATE_PERSONAL_ID_IMAGE_FAILURE,
+      });
+
+      throw error;
+    }
+  };
+
+export default createPersonalIdImageFactory;

--- a/packages/redux/src/users/actions/factories/fetchPersonalIdFactory.ts
+++ b/packages/redux/src/users/actions/factories/fetchPersonalIdFactory.ts
@@ -1,0 +1,56 @@
+import {
+  FETCH_PERSONAL_ID_FAILURE,
+  FETCH_PERSONAL_ID_REQUEST,
+  FETCH_PERSONAL_ID_SUCCESS,
+} from '../../actionTypes';
+import type { Config } from '@farfetch/blackout-client/types';
+import type { Dispatch } from 'redux';
+import type {
+  GetPersonalId,
+  PersonalIdResponse,
+} from '@farfetch/blackout-client/users/types';
+
+/**
+ * @param id - The user's id.
+ * @param personalId - Alphanumeric identifier of the personal id.
+ * @param config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Get a specific personal id.
+ *
+ * @param getPersonalId - Get a specific personal id client.
+ *
+ * @returns Thunk factory.
+ */
+const fetchPersonalIdFactory =
+  (getPersonalId: GetPersonalId) =>
+  (userId: number, personalId: string, config: Config) =>
+  async (dispatch: Dispatch): Promise<PersonalIdResponse> => {
+    dispatch({
+      type: FETCH_PERSONAL_ID_REQUEST,
+    });
+
+    try {
+      const result = await getPersonalId(userId, personalId, config);
+
+      dispatch({
+        payload: result,
+        type: FETCH_PERSONAL_ID_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: FETCH_PERSONAL_ID_FAILURE,
+      });
+
+      throw error;
+    }
+  };
+
+export default fetchPersonalIdFactory;

--- a/packages/redux/src/users/actions/factories/index.ts
+++ b/packages/redux/src/users/actions/factories/index.ts
@@ -26,3 +26,7 @@ export { default as fetchPersonalIdsFactory } from './fetchPersonalIdsFactory';
 export { default as createPersonalIdsFactory } from './createPersonalIdsFactory';
 export { default as fetchDefaultPersonalIdFactory } from './fetchDefaultPersonalIdFactory';
 export { default as setDefaultPersonalIdFactory } from './setDefaultPersonalIdFactory';
+export { default as createPersonalIdImageFactory } from './createPersonalIdImageFactory';
+export { default as fetchPersonalIdFactory } from './fetchPersonalIdFactory';
+export { default as updatePersonalIdFactory } from './updatePersonalIdFactory';
+export { default as removePersonalIdFactory } from './removePersonalIdFactory';

--- a/packages/redux/src/users/actions/factories/removePersonalIdFactory.ts
+++ b/packages/redux/src/users/actions/factories/removePersonalIdFactory.ts
@@ -1,0 +1,53 @@
+import {
+  REMOVE_PERSONAL_ID_FAILURE,
+  REMOVE_PERSONAL_ID_REQUEST,
+  REMOVE_PERSONAL_ID_SUCCESS,
+} from '../../actionTypes';
+import type { Config } from '@farfetch/blackout-client/types';
+import type { DeletePersonalId } from '@farfetch/blackout-client/users/types';
+import type { Dispatch } from 'redux';
+
+/**
+ * @param userId - The user's id.
+ * @param personalId - Personal identifier.
+ * @param config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Deletes a specific user attribute.
+ *
+ * @param deletePersonalId - Delete a specific personal id.
+ *
+ * @returns Thunk factory.
+ */
+const removePersonalIdFactory =
+  (deletePersonalId: DeletePersonalId) =>
+  (userId: number, personalId: string, config: Config) =>
+  async (dispatch: Dispatch): Promise<number> => {
+    dispatch({
+      type: REMOVE_PERSONAL_ID_REQUEST,
+    });
+
+    try {
+      const result = await deletePersonalId(userId, personalId, config);
+
+      dispatch({
+        type: REMOVE_PERSONAL_ID_SUCCESS,
+        payload: result,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: REMOVE_PERSONAL_ID_FAILURE,
+      });
+
+      throw error;
+    }
+  };
+
+export default removePersonalIdFactory;

--- a/packages/redux/src/users/actions/factories/updatePersonalIdFactory.ts
+++ b/packages/redux/src/users/actions/factories/updatePersonalIdFactory.ts
@@ -1,0 +1,63 @@
+import {
+  UPDATE_PERSONAL_ID_FAILURE,
+  UPDATE_PERSONAL_ID_REQUEST,
+  UPDATE_PERSONAL_ID_SUCCESS,
+} from '../../actionTypes';
+import type { Config } from '@farfetch/blackout-client/types';
+import type { Dispatch } from 'redux';
+import type {
+  PatchPersonalId,
+  PatchPersonalIdData,
+  PatchPersonalIdResponse,
+} from '@farfetch/blackout-client/users/types';
+
+/**
+ * @param userId - User identifier.
+ * @param personalId - Personal id to be filtered for.
+ * @param data - Personal id data.
+ * @param config - Custom configurations to send to the client
+ * instance (axios). X-SUMMER-RequestId header is required.
+ *
+ * @returns Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Updates a specific personal id.
+ *
+ * @param patchPersonalId - Update a specific personal id.
+ *
+ * @returns Thunk factory.
+ */
+const updatePersonalIdFactory =
+  (patchPersonalId: PatchPersonalId) =>
+  (
+    userId: number,
+    personalId: string,
+    data: PatchPersonalIdData,
+    config: Config,
+  ) =>
+  async (dispatch: Dispatch): Promise<PatchPersonalIdResponse> => {
+    dispatch({
+      type: UPDATE_PERSONAL_ID_REQUEST,
+    });
+
+    try {
+      const result = await patchPersonalId(userId, personalId, data, config);
+
+      dispatch({
+        type: UPDATE_PERSONAL_ID_SUCCESS,
+        payload: result,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: UPDATE_PERSONAL_ID_FAILURE,
+      });
+
+      throw error;
+    }
+  };
+
+export default updatePersonalIdFactory;

--- a/packages/redux/src/users/actions/fetchPersonalId.ts
+++ b/packages/redux/src/users/actions/fetchPersonalId.ts
@@ -1,0 +1,7 @@
+import { fetchPersonalIdFactory } from './factories';
+import { getPersonalId } from '@farfetch/blackout-client/users';
+
+/**
+ * Fetch a specific personal id.
+ */
+export default fetchPersonalIdFactory(getPersonalId);

--- a/packages/redux/src/users/actions/index.ts
+++ b/packages/redux/src/users/actions/index.ts
@@ -34,3 +34,7 @@ export { default as fetchPersonalIds } from './fetchPersonalIds';
 export { default as createPersonalIds } from './createPersonalIds';
 export { default as fetchDefaultPersonalId } from './fetchDefaultPersonalId';
 export { default as setDefaultPersonalId } from './setDefaultPersonalId';
+export { default as createPersonalIdImage } from './createPersonalIdImage';
+export { default as removePersonalId } from './removePersonalId';
+export { default as fetchPersonalId } from './fetchPersonalId';
+export { default as updatePersonalId } from './updatePersonalId';

--- a/packages/redux/src/users/actions/removePersonalId.ts
+++ b/packages/redux/src/users/actions/removePersonalId.ts
@@ -1,0 +1,7 @@
+import { deletePersonalId } from '@farfetch/blackout-client/users';
+import { removePersonalIdFactory } from './factories';
+
+/**
+ * Removes a personal id.
+ */
+export default removePersonalIdFactory(deletePersonalId);

--- a/packages/redux/src/users/actions/updatePersonalId.ts
+++ b/packages/redux/src/users/actions/updatePersonalId.ts
@@ -1,0 +1,7 @@
+import { patchPersonalId } from '@farfetch/blackout-client/users';
+import { updatePersonalIdFactory } from './factories';
+
+/**
+ * Updates a specific personal id.
+ */
+export default updatePersonalIdFactory(patchPersonalId);

--- a/tests/__fixtures__/users/personalIds.fixtures.ts
+++ b/tests/__fixtures__/users/personalIds.fixtures.ts
@@ -1,4 +1,15 @@
-import { VerifyLevel } from '@farfetch/blackout-client/users/types';
+import { Side, VerifyLevel } from '@farfetch/blackout-client/users/types';
+
+export const mockPersonalIdResponse = {
+  backImageId: '',
+  expiryDate: '',
+  frontImageId: '',
+  id: '',
+  isDefault: true,
+  maskedIdNumber: '',
+  maskedName: '',
+  verifyLevel: VerifyLevel.VALID,
+};
 
 export const mockGetDefaultPersonalIdResponse = {
   backImageId: 'string',
@@ -42,6 +53,20 @@ export const mockPutDefaultPersonalIdResponse = {
   maskedIdNumber: 'string',
   maskedName: 'string',
   verifyLevel: VerifyLevel.VALID,
+};
+
+export const mockPatchPersonalIdResponse = {
+  backImageId: '',
+  expiryDate: '',
+  frontImageId: '',
+  id: '',
+  idNumber: '',
+  name: '',
+};
+
+export const mockPostPersonalIdImageResponse = {
+  id: '',
+  side: Side.FRONT,
 };
 
 export const mockPostPersonalIdsData = {


### PR DESCRIPTION
## Description

- Add personal id and image clients and redux actions

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
