### PR TITLE
fix(core): fix pickup capabilities timestamp parsing

### DIFF
--- a/packages/core/src/returns/client/__fixtures__/getPickupCapabilities.fixtures.js
+++ b/packages/core/src/returns/client/__fixtures__/getPickupCapabilities.fixtures.js
@@ -38,7 +38,7 @@ export default {
     success: params => {
       moxios.stubRequest(
         join('/api/legacy/v1/returns', params.id, 'pickupcapabilities/', {
-          query: params.query,
+          query: { pickupDay: params.parsedPickupDay },
         }),
         {
           method: 'get',
@@ -50,7 +50,7 @@ export default {
     failure: params => {
       moxios.stubRequest(
         join('/api/legacy/v1/returns', params.id, 'pickupcapabilities/', {
-          query: params.query,
+          query: { pickupDay: params.parsedPickupDay },
         }),
         {
           method: 'get',

--- a/packages/core/src/returns/client/__tests__/getPickupCapabilities.test.js
+++ b/packages/core/src/returns/client/__tests__/getPickupCapabilities.test.js
@@ -3,6 +3,7 @@ import client from '../../../helpers/client';
 import fixture from '../__fixtures__/getPickupCapabilities.fixtures';
 import join from 'proper-url-join';
 import moxios from 'moxios';
+import parsePickupDate from '../../../helpers/parsePickupDate';
 
 describe('getPickupCapabilities', () => {
   const spy = jest.spyOn(client, 'get');
@@ -16,7 +17,7 @@ describe('getPickupCapabilities', () => {
   afterEach(() => moxios.uninstall(client));
 
   describe('Account SVC', () => {
-    const id = 123456;
+    const id = '123456';
     const pickupDay = '2020-04-20';
 
     it('should handle a client request successfully', async () => {
@@ -54,28 +55,38 @@ describe('getPickupCapabilities', () => {
 
   describe('Legacy', () => {
     const query = { pickupDay: 1519211809934 };
+    const pickupDay = 1519211809934;
+    const parsedPickupDay = parsePickupDate(pickupDay);
     const id = '123456';
 
     it('should handle a client request successfully', async () => {
       const response = {};
 
-      fixture.legacy.success({ id, query, response });
+      fixture.legacy.success({ id, parsedPickupDay, response });
 
       expect.assertions(2);
-      await expect(getPickupCapabilities(id, query)).resolves.toBe(response);
+      await expect(getPickupCapabilities(id, pickupDay, query)).resolves.toBe(
+        response,
+      );
       expect(spy).toHaveBeenCalledWith(
-        join('/legacy/v1/returns', id, 'pickupcapabilities', { query }),
+        join(`/legacy/v1/returns/${id}/pickupcapabilities/`, {
+          query: { pickupDay: parsedPickupDay },
+        }),
         expectedConfig,
       );
     });
 
     it('should receive a client request error', async () => {
-      fixture.legacy.failure({ id, query });
+      fixture.legacy.failure({ id, parsedPickupDay });
 
       expect.assertions(2);
-      await expect(getPickupCapabilities(id, query)).rejects.toMatchSnapshot();
+      await expect(
+        getPickupCapabilities(id, pickupDay, query),
+      ).rejects.toMatchSnapshot();
       expect(spy).toHaveBeenCalledWith(
-        join('/legacy/v1/returns', id, 'pickupcapabilities', { query }),
+        join('/legacy/v1/returns', id, 'pickupcapabilities', {
+          query: { pickupDay: parsedPickupDay },
+        }),
         expectedConfig,
       );
     });

--- a/packages/core/src/returns/client/getPickupCapabilities.js
+++ b/packages/core/src/returns/client/getPickupCapabilities.js
@@ -1,5 +1,6 @@
 import client, { adaptError } from '../../helpers/client';
 import join from 'proper-url-join';
+import parsePickupDate from '../../helpers/parsePickupDate';
 
 /**
  * @typedef {object} GetPickupCapabilitiesQuery
@@ -7,7 +8,7 @@ import join from 'proper-url-join';
  * @alias GetPickupCapabilitiesQuery
  * @memberof module:returns/client
  *
- * @property {Date} [pickupDay] - Timestamp for the day of pickup.
+ * @property {Date} pickupDay - Timestamp for the day of pickup.
  * @property {string} [guestOrderId] - Order identifier. Only required if
  * the user is not registered (guest).
  * @property {string} [guestUserEmail] - User email. Only required if
@@ -21,26 +22,31 @@ import join from 'proper-url-join';
  * @memberof module:returns/client
  *
  * @param {number} id - Return identifier.
- * @param {GetPickupCapabilitiesQuery} pickupDay - Query parameters.
+ * @param {string|number} pickupDay - Day of the pickup. Format: YYYY-MM-DD or a Timestamp.
+ * @param {GetPickupCapabilitiesQuery} [query] - Query object for the request.
  * @param {object} [config] - Custom configurations to send to the client
  * instance (axios).
  *
  * @returns {Promise} Promise that will resolve when the call to
  * the endpoint finishes.
  */
-export default (id, pickupDay, config) => {
-  const returnId = id.toString();
-  const isQuery = typeof pickupDay !== 'string';
+export default (id, pickupDay, query, config) => {
+  const queryParams = {
+    ...query,
+    pickupDay: parsePickupDate(query?.pickupDay ? query.pickupDay : pickupDay),
+  };
+  const isQuery =
+    typeof pickupDay !== 'string' || typeof query?.pickupDay === 'number';
 
   const args = isQuery
     ? [
         join('/legacy/v1/returns', id, 'pickupcapabilities', {
-          query: pickupDay,
+          query: { pickupDay: queryParams.pickupDay },
         }),
         config,
       ]
     : [
-        join('/account/v1/returns', returnId, 'pickupcapabilities', pickupDay),
+        join('/account/v1/returns', id, 'pickupcapabilities', pickupDay),
         config,
       ];
 

--- a/packages/core/src/returns/redux/actions/__tests__/doGetPickupCapabilities.test.js
+++ b/packages/core/src/returns/redux/actions/__tests__/doGetPickupCapabilities.test.js
@@ -10,6 +10,7 @@ const returnsMockStore = (state = {}) =>
 describe('doGetPickupCapabilities action creator', () => {
   const pickupDay = '1974-11-29';
   const expectedConfig = undefined;
+  const query = {};
   let store;
 
   const getPickupCapabilities = jest.fn();
@@ -28,13 +29,14 @@ describe('doGetPickupCapabilities action creator', () => {
     expect.assertions(4);
 
     try {
-      await store.dispatch(action(returnId, pickupDay));
+      await store.dispatch(action(returnId, pickupDay, query));
     } catch (error) {
       expect(error).toBe(expectedError);
       expect(getPickupCapabilities).toHaveBeenCalledTimes(1);
       expect(getPickupCapabilities).toHaveBeenCalledWith(
         returnId,
         pickupDay,
+        query,
         expectedConfig,
       );
       expect(store.getActions()).toEqual(
@@ -91,7 +93,7 @@ describe('doGetPickupCapabilities action creator', () => {
     getPickupCapabilities.mockResolvedValueOnce(
       responses.getPickupCapabilities.success,
     );
-    await store.dispatch(action(returnId, pickupDay));
+    await store.dispatch(action(returnId, pickupDay, query));
 
     const actionResults = store.getActions();
 
@@ -99,6 +101,7 @@ describe('doGetPickupCapabilities action creator', () => {
     expect(getPickupCapabilities).toHaveBeenCalledWith(
       returnId,
       pickupDay,
+      query,
       expectedConfig,
     );
     expect(actionResults).toMatchObject([

--- a/packages/core/src/returns/redux/actions/doGetPickupCapabilities.js
+++ b/packages/core/src/returns/redux/actions/doGetPickupCapabilities.js
@@ -17,7 +17,8 @@ import {
 /**
  * @callback GetPickupCapabilitiesThunkFactory
  * @param {number} id - Return identifier.
- * @param {string} pickupDay - Day of the pickup. Format: YYYY-MM-DD.
+ * @param {string|number} pickupDay - Day of the pickup. Format: YYYY-MM-DD.
+ * @param {GetPickupCapabilitiesQuery} [query] - Query object for the request.
  * @param {object} [config] - Custom configurations to send to the client
  * instance (axios).
  *
@@ -35,7 +36,7 @@ import {
  * @returns {GetPickupCapabilitiesThunkFactory} Thunk factory.
  */
 export default getPickupCapabilities =>
-  (id, pickupDay, config) =>
+  (id, pickupDay, query = {}, config) =>
   async dispatch => {
     dispatch({
       type: GET_PICKUP_CAPABILITIES_REQUEST,
@@ -47,7 +48,7 @@ export default getPickupCapabilities =>
         availableStartHours,
         availableTimeSlots,
         pickupDate,
-      } = await getPickupCapabilities(id, pickupDay, config);
+      } = await getPickupCapabilities(id, pickupDay, query, config);
 
       dispatch({
         meta: { id },


### PR DESCRIPTION
## Description

- Fix Pickup Capabilities timestamp parsing for pickupday and query.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
