### PR TITLE
fix(blackout-react): remove Castle's default Date when no valid 'createdDate' is passed

### DIFF
--- a/packages/react/src/analytics/integrations/Castle/CastleV2.js
+++ b/packages/react/src/analytics/integrations/Castle/CastleV2.js
@@ -216,9 +216,8 @@ class CastleV2 extends integrations.Integration {
    * @returns {string} - The ISO date string.
    */
   getNormalizedCreatedDate(createdDate) {
-    // If no date is received, send a default valid date
     if (!createdDate) {
-      return new Date(0).toISOString();
+      return undefined;
     }
 
     const isCreatedDateNaN = isNaN(new Date(createdDate).getTime());
@@ -228,7 +227,7 @@ class CastleV2 extends integrations.Integration {
       const extractedTimestamp = parseInt(createdDate.replace(/[^0-9]/g, ''));
 
       // If the timestamp is a valid number, create a date with it,
-      // If its not, send a default valid date
+      // If its not, send undefined
       if (
         typeof extractedTimestamp === 'number' &&
         !isNaN(extractedTimestamp)
@@ -236,7 +235,7 @@ class CastleV2 extends integrations.Integration {
         return new Date(extractedTimestamp).toISOString();
       }
 
-      return new Date(0).toISOString();
+      return undefined;
     }
 
     return createdDate;

--- a/packages/react/src/analytics/integrations/__tests__/CastleV2.test.js
+++ b/packages/react/src/analytics/integrations/__tests__/CastleV2.test.js
@@ -255,8 +255,8 @@ describe('Castle integration', () => {
         };
 
         const expectedCallPayload = {
-          user: expect.objectContaining({
-            registered_at: new Date(0).toISOString(),
+          user: expect.not.objectContaining({
+            createdDate: 'gibberish', // Invalid date value
           }),
           name: mockEventData.event,
           values: mockEventData.properties,
@@ -275,8 +275,8 @@ describe('Castle integration', () => {
 
         mockEventData.user.traits.createdDate = null; // No createdDate value
 
-        expectedCallPayload.user = expect.objectContaining({
-          registered_at: new Date(0).toISOString(),
+        expectedCallPayload.user = expect.not.objectContaining({
+          registered_at: null,
         });
 
         await instance.track(mockEventData);


### PR DESCRIPTION
## Description
This PR fixes an edge case where the backend does not send a createdDate on the user info.
In this case, Castle does not accept the default date that was being calculated: `new Date(0).toISOString()`.
Now we're going to send `undefined` for these cases.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
