### PR TITLE
fix: add fallback for filter segments without facet

### DIFF
--- a/packages/core/src/entities/schemas/searchResult.js
+++ b/packages/core/src/entities/schemas/searchResult.js
@@ -35,14 +35,14 @@ export default new schema.Entity(
           ({ type, deep }) =>
             type === filterSegment.type && deep === filterSegment.deep,
         );
-        const facet = facetGroup.values[0].find(
+        const facet = facetGroup?.values[0].find(
           ({ value }) => value === filterSegment.value,
         );
 
         return {
           ...filterSegment,
-          description: facet.description,
-          facetId: getId(facet, facetGroup),
+          description: facet?.description,
+          facetId: facet ? getId(facet, facetGroup) : undefined,
         };
       });
       const searchResult = {


### PR DESCRIPTION
## Description
This adds a new fallback when generating the "facetId" for the filter segments. It will
use `undefined` for the descriptions and the facetId.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
