### PR TITLE
feat(client|redux): add reschedule endpoints

### DIFF
--- a/packages/client/src/returns/__fixtures__/getPickupRescheduleRequest.fixtures.ts
+++ b/packages/client/src/returns/__fixtures__/getPickupRescheduleRequest.fixtures.ts
@@ -1,0 +1,38 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+import type { PickupRescheduleRequest } from '../types';
+
+export default {
+  success: (
+    id: string,
+    rescheduleRequestId: string,
+    response: PickupRescheduleRequest,
+  ): void => {
+    moxios.stubRequest(
+      join(
+        '/api/account/v1/returns',
+        id,
+        'pickupRescheduleRequests/',
+        rescheduleRequestId,
+      ),
+      {
+        response: response,
+        status: 200,
+      },
+    );
+  },
+  failure: (id: string, rescheduleRequestId: string): void => {
+    moxios.stubRequest(
+      join(
+        '/api/account/v1/returns',
+        id,
+        'pickupRescheduleRequests/',
+        rescheduleRequestId,
+      ),
+      {
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/client/src/returns/__fixtures__/getPickupRescheduleRequests.fixtures.ts
+++ b/packages/client/src/returns/__fixtures__/getPickupRescheduleRequests.fixtures.ts
@@ -1,0 +1,24 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+import type { PickupRescheduleRequests } from '../types';
+
+export default {
+  success: (id: string, response: PickupRescheduleRequests): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/returns', id, 'pickupRescheduleRequests/'),
+      {
+        response: response,
+        status: 200,
+      },
+    );
+  },
+  failure: (id: string): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/returns', id, 'pickupRescheduleRequests/'),
+      {
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/client/src/returns/__fixtures__/postPickupRescheduleRequest.fixtures.ts
+++ b/packages/client/src/returns/__fixtures__/postPickupRescheduleRequest.fixtures.ts
@@ -1,0 +1,23 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: (id: string, response: number): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/returns', id, 'pickupRescheduleRequests/'),
+      {
+        response: response,
+        status: 202,
+      },
+    );
+  },
+  failure: (id: string): void => {
+    moxios.stubRequest(
+      join('/api/account/v1/returns', id, 'pickupRescheduleRequests/'),
+      {
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/client/src/returns/__tests__/__snapshots__/getPickupRescheduleRequest.test.ts.snap
+++ b/packages/client/src/returns/__tests__/__snapshots__/getPickupRescheduleRequest.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPickupRescheduleRequest should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/client/src/returns/__tests__/__snapshots__/getPickupRescheduleRequests.test.ts.snap
+++ b/packages/client/src/returns/__tests__/__snapshots__/getPickupRescheduleRequests.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPickupRescheduleRequests should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/client/src/returns/__tests__/__snapshots__/postPickupRescheduleRequest.test.ts.snap
+++ b/packages/client/src/returns/__tests__/__snapshots__/postPickupRescheduleRequest.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`postPickupRescheduleRequests() should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/client/src/returns/__tests__/getPickupRescheduleRequest.test.ts
+++ b/packages/client/src/returns/__tests__/getPickupRescheduleRequest.test.ts
@@ -1,0 +1,54 @@
+import { getPickupRescheduleRequest } from '..';
+import { responses } from 'tests/__fixtures__/returns';
+import client from '../../helpers/client';
+import fixture from '../__fixtures__/getPickupRescheduleRequest.fixtures';
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+describe('getPickupRescheduleRequest', () => {
+  const spy = jest.spyOn(client, 'get');
+  const id = '123456';
+  const rescheduleRequestId = '1654321';
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = responses.getPickupRescheduleRequest.success;
+
+    fixture.success(id, rescheduleRequestId, response);
+
+    expect.assertions(2);
+    await expect(
+      getPickupRescheduleRequest(id, rescheduleRequestId),
+    ).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      join(
+        `/account/v1/returns/${id}/pickupRescheduleRequests/${rescheduleRequestId}`,
+      ),
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixture.failure(id, rescheduleRequestId);
+
+    expect.assertions(2);
+    await expect(
+      getPickupRescheduleRequest(id, rescheduleRequestId),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      join(
+        `/account/v1/returns/${id}/pickupRescheduleRequests/${rescheduleRequestId}`,
+      ),
+      expectedConfig,
+    );
+  });
+});

--- a/packages/client/src/returns/__tests__/getPickupRescheduleRequests.test.ts
+++ b/packages/client/src/returns/__tests__/getPickupRescheduleRequests.test.ts
@@ -1,0 +1,47 @@
+import { getPickupRescheduleRequests } from '..';
+import { responses } from 'tests/__fixtures__/returns';
+import client from '../../helpers/client';
+import fixture from '../__fixtures__/getPickupRescheduleRequests.fixtures';
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+describe('getPickupRescheduleRequests', () => {
+  const spy = jest.spyOn(client, 'get');
+  const id = '123456';
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = responses.getPickupRescheduleRequests.success;
+
+    fixture.success(id, response);
+
+    expect.assertions(2);
+
+    await expect(getPickupRescheduleRequests(id)).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      join(`/account/v1/returns/${id}/pickupRescheduleRequests`),
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixture.failure(id);
+
+    expect.assertions(2);
+
+    await expect(getPickupRescheduleRequests(id)).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      join(`/account/v1/returns/${id}/pickupRescheduleRequests`),
+      expectedConfig,
+    );
+  });
+});

--- a/packages/client/src/returns/__tests__/postPickupRescheduleRequest.test.ts
+++ b/packages/client/src/returns/__tests__/postPickupRescheduleRequest.test.ts
@@ -1,0 +1,55 @@
+import {
+  mockPickupReschedulePostData,
+  responses,
+} from 'tests/__fixtures__/returns';
+import { postPickupRescheduleRequest } from '..';
+import client from '../../helpers/client';
+import fixture from '../__fixtures__/postPickupRescheduleRequest.fixtures';
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+describe('postPickupRescheduleRequests()', () => {
+  const data = mockPickupReschedulePostData;
+  const spy = jest.spyOn(client, 'post');
+  const expectedConfig = undefined;
+  const id = '123456';
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = responses.postPickupRescheduleRequests.success;
+
+    fixture.success(id, response);
+
+    expect.assertions(2);
+
+    await expect(postPickupRescheduleRequest(id, data)).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      join(`/account/v1/returns/${id}/pickupRescheduleRequests`),
+      data,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixture.failure(id);
+
+    expect.assertions(2);
+
+    await expect(
+      postPickupRescheduleRequest(id, data),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      join(`/account/v1/returns/${id}/pickupRescheduleRequests`),
+      data,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/client/src/returns/getPickupRescheduleRequest.ts
+++ b/packages/client/src/returns/getPickupRescheduleRequest.ts
@@ -1,0 +1,36 @@
+import client, { adaptError } from '../helpers/client';
+import join from 'proper-url-join';
+import type { GetPickupRescheduleRequest } from './types';
+
+/**
+ * Obtains a specific pickup reschedule request.
+ *
+ * @param id - Return identifier.
+ * @param rescheduleRequestId - Reschedule request identifier.
+ * @param config - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+const getPickupRescheduleRequest: GetPickupRescheduleRequest = (
+  id,
+  rescheduleRequestId,
+  config,
+) =>
+  client
+    .get(
+      join(
+        '/account/v1/returns/',
+        id,
+        'pickupRescheduleRequests/',
+        rescheduleRequestId,
+      ),
+      config,
+    )
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });
+
+export default getPickupRescheduleRequest;

--- a/packages/client/src/returns/getPickupRescheduleRequests.ts
+++ b/packages/client/src/returns/getPickupRescheduleRequests.ts
@@ -1,0 +1,23 @@
+import client, { adaptError } from '../helpers/client';
+import join from 'proper-url-join';
+import type { GetPickupRescheduleRequests } from './types';
+
+/**
+ * Obtains the pickup reschedule requests.
+ *
+ * @param id - Return identifier.
+ * @param config - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+const getPickupRescheduleRequests: GetPickupRescheduleRequests = (id, config) =>
+  client
+    .get(join('/account/v1/returns/', id, 'pickupRescheduleRequests/'), config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });
+
+export default getPickupRescheduleRequests;

--- a/packages/client/src/returns/index.ts
+++ b/packages/client/src/returns/index.ts
@@ -1,9 +1,5 @@
 /**
  * Returns clients.
- *
- * @module returns/client
- * @category Returns
- * @subcategory Clients
  */
 
 export { default as getPickupCapabilities } from './getPickupCapabilities';
@@ -12,3 +8,6 @@ export { default as getReturn } from './getReturn';
 export { default as getReturnsFromOrder } from './getReturnsFromOrder';
 export { default as patchReturn } from './patchReturn';
 export { default as postReturn } from './postReturn';
+export { default as getPickupRescheduleRequests } from './getPickupRescheduleRequests';
+export { default as getPickupRescheduleRequest } from './getPickupRescheduleRequest';
+export { default as postPickupRescheduleRequest } from './postPickupRescheduleRequest';

--- a/packages/client/src/returns/postPickupRescheduleRequest.ts
+++ b/packages/client/src/returns/postPickupRescheduleRequest.ts
@@ -1,0 +1,32 @@
+import client, { adaptError } from '../helpers/client';
+import join from 'proper-url-join';
+import type { PostPickupRescheduleRequest } from './types';
+
+/**
+ * Method responsible for creating pickup reschedule requests.
+ *
+ * @param id - Return identifier.
+ * @param data - Request data.
+ * @param config - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+const postPickupRescheduleRequest: PostPickupRescheduleRequest = (
+  id,
+  data,
+  config,
+) =>
+  client
+    .post(
+      join('/account/v1/returns', id, 'pickupRescheduleRequests/'),
+      data,
+      config,
+    )
+    .then(response => response.status)
+    .catch(error => {
+      throw adaptError(error);
+    });
+
+export default postPickupRescheduleRequest;

--- a/packages/client/src/returns/types/getPickupRescheduleRequest.types.ts
+++ b/packages/client/src/returns/types/getPickupRescheduleRequest.types.ts
@@ -1,0 +1,8 @@
+import type { Config } from '@farfetch/blackout-client/types';
+import type { PickupRescheduleRequest } from './pickupRescheduleRequests.types';
+
+export type GetPickupRescheduleRequest = (
+  id: string,
+  rescheduleRequestId: string,
+  config?: Config,
+) => Promise<PickupRescheduleRequest>;

--- a/packages/client/src/returns/types/getPickupRescheduleRequests.types.ts
+++ b/packages/client/src/returns/types/getPickupRescheduleRequests.types.ts
@@ -1,0 +1,7 @@
+import type { Config } from '@farfetch/blackout-client/types';
+import type { PickupRescheduleRequests } from './pickupRescheduleRequests.types';
+
+export type GetPickupRescheduleRequests = (
+  id: string,
+  config?: Config,
+) => Promise<PickupRescheduleRequests>;

--- a/packages/client/src/returns/types/index.ts
+++ b/packages/client/src/returns/types/index.ts
@@ -8,3 +8,7 @@ export * from './getReturnsFromOrder.types';
 export * from './patchReturn.types';
 export * from './postReturn.types';
 export * from './returnItem.types';
+export * from './getPickupRescheduleRequests.types';
+export * from './getPickupRescheduleRequest.types';
+export * from './postPickupRescheduleRequests.types';
+export * from './pickupRescheduleRequests.types';

--- a/packages/client/src/returns/types/pickupRescheduleRequests.types.ts
+++ b/packages/client/src/returns/types/pickupRescheduleRequests.types.ts
@@ -1,0 +1,16 @@
+export enum RescheduleStatus {
+  InProgress,
+  Succeeded,
+  Failed,
+}
+
+export type PickupRescheduleRequest = {
+  id: string;
+  timeWindow: {
+    start: string;
+    end: string;
+  };
+  status: RescheduleStatus;
+};
+
+export type PickupRescheduleRequests = PickupRescheduleRequest[];

--- a/packages/client/src/returns/types/postPickupRescheduleRequests.types.ts
+++ b/packages/client/src/returns/types/postPickupRescheduleRequests.types.ts
@@ -1,0 +1,8 @@
+import type { Config } from '@farfetch/blackout-client/types';
+import type { PickupRescheduleRequest } from './pickupRescheduleRequests.types';
+
+export type PostPickupRescheduleRequest = (
+  id: string,
+  data: PickupRescheduleRequest,
+  config?: Config,
+) => Promise<number>;

--- a/packages/redux/src/returns/actionTypes.ts
+++ b/packages/redux/src/returns/actionTypes.ts
@@ -1,9 +1,3 @@
-/**
- * @module returns/actionTypes
- * @category Returns
- * @subcategory Actions
- */
-
 /** Action type dispatched when the create return request fails. */
 export const CREATE_RETURN_FAILURE =
   '@farfetch/blackout-client/CREATE_RETURN_FAILURE';
@@ -66,3 +60,33 @@ export const UPDATE_RETURN_REQUEST =
 /** Action type dispatched when the update return request succeeds. */
 export const UPDATE_RETURN_SUCCESS =
   '@farfetch/blackout-client/UPDATE_RETURN_SUCCESS';
+
+/** Action type dispatched when the fetch pickup reschedule requests fails. */
+export const FETCH_PICKUP_RESCHEDULE_REQUESTS_FAILURE =
+  '@farfetch/blackout-client/FETCH_PICKUP_RESCHEDULE_REQUESTS_FAILURE';
+/** Action type dispatched when the fetch pickup reschedule requests starts. */
+export const FETCH_PICKUP_RESCHEDULE_REQUESTS_REQUEST =
+  '@farfetch/blackout-client/FETCH_PICKUP_RESCHEDULE_REQUESTS_REQUEST';
+/** Action type dispatched when the fetch pickup reschedule requests succeeds. */
+export const FETCH_PICKUP_RESCHEDULE_REQUESTS_SUCCESS =
+  '@farfetch/blackout-client/FETCH_PICKUP_RESCHEDULE_REQUESTS_SUCCESS';
+
+/** Action type dispatched when the fetch pickup reschedule request fails. */
+export const FETCH_PICKUP_RESCHEDULE_REQUEST_FAILURE =
+  '@farfetch/blackout-client/FETCH_PICKUP_RESCHEDULE_REQUEST_FAILURE';
+/** Action type dispatched when the fetch pickup reschedule request starts. */
+export const FETCH_PICKUP_RESCHEDULE_REQUEST_REQUEST =
+  '@farfetch/blackout-client/FETCH_PICKUP_RESCHEDULE_REQUEST_REQUEST';
+/** Action type dispatched when the fetch pickup reschedule request succeeds. */
+export const FETCH_PICKUP_RESCHEDULE_REQUEST_SUCCESS =
+  '@farfetch/blackout-client/FETCH_PICKUP_RESCHEDULE_REQUEST_SUCCESS';
+
+/** Action type dispatched when the create pickup reschedule request fails. */
+export const CREATE_PICKUP_RESCHEDULE_REQUEST_FAILURE =
+  '@farfetch/blackout-client/CREATE_PICKUP_RESCHEDULE_REQUEST_FAILURE';
+/** Action type dispatched when the create pickup reschedule request starts. */
+export const CREATE_PICKUP_RESCHEDULE_REQUEST_REQUEST =
+  '@farfetch/blackout-client/CREATE_PICKUP_RESCHEDULE_REQUEST_REQUEST';
+/** Action type dispatched when the create pickup reschedule request succeeds. */
+export const CREATE_PICKUP_RESCHEDULE_REQUEST_SUCCESS =
+  '@farfetch/blackout-client/CREATE_PICKUP_RESCHEDULE_REQUEST_SUCCESS';

--- a/packages/redux/src/returns/actions/__tests__/__snapshots__/createPickupRescheduleRequest.test.ts.snap
+++ b/packages/redux/src/returns/actions/__tests__/__snapshots__/createPickupRescheduleRequest.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createPickupRescheduleRequest action creator should create the correct actions for when the create pickup reschedule request procedure is successful: create pickup reschedule request success payload 1`] = `
+Object {
+  "payload": 202,
+  "type": "@farfetch/blackout-client/CREATE_PICKUP_RESCHEDULE_REQUEST_SUCCESS",
+}
+`;

--- a/packages/redux/src/returns/actions/__tests__/__snapshots__/fetchPickupRescheduleRequest.test.ts.snap
+++ b/packages/redux/src/returns/actions/__tests__/__snapshots__/fetchPickupRescheduleRequest.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPickupRescheduleRequest action creator should create the correct actions for when the fetch pickup reschedule request procedure is successful: fetch pickup reschedule request success payload 1`] = `
+Object {
+  "payload": Object {
+    "availableTimeSlots": Array [
+      Object {
+        "end": "2022-01-07T10:59:03.9169641Z",
+        "start": "2022-01-07T10:59:03.9169641Z",
+      },
+    ],
+  },
+  "type": "@farfetch/blackout-client/FETCH_PICKUP_RESCHEDULE_REQUEST_SUCCESS",
+}
+`;

--- a/packages/redux/src/returns/actions/__tests__/__snapshots__/fetchPickupRescheduleRequestsFactory.test.ts.snap
+++ b/packages/redux/src/returns/actions/__tests__/__snapshots__/fetchPickupRescheduleRequestsFactory.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPickupRescheduleRequests action creator should create the correct actions for when the fetch pickup reschedule requests procedure is successful: fetch pickup reschedule requests success payload 1`] = `
+Object {
+  "payload": Object {
+    "availableTimeSlots": Array [
+      Object {
+        "end": "2022-01-07T10:59:03.9169641Z",
+        "start": "2022-01-07T10:59:03.9169641Z",
+      },
+    ],
+  },
+  "type": "@farfetch/blackout-client/FETCH_PICKUP_RESCHEDULE_REQUESTS_SUCCESS",
+}
+`;

--- a/packages/redux/src/returns/actions/__tests__/createPickupRescheduleRequest.test.ts
+++ b/packages/redux/src/returns/actions/__tests__/createPickupRescheduleRequest.test.ts
@@ -1,0 +1,94 @@
+import { actionTypes } from '../..';
+import { createPickupRescheduleRequest } from '../';
+import { INITIAL_STATE } from '../../reducer';
+import { mockStore } from '../../../../tests';
+import { postPickupRescheduleRequest } from '@farfetch/blackout-client/returns';
+import { RescheduleStatus } from '@farfetch/blackout-client/returns/types';
+import { responses } from 'tests/__fixtures__/returns';
+import find from 'lodash/find';
+
+jest.mock('@farfetch/blackout-client/returns', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/returns'),
+  postPickupRescheduleRequest: jest.fn(),
+}));
+
+const returnsMockStore = (state = {}) =>
+  mockStore({ returns: INITIAL_STATE }, state);
+
+describe('createPickupRescheduleRequest action creator', () => {
+  let store = returnsMockStore();
+  const id = '12345';
+  const data = {
+    id: '',
+    timeWindow: {
+      start: '',
+      end: '',
+    },
+    status: RescheduleStatus.InProgress,
+  };
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = returnsMockStore();
+  });
+
+  it('should create the correct actions for when the create pickup reschedule request procedure fails', async () => {
+    const expectedError = new Error('create pickup reschedule request error');
+
+    (postPickupRescheduleRequest as jest.Mock).mockRejectedValueOnce(
+      expectedError,
+    );
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(createPickupRescheduleRequest(id, data));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(postPickupRescheduleRequest).toHaveBeenCalledTimes(1);
+      expect(postPickupRescheduleRequest).toHaveBeenCalledWith(
+        id,
+        data,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.CREATE_PICKUP_RESCHEDULE_REQUEST_REQUEST },
+          {
+            type: actionTypes.CREATE_PICKUP_RESCHEDULE_REQUEST_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the create pickup reschedule request procedure is successful', async () => {
+    (postPickupRescheduleRequest as jest.Mock).mockResolvedValueOnce(
+      responses.postPickupRescheduleRequests.success,
+    );
+    await store.dispatch(createPickupRescheduleRequest(id, data));
+
+    const actionResults = store.getActions();
+
+    expect(postPickupRescheduleRequest).toHaveBeenCalledTimes(1);
+    expect(postPickupRescheduleRequest).toHaveBeenCalledWith(
+      id,
+      data,
+      expectedConfig,
+    );
+
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.CREATE_PICKUP_RESCHEDULE_REQUEST_REQUEST },
+      {
+        payload: responses.postPickupRescheduleRequests.success,
+        type: actionTypes.CREATE_PICKUP_RESCHEDULE_REQUEST_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.CREATE_PICKUP_RESCHEDULE_REQUEST_SUCCESS,
+      }),
+    ).toMatchSnapshot('create pickup reschedule request success payload');
+  });
+});

--- a/packages/redux/src/returns/actions/__tests__/fetchPickupRescheduleRequest.test.ts
+++ b/packages/redux/src/returns/actions/__tests__/fetchPickupRescheduleRequest.test.ts
@@ -1,0 +1,89 @@
+import { actionTypes } from '../..';
+import { fetchPickupRescheduleRequest } from '..';
+import { getPickupRescheduleRequest } from '@farfetch/blackout-client/returns';
+import { INITIAL_STATE } from '../../reducer';
+import { mockPickupCapabilitiesResponse } from 'tests/__fixtures__/returns';
+import { mockStore } from '../../../../tests';
+import find from 'lodash/find';
+
+jest.mock('@farfetch/blackout-client/returns', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/returns'),
+  getPickupRescheduleRequest: jest.fn(),
+}));
+
+const returnsMockStore = (state = {}) =>
+  mockStore({ returns: INITIAL_STATE }, state);
+
+describe('getPickupRescheduleRequest action creator', () => {
+  let store = returnsMockStore();
+  const id = '12345';
+  const rescheduleRequestId = '654321';
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = returnsMockStore();
+  });
+
+  it('should create the correct actions for when the fetch pickup reschedule request procedure fails', async () => {
+    const expectedError = new Error('fetch pickup reschedule request error');
+
+    (getPickupRescheduleRequest as jest.Mock).mockRejectedValueOnce(
+      expectedError,
+    );
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(
+        fetchPickupRescheduleRequest(id, rescheduleRequestId),
+      );
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(getPickupRescheduleRequest).toHaveBeenCalledTimes(1);
+      expect(getPickupRescheduleRequest).toHaveBeenCalledWith(
+        id,
+        rescheduleRequestId,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          {
+            type: actionTypes.FETCH_PICKUP_RESCHEDULE_REQUEST_REQUEST,
+          },
+          {
+            type: actionTypes.FETCH_PICKUP_RESCHEDULE_REQUEST_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the fetch pickup reschedule request procedure is successful', async () => {
+    (getPickupRescheduleRequest as jest.Mock).mockResolvedValueOnce(
+      mockPickupCapabilitiesResponse,
+    );
+
+    await store.dispatch(fetchPickupRescheduleRequest(id, rescheduleRequestId));
+
+    const actionResults = store.getActions();
+
+    expect(getPickupRescheduleRequest).toHaveBeenCalledTimes(1);
+    expect(getPickupRescheduleRequest).toHaveBeenCalledWith(
+      id,
+      rescheduleRequestId,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.FETCH_PICKUP_RESCHEDULE_REQUEST_REQUEST },
+      {
+        type: actionTypes.FETCH_PICKUP_RESCHEDULE_REQUEST_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.FETCH_PICKUP_RESCHEDULE_REQUEST_SUCCESS,
+      }),
+    ).toMatchSnapshot('fetch pickup reschedule request success payload');
+  });
+});

--- a/packages/redux/src/returns/actions/__tests__/fetchPickupRescheduleRequestsFactory.test.ts
+++ b/packages/redux/src/returns/actions/__tests__/fetchPickupRescheduleRequestsFactory.test.ts
@@ -1,0 +1,84 @@
+import { actionTypes } from '../..';
+import { fetchPickupRescheduleRequests } from '..';
+import { getPickupRescheduleRequests } from '@farfetch/blackout-client/returns';
+import { INITIAL_STATE } from '../../reducer';
+import { mockPickupCapabilitiesResponse } from 'tests/__fixtures__/returns';
+import { mockStore } from '../../../../tests';
+import find from 'lodash/find';
+
+jest.mock('@farfetch/blackout-client/returns', () => ({
+  ...jest.requireActual('@farfetch/blackout-client/returns'),
+  getPickupRescheduleRequests: jest.fn(),
+}));
+
+const returnsMockStore = (state = {}) =>
+  mockStore({ returns: INITIAL_STATE }, state);
+
+describe('getPickupRescheduleRequests action creator', () => {
+  let store = returnsMockStore();
+  const id = '12345';
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = returnsMockStore();
+  });
+
+  it('should create the correct actions for when the fetch pickup reschedule requests procedure fails', async () => {
+    const expectedError = new Error('fetch pickup reschedule requests error');
+
+    (getPickupRescheduleRequests as jest.Mock).mockRejectedValueOnce(
+      expectedError,
+    );
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(fetchPickupRescheduleRequests(id));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(getPickupRescheduleRequests).toHaveBeenCalledTimes(1);
+      expect(getPickupRescheduleRequests).toHaveBeenCalledWith(
+        id,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          {
+            type: actionTypes.FETCH_PICKUP_RESCHEDULE_REQUESTS_REQUEST,
+          },
+          {
+            type: actionTypes.FETCH_PICKUP_RESCHEDULE_REQUESTS_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the fetch pickup reschedule requests procedure is successful', async () => {
+    (getPickupRescheduleRequests as jest.Mock).mockResolvedValueOnce(
+      mockPickupCapabilitiesResponse,
+    );
+
+    await store.dispatch(fetchPickupRescheduleRequests(id));
+
+    const actionResults = store.getActions();
+
+    expect(getPickupRescheduleRequests).toHaveBeenCalledTimes(1);
+    expect(getPickupRescheduleRequests).toHaveBeenCalledWith(
+      id,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.FETCH_PICKUP_RESCHEDULE_REQUESTS_REQUEST },
+      {
+        type: actionTypes.FETCH_PICKUP_RESCHEDULE_REQUESTS_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.FETCH_PICKUP_RESCHEDULE_REQUESTS_SUCCESS,
+      }),
+    ).toMatchSnapshot('fetch pickup reschedule requests success payload');
+  });
+});

--- a/packages/redux/src/returns/actions/createPickupRescheduleRequest.ts
+++ b/packages/redux/src/returns/actions/createPickupRescheduleRequest.ts
@@ -1,0 +1,9 @@
+import { createPickupRescheduleRequestFactory } from './factories';
+import { postPickupRescheduleRequest } from '@farfetch/blackout-client/returns';
+
+/**
+ * Create pickup reschedule request.
+ */
+export default createPickupRescheduleRequestFactory(
+  postPickupRescheduleRequest,
+);

--- a/packages/redux/src/returns/actions/factories/createPickupRescheduleRequestFactory.ts
+++ b/packages/redux/src/returns/actions/factories/createPickupRescheduleRequestFactory.ts
@@ -1,0 +1,47 @@
+import {
+  CREATE_PICKUP_RESCHEDULE_REQUEST_FAILURE,
+  CREATE_PICKUP_RESCHEDULE_REQUEST_REQUEST,
+  CREATE_PICKUP_RESCHEDULE_REQUEST_SUCCESS,
+} from '../../actionTypes';
+import type { Config } from '@farfetch/blackout-client/types';
+import type { Dispatch } from 'redux';
+import type {
+  PickupRescheduleRequest,
+  PostPickupRescheduleRequest,
+} from '@farfetch/blackout-client/src/returns/types';
+
+/**
+ * Method responsible for creating a pickup reschedule request.
+ *
+ * @param postPickupRescheduleRequest - Post pickup reschedule request client.
+ *
+ * @returns Thunk factory.
+ */
+const createPickupRescheduleRequestFactory =
+  (postPickupRescheduleRequest: PostPickupRescheduleRequest) =>
+  (id: string, data: PickupRescheduleRequest, config?: Config) =>
+  async (dispatch: Dispatch): Promise<number> => {
+    dispatch({
+      type: CREATE_PICKUP_RESCHEDULE_REQUEST_REQUEST,
+    });
+
+    try {
+      const result = await postPickupRescheduleRequest(id, data, config);
+
+      dispatch({
+        payload: result,
+        type: CREATE_PICKUP_RESCHEDULE_REQUEST_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: CREATE_PICKUP_RESCHEDULE_REQUEST_FAILURE,
+      });
+
+      throw error;
+    }
+  };
+
+export default createPickupRescheduleRequestFactory;

--- a/packages/redux/src/returns/actions/factories/fetchPickupRescheduleRequestFactory.ts
+++ b/packages/redux/src/returns/actions/factories/fetchPickupRescheduleRequestFactory.ts
@@ -1,0 +1,51 @@
+import {
+  FETCH_PICKUP_RESCHEDULE_REQUEST_FAILURE,
+  FETCH_PICKUP_RESCHEDULE_REQUEST_REQUEST,
+  FETCH_PICKUP_RESCHEDULE_REQUEST_SUCCESS,
+} from '../../actionTypes';
+import type { Config } from '@farfetch/blackout-client/types';
+import type { Dispatch } from 'redux';
+import type {
+  GetPickupRescheduleRequest,
+  PickupRescheduleRequest,
+} from '@farfetch/blackout-client/src/returns/types';
+
+/**
+ * Obtains the pickup reschedule request.
+ *
+ * @param getPickupRescheduleRequest - Get pickup reschedule request client.
+ *
+ * @returns Thunk factory.
+ */
+const fetchPickupRescheduleRequestFactory =
+  (getPickupRescheduleRequest: GetPickupRescheduleRequest) =>
+  (id: string, rescheduleRequestId: string, config?: Config) =>
+  async (dispatch: Dispatch): Promise<PickupRescheduleRequest> => {
+    dispatch({
+      type: FETCH_PICKUP_RESCHEDULE_REQUEST_REQUEST,
+    });
+
+    try {
+      const result = await getPickupRescheduleRequest(
+        id,
+        rescheduleRequestId,
+        config,
+      );
+
+      dispatch({
+        payload: result,
+        type: FETCH_PICKUP_RESCHEDULE_REQUEST_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: FETCH_PICKUP_RESCHEDULE_REQUEST_FAILURE,
+      });
+
+      throw error;
+    }
+  };
+
+export default fetchPickupRescheduleRequestFactory;

--- a/packages/redux/src/returns/actions/factories/fetchPickupRescheduleRequestsFactory.ts
+++ b/packages/redux/src/returns/actions/factories/fetchPickupRescheduleRequestsFactory.ts
@@ -1,0 +1,47 @@
+import {
+  FETCH_PICKUP_RESCHEDULE_REQUESTS_FAILURE,
+  FETCH_PICKUP_RESCHEDULE_REQUESTS_REQUEST,
+  FETCH_PICKUP_RESCHEDULE_REQUESTS_SUCCESS,
+} from '../../actionTypes';
+import type { Config } from '@farfetch/blackout-client/types';
+import type { Dispatch } from 'redux';
+import type {
+  GetPickupRescheduleRequests,
+  PickupRescheduleRequests,
+} from '@farfetch/blackout-client/src/returns/types';
+
+/**
+ * Obtains the pickup reschedule requests.
+ *
+ * @param getPickupRescheduleRequests - Get pickup reschedule requests client.
+ *
+ * @returns Thunk factory.
+ */
+const fetchPickupRescheduleRequestsFactory =
+  (getPickupRescheduleRequests: GetPickupRescheduleRequests) =>
+  (id: string, config?: Config) =>
+  async (dispatch: Dispatch): Promise<PickupRescheduleRequests> => {
+    dispatch({
+      type: FETCH_PICKUP_RESCHEDULE_REQUESTS_REQUEST,
+    });
+
+    try {
+      const result = await getPickupRescheduleRequests(id, config);
+
+      dispatch({
+        payload: result,
+        type: FETCH_PICKUP_RESCHEDULE_REQUESTS_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: FETCH_PICKUP_RESCHEDULE_REQUESTS_FAILURE,
+      });
+
+      throw error;
+    }
+  };
+
+export default fetchPickupRescheduleRequestsFactory;

--- a/packages/redux/src/returns/actions/factories/index.ts
+++ b/packages/redux/src/returns/actions/factories/index.ts
@@ -1,9 +1,5 @@
 /**
  * Returns actions factories.
- *
- * @module returns/actions/factories
- * @category Returns
- * @subcategory Actions
  */
 
 export { default as fetchReturnFactory } from './fetchReturnFactory';
@@ -12,3 +8,6 @@ export { default as fetchPickupCapabilitiesFactory } from './fetchPickupCapabili
 export { default as fetchReferencesFactory } from './fetchReferencesFactory';
 export { default as fetchReturnsFromOrderFactory } from './fetchReturnsFromOrderFactory';
 export { default as updateReturnFactory } from './updateReturnFactory';
+export { default as fetchPickupRescheduleRequestsFactory } from './fetchPickupRescheduleRequestsFactory';
+export { default as fetchPickupRescheduleRequestFactory } from './fetchPickupRescheduleRequestFactory';
+export { default as createPickupRescheduleRequestFactory } from './createPickupRescheduleRequestFactory';

--- a/packages/redux/src/returns/actions/fetchPickupRescheduleRequest.ts
+++ b/packages/redux/src/returns/actions/fetchPickupRescheduleRequest.ts
@@ -1,0 +1,7 @@
+import { fetchPickupRescheduleRequestFactory } from './factories';
+import { getPickupRescheduleRequest } from '@farfetch/blackout-client/returns';
+
+/**
+ * Fetch pickup reschedule request.
+ */
+export default fetchPickupRescheduleRequestFactory(getPickupRescheduleRequest);

--- a/packages/redux/src/returns/actions/fetchPickupRescheduleRequests.ts
+++ b/packages/redux/src/returns/actions/fetchPickupRescheduleRequests.ts
@@ -1,0 +1,9 @@
+import { fetchPickupRescheduleRequestsFactory } from './factories';
+import { getPickupRescheduleRequests } from '@farfetch/blackout-client/returns';
+
+/**
+ * Fetch pickup reschedule requests.
+ */
+export default fetchPickupRescheduleRequestsFactory(
+  getPickupRescheduleRequests,
+);

--- a/packages/redux/src/returns/actions/index.ts
+++ b/packages/redux/src/returns/actions/index.ts
@@ -13,3 +13,6 @@ export { default as fetchReferences } from './fetchReferences';
 export { default as fetchReturnsFromOrder } from './fetchReturnsFromOrder';
 export { default as resetReturn } from './resetReturn';
 export { default as updateReturn } from './updateReturn';
+export { default as fetchPickupRescheduleRequest } from './fetchPickupRescheduleRequest';
+export { default as fetchPickupRescheduleRequests } from './fetchPickupRescheduleRequests';
+export { default as createPickupRescheduleRequest } from './createPickupRescheduleRequest';

--- a/packages/redux/src/returns/types/actions.types.ts
+++ b/packages/redux/src/returns/types/actions.types.ts
@@ -128,6 +128,58 @@ export type UpdateReturnAction =
   | UpdateReturnSuccessAction
   | UpdateReturnFailureAction;
 
+export interface FetchPickupRescheduleRequestsRequestAction extends Action {
+  type: typeof actionTypes.FETCH_PICKUP_RESCHEDULE_REQUESTS_REQUEST;
+}
+export interface FetchPickupRescheduleRequestsSuccessAction extends Action {
+  type: typeof actionTypes.FETCH_PICKUP_RESCHEDULE_REQUESTS_SUCCESS;
+}
+export interface FetchPickupRescheduleRequestsFailureAction extends Action {
+  type: typeof actionTypes.FETCH_PICKUP_RESCHEDULE_REQUESTS_FAILURE;
+  payload: { error: Error };
+}
+
+/** Actions dispatched when the fetch pickup reschedule requests is made. */
+export type FetchPickupRescheduleRequestsAction =
+  | FetchPickupRescheduleRequestsRequestAction
+  | FetchPickupRescheduleRequestsSuccessAction
+  | FetchPickupRescheduleRequestsFailureAction;
+
+export interface FetchPickupRescheduleRequestRequestAction extends Action {
+  type: typeof actionTypes.FETCH_PICKUP_RESCHEDULE_REQUEST_REQUEST;
+}
+export interface FetchPickupRescheduleRequestSuccessAction extends Action {
+  type: typeof actionTypes.FETCH_PICKUP_RESCHEDULE_REQUEST_SUCCESS;
+}
+export interface FetchPickupRescheduleRequestFailureAction extends Action {
+  type: typeof actionTypes.FETCH_PICKUP_RESCHEDULE_REQUEST_FAILURE;
+  payload: { error: Error };
+}
+
+/** Actions dispatched when the fetch pickup reschedule request is made. */
+export type FetchPickupRescheduleRequestAction =
+  | FetchPickupRescheduleRequestRequestAction
+  | FetchPickupRescheduleRequestSuccessAction
+  | FetchPickupRescheduleRequestFailureAction;
+
+export interface CreatePickupRescheduleRequestRequestAction extends Action {
+  type: typeof actionTypes.CREATE_PICKUP_RESCHEDULE_REQUEST_REQUEST;
+}
+export interface CreatePickupRescheduleRequestSuccessAction extends Action {
+  type: typeof actionTypes.CREATE_PICKUP_RESCHEDULE_REQUEST_SUCCESS;
+  payload: Payload;
+}
+export interface CreatePickupRescheduleRequestFailureAction extends Action {
+  type: typeof actionTypes.CREATE_PICKUP_RESCHEDULE_REQUEST_FAILURE;
+  payload: { error: Error };
+}
+
+/** Actions dispatched when the create pickup reschedule request is made. */
+export type CreatePickupRescheduleRequestAction =
+  | CreatePickupRescheduleRequestRequestAction
+  | CreatePickupRescheduleRequestSuccessAction
+  | CreatePickupRescheduleRequestFailureAction;
+
 /** Actions dispatched when the reset return request is made. */
 export interface ResetReturnAction extends Action {
   type: typeof actionTypes.RESET_RETURN;

--- a/tests/__fixtures__/returns/returns.fixtures.ts
+++ b/tests/__fixtures__/returns/returns.fixtures.ts
@@ -1,4 +1,10 @@
 // @ts-nocheck
+enum RescheduleStatus {
+  InProgress,
+  Succeeded,
+  Failed,
+}
+
 export const responses = {
   post: {
     success: {
@@ -154,6 +160,31 @@ export const responses = {
         'https://obx05-whitelabel.fftech.info/pt/account/return/summary/?id=5926969',
     },
   },
+  getPickupRescheduleRequests: {
+    success: [
+      {
+        id: 'string',
+        timeWindow: {
+          start: '2022-05-06T09:45:32.623Z',
+          end: '2022-05-06T09:45:32.623Z',
+        },
+        status: RescheduleStatus.InProgress,
+      },
+    ],
+  },
+  getPickupRescheduleRequest: {
+    success: {
+      id: 'string',
+      timeWindow: {
+        start: '2022-05-06T09:40:01.115Z',
+        end: '2022-05-06T09:40:01.115Z',
+      },
+      status: RescheduleStatus.InProgress,
+    },
+  },
+  postPickupRescheduleRequests: {
+    success: 202,
+  },
 };
 
 export const orderId = responses.get.success.orderId;
@@ -298,4 +329,13 @@ export const mockPickupCapabilitiesResponse = {
       end: '2022-01-07T10:59:03.9169641Z',
     },
   ],
+};
+
+export const mockPickupReschedulePostData = {
+  id: '',
+  timeWindow: {
+    start: '',
+    end: '',
+  },
+  status: RescheduleStatus.InProgress,
 };


### PR DESCRIPTION
## Description

- This adds clients and redux actions for reschedule endpoints
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
