### PR TITLE
feat(blackout-react): add product viewed/search mappings in Zaraz

### DIFF
--- a/packages/react/src/analytics/integrations/Zaraz/Zaraz.js
+++ b/packages/react/src/analytics/integrations/Zaraz/Zaraz.js
@@ -99,7 +99,7 @@ class Zaraz extends integrations.Integration {
       }
 
       const mappedEventData = mapper(data);
-      const [zarazMethod, zarazData] = mappedEventData;
+      const [zarazMethod, zarazEventName, zarazData] = mappedEventData;
 
       if (typeof window.zaraz[zarazMethod] !== 'function') {
         utils.logger
@@ -108,7 +108,14 @@ class Zaraz extends integrations.Integration {
         return;
       }
 
-      window.zaraz[zarazMethod](zarazData);
+      if (typeof zarazEventName !== 'string') {
+        utils.logger
+          .error(`[Zaraz] - Invalid value for the zaraz event name returned from mapper for event '${data.event}': '${zarazEventName}' is not a string.
+          This event will be discarded.`);
+        return;
+      }
+
+      window.zaraz[zarazMethod](zarazEventName, zarazData);
     } catch (e) {
       utils.logger.error(
         `[Zaraz] - An error occurred when trying to track event '${data.event}' with Zaraz: `,

--- a/packages/react/src/analytics/integrations/Zaraz/constants.js
+++ b/packages/react/src/analytics/integrations/Zaraz/constants.js
@@ -6,3 +6,24 @@ export const OPTION_ENVIRONMENT = 'environment';
 export const OPTION_EVENTS_MAPPER = 'eventsMapper';
 export const OPTION_ZARAZ_INIT_SCRIPT_ENDPOINT = 'initScriptEndpoint';
 export const DEFAULT_ZARAZ_INIT_SCRIPT_ENDPOINT = '/cdn-cgi/zaraz/i.js';
+
+export const ZARAZ_ECOMMERCE_EVENTS = {
+  PRODUCT_LIST_VIEWED: 'Product List Viewed',
+  PRODUCTS_SEARCHED: 'Products Searched',
+  PRODUCT_CLICKED: 'Product Clicked',
+  PRODUCT_ADDED: 'Product Added',
+  PRODUCT_ADDED_TO_WISHLIST: 'Product Added to Wishlist',
+  PRODUCT_REMOVED: 'Product Removed',
+  PRODUCT_VIEWED: 'Product Viewed',
+  CART_VIEWED: 'Cart Viewed',
+  CHECKOUT_STARTED: 'Checkout Started',
+  CHECKOUT_STEP_VIEWED: 'Checkout Step Viewed',
+  CHECKOUT_STEP_COMPLETED: 'Checkout Step Completed',
+  PAYMENT_INFO_ENTERED: 'Payment Info Entered',
+  ORDER_COMPLETED: 'Order Completed',
+  ORDER_UPDATED: 'Order Updated',
+  ORDER_REFUNDED: 'Order Refunded',
+  ORDER_CANCELLED: 'Order Cancelled',
+  CLICKED_PROMOTION: 'Clicked Promotion',
+  VIEWED_PROMOTION: 'Viewed Promotion',
+};

--- a/packages/react/src/analytics/integrations/Zaraz/eventsMapper.js
+++ b/packages/react/src/analytics/integrations/Zaraz/eventsMapper.js
@@ -1,4 +1,4 @@
-import { eventTypes } from '@farfetch/blackout-core/analytics';
+import { eventTypes, pageTypes } from '@farfetch/blackout-core/analytics';
 
 export default {
   [eventTypes.PRODUCT_ADDED_TO_CART]: data => {
@@ -10,7 +10,7 @@ export default {
         currency: eventProperties.currency,
         name: eventProperties.name,
         price: eventProperties.price,
-        product_id: eventProperties.id,
+        product_id: `${eventProperties.id}`, // Zaraz's product_id is a string
       },
     ];
   },
@@ -24,7 +24,35 @@ export default {
         currency: eventProperties.currency,
         name: eventProperties.name,
         price: eventProperties.price,
-        product_id: eventProperties.id,
+        product_id: `${eventProperties.id}`, // Zaraz's product_id is a string
+      },
+    ];
+  },
+  [eventTypes.PRODUCT_VIEWED]: data => {
+    const eventProperties = data.properties;
+
+    return [
+      'ecommerce',
+      {
+        currency: eventProperties.currency,
+        name: eventProperties.name,
+        price: eventProperties.price,
+        product_id: `${eventProperties.id}`, // Zaraz's product_id is a string
+      },
+    ];
+  },
+  [pageTypes.SEARCH]: data => {
+    const eventProperties = data.properties;
+
+    return [
+      'ecommerce',
+      {
+        price: 0, // This was required by Zaraz
+        currency: eventProperties.currency,
+        products: eventProperties.products?.map(product => ({
+          product_id: `${product.id}`, // Zaraz's product_id is a string
+        })),
+        query: eventProperties.searchQuery,
       },
     ];
   },

--- a/packages/react/src/analytics/integrations/Zaraz/eventsMapper.js
+++ b/packages/react/src/analytics/integrations/Zaraz/eventsMapper.js
@@ -1,4 +1,5 @@
 import { eventTypes, pageTypes } from '@farfetch/blackout-core/analytics';
+import { ZARAZ_ECOMMERCE_EVENTS } from './constants';
 
 export default {
   [eventTypes.PRODUCT_ADDED_TO_CART]: data => {
@@ -6,6 +7,7 @@ export default {
 
     return [
       'ecommerce',
+      ZARAZ_ECOMMERCE_EVENTS.PRODUCT_ADDED,
       {
         currency: eventProperties.currency,
         name: eventProperties.name,
@@ -19,6 +21,7 @@ export default {
 
     return [
       'ecommerce',
+      ZARAZ_ECOMMERCE_EVENTS.PRODUCT_ADDED_TO_WISHLIST,
       {
         category: eventProperties.category,
         currency: eventProperties.currency,
@@ -33,6 +36,7 @@ export default {
 
     return [
       'ecommerce',
+      ZARAZ_ECOMMERCE_EVENTS.PRODUCT_VIEWED,
       {
         currency: eventProperties.currency,
         name: eventProperties.name,
@@ -46,6 +50,7 @@ export default {
 
     return [
       'ecommerce',
+      ZARAZ_ECOMMERCE_EVENTS.PRODUCTS_SEARCHED,
       {
         price: 0, // This was required by Zaraz
         currency: eventProperties.currency,

--- a/packages/react/src/analytics/integrations/__fixtures__/gaData.fixtures.js
+++ b/packages/react/src/analytics/integrations/__fixtures__/gaData.fixtures.js
@@ -492,7 +492,9 @@ const validTrackEvents = {
     type: analyticsTrackTypes.PAGE,
     event: pageTypes.SEARCH,
     properties: {
-      searchTerm: 'shoes',
+      searchQuery: 'shoes',
+      currency: 'EUR',
+      products: [{ id: 10000 }, { id: 20000 }],
     },
   },
 

--- a/packages/react/src/analytics/integrations/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/__tests__/GA4.test.js
@@ -1218,7 +1218,7 @@ describe('GA4 Integration', () => {
               ...defaultEvent,
               properties: {
                 ...defaultEvent.properties,
-                searchTerm: undefined,
+                searchQuery: undefined,
               },
             };
 

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/Zaraz.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/Zaraz.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Zaraz integration default events mapper should map the Product Added to Cart event correctly 1`] = `
 Array [
   Array [
+    "Product Added",
     Object {
       "currency": "USD",
       "name": "Gareth McConnell Dreamscape T-Shirt",
@@ -16,6 +17,7 @@ Array [
 exports[`Zaraz integration default events mapper should map the Product Added to Wishlist event correctly 1`] = `
 Array [
   Array [
+    "Product Added to Wishlist",
     Object {
       "category": "Clothing/Tops/T-shirts",
       "currency": "USD",
@@ -30,6 +32,7 @@ Array [
 exports[`Zaraz integration default events mapper should map the Product Viewed event correctly 1`] = `
 Array [
   Array [
+    "Product Viewed",
     Object {
       "currency": "USD",
       "name": "Gareth McConnell Dreamscape T-Shirt",
@@ -43,6 +46,7 @@ Array [
 exports[`Zaraz integration default events mapper should map the search event correctly 1`] = `
 Array [
   Array [
+    "Products Searched",
     Object {
       "currency": "EUR",
       "price": 0,

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/Zaraz.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/Zaraz.test.js.snap
@@ -26,3 +26,36 @@ Array [
   ],
 ]
 `;
+
+exports[`Zaraz integration default events mapper should map the Product Viewed event correctly 1`] = `
+Array [
+  Array [
+    Object {
+      "currency": "USD",
+      "name": "Gareth McConnell Dreamscape T-Shirt",
+      "price": 19,
+      "product_id": "507f1f77bcf86cd799439011",
+    },
+  ],
+]
+`;
+
+exports[`Zaraz integration default events mapper should map the search event correctly 1`] = `
+Array [
+  Array [
+    Object {
+      "currency": "EUR",
+      "price": 0,
+      "products": Array [
+        Object {
+          "product_id": "10000",
+        },
+        Object {
+          "product_id": "20000",
+        },
+      ],
+      "query": "shoes",
+    },
+  ],
+]
+`;


### PR DESCRIPTION
## Description

- This adds mappings for "Product Viewed" and "Search"
events in Zaraz integration.
- Force transforming product ids to a string in Zaraz events.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
