### PR TITLE
fix(redux): get entity selectors errors

### DIFF
--- a/packages/redux/src/addresses/selectors.ts
+++ b/packages/redux/src/addresses/selectors.ts
@@ -31,7 +31,7 @@ import type { StoreState } from '../types';
  *
  * @function
  *
- * @param {object} state        - Application state.
+ * @param {object} state - Application state.
  *
  * @returns {Array} Array containing the loaded addresses id.
  */
@@ -43,7 +43,7 @@ export const getResult = (state: StoreState): State['result'] =>
  *
  * @function
  *
- * @param {object} state        - Application state.
+ * @param {object} state - Application state.
  *
  * @returns {object} Address information object.
  */
@@ -55,7 +55,7 @@ export const getError = (state: StoreState): State['error'] =>
  *
  * @function
  *
- * @param {object} state        - Application state.
+ * @param {object} state - Application state.
  *
  * @returns {boolean} Loader status.
  */
@@ -67,7 +67,7 @@ export const isAddressesLoading = (state: StoreState): State['isLoading'] =>
  *
  * @function
  *
- * @param {object} state        - Application state.
+ * @param {object} state - Application state.
  *
  * @returns {object} Object containing all the currently loaded addresses.
  */
@@ -79,15 +79,15 @@ export const getAddresses = (state: StoreState): AddressesEntity =>
  *
  * @function
  *
- * @param {object} state        - Application state.
- * @param {string} addressId    - Address id.
+ * @param {object} state - Application state.
+ * @param {string} addressId - Address id.
  *
  * @returns {object} Address information object.
  */
 export const getAddress = (
   state: StoreState,
   addressId: AddressEntity['id'],
-): AddressEntity => getEntityById(state, 'addresses', addressId);
+): AddressEntity | undefined => getEntityById(state, 'addresses', addressId);
 
 /**
  * Returns a list with all addresses schemas in the application state.
@@ -107,13 +107,15 @@ export const getSchemas = (state: StoreState): AddressSchemaEntity =>
  *
  * @function
  *
- * @param {object} state     - Application state.
- * @param {string} isoCode   - Iso code or CountryId (deprecated).
+ * @param {object} state - Application state.
+ * @param {string} isoCode - Iso code or CountryId (deprecated).
  *
  * @returns {object} Schema information object.
  */
-export const getSchema = (state: StoreState, isoCode: string): SchemaEntity =>
-  getEntityById(state, 'addressSchema', isoCode);
+export const getSchema = (
+  state: StoreState,
+  isoCode: string,
+): SchemaEntity | undefined => getEntityById(state, 'addressSchema', isoCode);
 
 /**
  * Returns the error or loading status of each sub-area.

--- a/packages/redux/src/bags/selectors.ts
+++ b/packages/redux/src/bags/selectors.ts
@@ -104,16 +104,20 @@ export const getBagId = (state: StoreState): State['id'] => getId(state.bag);
  *     bagItem: getBagItem(state, id)
  * });
  */
-
+// @TODO Remove cast from functions
 export const getBagItem = createSelector(
   [
-    (state: StoreState, bagItemId: BagItem['id']): BagItemEntity =>
-      getEntityById(state, 'bagItems', bagItemId),
+    (state: StoreState, bagItemId: BagItem['id']) =>
+      getEntityById(state, 'bagItems', bagItemId) as BagItemEntity,
     (
       state: StoreState,
       bagItemId: BagItem['id'],
     ): ProductEntity | undefined => {
-      const bagItem = getEntityById(state, 'bagItems', bagItemId);
+      const bagItem = getEntityById(
+        state,
+        'bagItems',
+        bagItemId,
+      ) as BagItemEntity;
 
       return getProduct(state, bagItem?.product);
     },

--- a/packages/redux/src/checkout/selectors.ts
+++ b/packages/redux/src/checkout/selectors.ts
@@ -80,7 +80,7 @@ export const getCheckoutId = (state: StoreState): State['id'] =>
 export const getCheckout = (state: StoreState): CheckoutEntity | undefined => {
   const checkoutId = getCheckoutId(state);
 
-  return checkoutId && getEntityById(state, 'checkout', checkoutId);
+  return checkoutId ? getEntityById(state, 'checkout', checkoutId) : undefined;
 };
 
 /**
@@ -109,7 +109,9 @@ export const getCheckoutOrder = (
 ): CheckoutOrderEntity | undefined => {
   const checkoutId = getCheckoutId(state);
 
-  return checkoutId && getEntityById(state, 'checkoutOrders', checkoutId);
+  return checkoutId
+    ? getEntityById(state, 'checkoutOrders', checkoutId)
+    : undefined;
 };
 
 /**
@@ -126,7 +128,9 @@ export const getCheckoutDetail = (
 ): CheckoutDetailsEntity | undefined => {
   const checkoutId = getCheckoutId(state);
 
-  return checkoutId && getEntityById(state, 'checkoutDetails', checkoutId);
+  return checkoutId
+    ? getEntityById(state, 'checkoutDetails', checkoutId)
+    : undefined;
 };
 
 /**

--- a/packages/redux/src/entities/selectors/cities.ts
+++ b/packages/redux/src/entities/selectors/cities.ts
@@ -13,5 +13,5 @@ import type { StoreState } from '../../types';
  *
  * @returns {object} - City normalized.
  */
-export const getCity = (state: StoreState, id: number): City =>
+export const getCity = (state: StoreState, id: number): City | undefined =>
   getEntityById(state, 'cities', id);

--- a/packages/redux/src/entities/selectors/contents.ts
+++ b/packages/redux/src/entities/selectors/contents.ts
@@ -13,5 +13,7 @@ import type { StoreState } from '../../types';
  *
  * @returns {object} Content normalized.
  */
-export const getContent = (state: StoreState, id: string): ContentEntries =>
-  getEntityById(state, 'contents', id);
+export const getContent = (
+  state: StoreState,
+  id: string,
+): ContentEntries | undefined => getEntityById(state, 'contents', id);

--- a/packages/redux/src/entities/selectors/countries.ts
+++ b/packages/redux/src/entities/selectors/countries.ts
@@ -16,8 +16,10 @@ import type { StoreState } from '../../types';
  *
  * @returns {object} - Country normalized.
  */
-export const getCountry = (state: StoreState, countryCode: string): Country =>
-  getEntityById(state, 'countries', countryCode);
+export const getCountry = (
+  state: StoreState,
+  countryCode: string,
+): Country | undefined => getEntityById(state, 'countries', countryCode);
 
 /**
  * Returns all countries from state.

--- a/packages/redux/src/entities/selectors/entity.ts
+++ b/packages/redux/src/entities/selectors/entity.ts
@@ -1,8 +1,9 @@
-import get from 'lodash/get';
 import invariant from 'invariant';
 import type { StoreState } from '../../types';
 
 type StateEntities = StoreState['entities'];
+type SchemaName = keyof NonNullable<StateEntities>;
+type EntityId = keyof NonNullable<NonNullable<StateEntities>[SchemaName]>;
 
 const throwError = (state: StoreState) => {
   invariant(
@@ -17,17 +18,13 @@ const throwError = (state: StoreState) => {
 /**
  * Gets all entities of a given schema name.
  *
- * @memberof module:entities/selectors
+ * @param state - Application state.
+ * @param name - Entity/schema name.
  *
- * @param {object} state - Application state.
- * @param {string} name - Entity/schema name.
- *
- * @returns {object|undefined} - All entities of the given schema name, undefined
+ * @returns - All entities of the given schema name, undefined
  * if none is found.
  */
-export const getEntities = <
-  SchemaName extends keyof NonNullable<StateEntities>,
->(
+export const getEntities = (
   state: StoreState,
   name: SchemaName,
 ): NonNullable<StateEntities>[SchemaName] | never => {
@@ -42,52 +39,15 @@ export const getEntities = <
 /**
  * Gets a specific entity of the given schema name, by id.
  *
- * @memberof module:entities/selectors
+ * @param state - Application state.
+ * @param name - Entity/schema name.
+ * @param id - Entity identifier.
  *
- * @param {object} state - Application state.
- * @param {string} name - Entity/schema name.
- * @param {string|number} id - Entity identifier.
- *
- * @returns {object|undefined} - The specific entity of the given id, undefined
+ * @returns - The specific entity of the given id, undefined
  * if it isn't found.
  */
-export const getEntityById = <
-  SchemaName extends keyof NonNullable<StateEntities>,
-  EntityId extends keyof NonNullable<NonNullable<StateEntities>[SchemaName]>,
->(
+export const getEntityById = <T>(
   state: StoreState,
   name: SchemaName,
   id: EntityId,
-): NonNullable<StateEntities>[SchemaName][EntityId] | undefined =>
-  getEntities(state, name)?.[id];
-
-/**
- * Returns a specific entity by given name and id.
- *
- * @function getEntity
- * @memberof module:entities/selectors
- *
- * @param   {object} state - Aplication state.
- * @param   {string} name  - Entity name.
- * @param   {string|number} id    - Entity identifier.
- *
- * @returns {object} The entity.
- */
-export const getEntity = (
-  state: StoreState,
-  name: string,
-  id: string | null = null,
-) => {
-  invariant(
-    typeof state.entities !== 'undefined',
-    [
-      'It looks like you are trying to access the `entities` state property but it does not exist.',
-      'You need to add a `entities` reducer to the top level of your state tree.',
-    ].join('\n'),
-  );
-
-  const path = ['entities', name];
-  if (id !== null) path.push(id);
-
-  return get(state, path);
-};
+): T | undefined => getEntities(state, name)?.[id];

--- a/packages/redux/src/entities/selectors/states.ts
+++ b/packages/redux/src/entities/selectors/states.ts
@@ -13,5 +13,5 @@ import type { StoreState } from '../../types';
  *
  * @returns {object} - State normalized.
  */
-export const getState = (state: StoreState, id: number): State =>
+export const getState = (state: StoreState, id: number): State | undefined =>
   getEntityById(state, 'states', id);

--- a/packages/redux/src/orders/__tests__/selectors.test.ts
+++ b/packages/redux/src/orders/__tests__/selectors.test.ts
@@ -221,7 +221,7 @@ describe('orders redux selectors', () => {
   describe('getOrders()', () => {
     it('should get the orders from state', () => {
       const expectedResult = mockState.entities.orders;
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntities');
 
       expect(selectors.getOrders(mockState)).toEqual(expectedResult);
       expect(spy).toHaveBeenCalledWith(mockState, 'orders');
@@ -230,7 +230,7 @@ describe('orders redux selectors', () => {
 
   describe('getOrder()', () => {
     it('should get the order from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntityById');
 
       expect(selectors.getOrder(mockState, orderId)).toEqual(orderEntity);
       expect(spy).toHaveBeenCalledWith(mockState, 'orders', orderId);
@@ -239,7 +239,7 @@ describe('orders redux selectors', () => {
 
   describe('getLabelTracking()', () => {
     it('should get the label tracking property from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntityById');
 
       expect(selectors.getLabelTracking(mockState, trackingNumber)).toBe(
         labelTrackingEntity,
@@ -250,7 +250,7 @@ describe('orders redux selectors', () => {
 
   describe('getCourier()', () => {
     it('should get the courier property from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntityById');
 
       expect(selectors.getCourier(mockState, courierId)).toBe(courierEntity);
       expect(spy).toHaveBeenCalledTimes(1);
@@ -260,7 +260,7 @@ describe('orders redux selectors', () => {
   describe('getMerchants()', () => {
     it('should get the merchants from state', () => {
       const expectedResult = mockState.entities.merchants;
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntities');
 
       expect(selectors.getMerchants(mockState)).toBe(expectedResult);
       expect(spy).toHaveBeenCalledTimes(1);
@@ -269,7 +269,7 @@ describe('orders redux selectors', () => {
 
   describe('getMerchant()', () => {
     it('should get the merchant from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntityById');
 
       expect(selectors.getMerchant(mockState, merchantId)).toEqual(
         merchantEntity,
@@ -281,7 +281,7 @@ describe('orders redux selectors', () => {
   describe('getOrderItems()', () => {
     it('should get the courier property from state', () => {
       const expectedResult = mockState.entities.orderItems;
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntities');
 
       expect(selectors.getOrderItems(mockState)).toBe(expectedResult);
       expect(spy).toHaveBeenCalledTimes(1);
@@ -290,7 +290,7 @@ describe('orders redux selectors', () => {
 
   describe('getOrderItem()', () => {
     it('should get the merchant from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntityById');
 
       expect(selectors.getOrderItem(mockState, orderItemId)).toEqual(
         orderItemEntity,
@@ -302,7 +302,7 @@ describe('orders redux selectors', () => {
   describe('getCountries()', () => {
     it('should get the countries from state', () => {
       const expectedResult = mockState.entities.countries;
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntities');
 
       expect(selectors.getCountries(mockState)).toBe(expectedResult);
       expect(spy).toHaveBeenCalledTimes(1);
@@ -311,7 +311,7 @@ describe('orders redux selectors', () => {
 
   describe('getCountry()', () => {
     it('should get the country from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntityById');
 
       expect(selectors.getCountry(mockState, countryId)).toBe(countryEntity);
       expect(spy).toHaveBeenCalledTimes(1);
@@ -321,7 +321,7 @@ describe('orders redux selectors', () => {
   describe('getReturnOptions()', () => {
     it('should get the return options from state', () => {
       const expectedResult = mockState.entities.returnOptions;
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntities');
 
       expect(selectors.getReturnOptions(mockState)).toBe(expectedResult);
       expect(spy).toHaveBeenCalledTimes(1);
@@ -330,7 +330,7 @@ describe('orders redux selectors', () => {
 
   describe('getReturnOption()', () => {
     it('should get the return option from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntityById');
 
       expect(selectors.getReturnOption(mockState, returnOptionId)).toBe(
         returnOptionEntity,
@@ -341,59 +341,70 @@ describe('orders redux selectors', () => {
 
   describe('getReturnOptionsFromOrder()', () => {
     it('should get the return options from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spyGetOrder = jest.spyOn(fromEntities, 'getEntityById');
+      const spyGetReturnOptions = jest.spyOn(fromEntities, 'getEntities');
 
       expect(
         selectors.getReturnOptionsFromOrder(mockState, orderId, merchantId),
       ).toEqual([returnOptionEntity]);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spyGetOrder).toHaveBeenCalledTimes(1);
+      expect(spyGetReturnOptions).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('getMerchantsFromOrder()', () => {
     it('should get the merchants from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spyGetOrder = jest.spyOn(fromEntities, 'getEntityById');
+      const spyGetMerchant = jest.spyOn(fromEntities, 'getEntities');
 
       expect(selectors.getMerchantsFromOrder(mockState, orderId)).toEqual([
         merchantEntity,
       ]);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spyGetOrder).toHaveBeenCalledTimes(1);
+      expect(spyGetMerchant).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('getOrderItemsByOrder()', () => {
     it('should get the order items by order from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spyGetOrder = jest.spyOn(fromEntities, 'getEntityById');
+      const spyGetOrderItems = jest.spyOn(fromEntities, 'getEntities');
 
       expect(selectors.getOrderItemsByOrder(mockState, orderId)).toEqual([
         orderItemEntity,
       ]);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spyGetOrder).toHaveBeenCalledTimes(1);
+      expect(spyGetOrderItems).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('getOrderItemsByMerchant()', () => {
     it('should get the order items by merchant from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spyGetOrder = jest.spyOn(fromEntities, 'getEntityById');
+      const spyGetOrderItems = jest.spyOn(fromEntities, 'getEntities');
 
       expect(selectors.getOrderItemsByMerchant(mockState, orderId)).toEqual({
         [merchantId]: [orderItemEntity],
       });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spyGetOrder).toHaveBeenCalledTimes(1);
+      expect(spyGetOrderItems).toHaveBeenCalledTimes(1);
     });
     it('should get undefined if there are no orderDetails from that order', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spyGetOrder = jest.spyOn(fromEntities, 'getEntityById');
+      const spyGetOrderItems = jest.spyOn(fromEntities, 'getEntities');
 
       expect(
         selectors.getOrderItemsByMerchant(mockState, 'randomOrderId'),
       ).toBe(undefined);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spyGetOrder).toHaveBeenCalledTimes(1);
+      expect(spyGetOrderItems).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('getOrderItemQuantity()', () => {
     it('should get the order item quantity as undefined from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spyGetOrder = jest.spyOn(fromEntities, 'getEntityById');
+      const spyGetOrderItems = jest.spyOn(fromEntities, 'getEntities');
 
       const newState = {
         entities: {
@@ -404,25 +415,30 @@ describe('orders redux selectors', () => {
       expect(
         selectors.getOrderItemQuantity(newState, orderId, orderItemId),
       ).toBe(undefined);
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spyGetOrder).toHaveBeenCalledTimes(2);
+      expect(spyGetOrderItems).toHaveBeenCalledTimes(1);
     });
 
     it('should get the order item quantity from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spyGetOrder = jest.spyOn(fromEntities, 'getEntityById');
+      const spyGetOrderItems = jest.spyOn(fromEntities, 'getEntities');
 
       expect(
         selectors.getOrderItemQuantity(mockState, orderId, orderItemId),
       ).toBe(1);
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spyGetOrder).toHaveBeenCalledTimes(2);
+      expect(spyGetOrderItems).toHaveBeenCalledTimes(1);
     });
 
     it('should get undefined if the order was not fetched', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spyGetOrder = jest.spyOn(fromEntities, 'getEntityById');
+      const spyGetOrderItems = jest.spyOn(fromEntities, 'getEntities');
 
       expect(
         selectors.getOrderItemQuantity(mockState, 'randomOrderId', orderItemId),
       ).toBe(undefined);
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spyGetOrder).toHaveBeenCalledTimes(2);
+      expect(spyGetOrderItems).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/redux/src/orders/selectors.ts
+++ b/packages/redux/src/orders/selectors.ts
@@ -17,7 +17,7 @@ import {
   getResult,
   getTrackings,
 } from './reducer';
-import { getEntity } from '../entities/selectors';
+import { getEntities, getEntityById } from '../entities/selectors';
 import get from 'lodash/get';
 import type { Error } from '@farfetch/blackout-client/types';
 import type {
@@ -62,7 +62,7 @@ export const getOrdersError = (state: StoreState): Error | null =>
  * @returns {object} Object with orders with its orderId as the key.
  */
 export const getOrders = (state: StoreState): OrderSummary =>
-  getEntity(state, 'orders');
+  getEntities(state, 'orders');
 
 /**
  * Returns a specific order identified by its id.
@@ -74,8 +74,10 @@ export const getOrders = (state: StoreState): OrderSummary =>
  *
  * @returns {object} Order object.
  */
-export const getOrder = (state: StoreState, orderId: string): Order =>
-  getEntity(state, 'orders', orderId);
+export const getOrder = (
+  state: StoreState,
+  orderId: string,
+): Order | undefined => getEntityById(state, 'orders', orderId);
 
 /**
  * Returns a label tracking with the order tracking events.
@@ -90,7 +92,8 @@ export const getOrder = (state: StoreState, orderId: string): Order =>
 export const getLabelTracking = (
   state: StoreState,
   trackingNumber: string,
-): LabelTracking => getEntity(state, 'labelTracking', trackingNumber);
+): LabelTracking | undefined =>
+  getEntityById(state, 'labelTracking', trackingNumber);
 
 /**
  * Retrieves pagination information of the user orders.
@@ -141,7 +144,7 @@ export const getOrdersPagination = createSelector(
  * @returns {object} Courier object.
  */
 export const getCourier = (state: StoreState, courierId: string) =>
-  getEntity(state, 'courier', courierId);
+  getEntityById(state, 'courier', courierId);
 
 /**
  * Returns all the merchants in the application state.
@@ -153,7 +156,7 @@ export const getCourier = (state: StoreState, courierId: string) =>
  * @returns {object} Object with all merchants with its merchantId as the key.
  */
 export const getMerchants = (state: StoreState) =>
-  getEntity(state, 'merchants');
+  getEntities(state, 'merchants');
 
 /**
  * Returns a specific merchant identified by its id.
@@ -166,7 +169,7 @@ export const getMerchants = (state: StoreState) =>
  * @returns {object} Merchant object.
  */
 export const getMerchant = (state: StoreState, merchantId: string) =>
-  getEntity(state, 'merchants', merchantId);
+  getEntityById(state, 'merchants', merchantId);
 
 /**
  * Returns all the order items in the application state.
@@ -178,7 +181,7 @@ export const getMerchant = (state: StoreState, merchantId: string) =>
  * @returns {object} Object with all order items with its orderItemId as the key.
  */
 export const getOrderItems = (state: StoreState): Order =>
-  getEntity(state, 'orderItems');
+  getEntities(state, 'orderItems');
 
 /**
  * Returns a specific order item identified by its id.
@@ -193,7 +196,7 @@ export const getOrderItems = (state: StoreState): Order =>
 export const getOrderItem = (
   state: StoreState,
   orderItemId: string,
-): OrderItem => getEntity(state, 'orderItems', orderItemId);
+): OrderItem | undefined => getEntityById(state, 'orderItems', orderItemId);
 
 /**
  * Returns all the countries in the application state.
@@ -205,7 +208,7 @@ export const getOrderItem = (
  * @returns {object} Object with all countries with its countryId as the key.
  */
 export const getCountries = (state: StoreState) =>
-  getEntity(state, 'countries');
+  getEntities(state, 'countries');
 
 /**
  * Returns a specific country identified by its id.
@@ -218,7 +221,7 @@ export const getCountries = (state: StoreState) =>
  * @returns {object} Country object.
  */
 export const getCountry = (state: StoreState, countryId: string) =>
-  getEntity(state, 'countries', countryId);
+  getEntityById(state, 'countries', countryId);
 
 /**
  * Returns all the return options in the application state.
@@ -231,7 +234,7 @@ export const getCountry = (state: StoreState, countryId: string) =>
  * its orderId_merchantId_type as the key.
  */
 export const getReturnOptions = (state: StoreState) =>
-  getEntity(state, 'returnOptions');
+  getEntities(state, 'returnOptions');
 
 /**
  * Returns a specific return option identified by its id.
@@ -244,7 +247,7 @@ export const getReturnOptions = (state: StoreState) =>
  * @returns {object} Return option object.
  */
 export const getReturnOption = (state: StoreState, returnOptionId: string) =>
-  getEntity(state, 'returnOptions', returnOptionId);
+  getEntityById(state, 'returnOptions', returnOptionId);
 
 /**
  * Returns all return options from a specific order and merchant.

--- a/packages/redux/src/payments/selectors.ts
+++ b/packages/redux/src/payments/selectors.ts
@@ -48,7 +48,8 @@ export const getPaymentTokens = (state: StoreState): PaymentTokensEntity =>
 export const getPaymentToken = (
   state: StoreState,
   paymentTokenId: PaymentTokenEntity['id'],
-): PaymentTokenEntity => getEntityById(state, 'paymentTokens', paymentTokenId);
+): PaymentTokenEntity | undefined =>
+  getEntityById(state, 'paymentTokens', paymentTokenId);
 
 /**
  * Returns the payment tokens error.
@@ -114,7 +115,8 @@ export const getInstruments = (state: StoreState): InstrumentsEntity =>
 export const getInstrument = (
   state: StoreState,
   instrumentId: InstrumentEntity['id'],
-): InstrumentEntity => getEntityById(state, 'instruments', instrumentId);
+): InstrumentEntity | undefined =>
+  getEntityById(state, 'instruments', instrumentId);
 
 /**
  * Returns the loading status of the instruments.

--- a/packages/redux/src/products/selectors/lists.ts
+++ b/packages/redux/src/products/selectors/lists.ts
@@ -146,7 +146,8 @@ export const isProductsListFetched = (
 export const getProductsListResult = (
   state: StoreState,
   hash: string | number | null = getProductsListHash(state),
-): ProductsListEntity => getEntityById(state, 'productsLists', checkHash(hash));
+): ProductsListEntity | undefined =>
+  getEntityById(state, 'productsLists', checkHash(hash));
 
 /**
  * Retrieves product id's from the current products list.

--- a/packages/redux/src/returns/__tests__/selectors.test.ts
+++ b/packages/redux/src/returns/__tests__/selectors.test.ts
@@ -14,7 +14,7 @@ describe('returns redux selectors', () => {
 
   describe('getReturnItem()', () => {
     it('should get the return item from state', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntity');
+      const spy = jest.spyOn(fromEntities, 'getEntityById');
       expect(selectors.getReturnItem(mockState, returnItemId)).toEqual(
         returnItem,
       );

--- a/packages/redux/src/returns/selectors.ts
+++ b/packages/redux/src/returns/selectors.ts
@@ -5,7 +5,7 @@
  */
 
 import { createSelector } from 'reselect';
-import { getEntity } from '../entities/selectors';
+import { getEntityById } from '../entities/selectors';
 import {
   getReturnItems as getEntityReturnItems,
   getReturns as getEntityReturns,
@@ -19,6 +19,7 @@ import {
   getReturns,
 } from './reducer';
 import get from 'lodash/get';
+import type { ReturnItem } from '@farfetch/blackout-client/returns/types';
 import type { StoreState } from '../types';
 
 /**
@@ -68,8 +69,10 @@ export const getReturnError = (state: StoreState) => getError(state.returns);
  *
  * @returns {object} Return item.
  */
-export const getReturnItem = (state: StoreState, returnItemId: string) =>
-  getEntity(state, 'returnItems', returnItemId);
+export const getReturnItem = (
+  state: StoreState,
+  returnItemId: string,
+): ReturnItem | undefined => getEntityById(state, 'returnItems', returnItemId);
 
 /**
  * Returns all the return items ids.

--- a/packages/redux/src/wishlists/selectors/wishlists.ts
+++ b/packages/redux/src/wishlists/selectors/wishlists.ts
@@ -77,6 +77,7 @@ export const getWishlist = (state: StoreState): State['result'] =>
  *     wishlistItem: getWishlistItem(state, id)
  * });
  */
+// @TODO Remove cast from functions
 export const getWishlistItem = createSelector(
   [
     (state: StoreState, wishlistItemId: WishlistItem['id']) =>

--- a/packages/redux/src/wishlists/selectors/wishlistsSets.ts
+++ b/packages/redux/src/wishlists/selectors/wishlistsSets.ts
@@ -172,8 +172,11 @@ export const isWishlistSetFetched = (
 export const getWishlistSet = createSelector(
   [
     (state: StoreState) => getEntities(state, 'wishlistItems'),
-    (state: StoreState, setId: WishlistSet['setId']) =>
-      getEntityById(state, 'wishlistSets', setId) as WishlistSetEntity,
+    (
+      state: StoreState,
+      setId: WishlistSet['setId'],
+    ): WishlistSetEntity | undefined =>
+      getEntityById(state, 'wishlistSets', setId),
     (state: StoreState) => getEntities(state, 'products'),
   ],
   (wishlistItems, wishlistSet, products) => {
@@ -248,11 +251,11 @@ export const getWishlistSetItemsCounter = (
   state: StoreState,
   setId: WishlistSet['setId'],
 ): number => {
-  const wishlistSet = getEntityById(
+  const wishlistSet: WishlistSetEntity | undefined = getEntityById(
     state,
     'wishlistSets',
     setId,
-  ) as WishlistSetEntity;
+  );
 
   if (!wishlistSet || wishlistSet.wishlistSetItems.length === 0) {
     return 0;


### PR DESCRIPTION
## Description

- Fix getEntityById selector
- Fix getEntityById implementation erros

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
