### PR TITLE
fix(redux): remove unsupported params from FetchUserFactory

### DIFF
--- a/packages/client/src/users/types/getUser.types.ts
+++ b/packages/client/src/users/types/getUser.types.ts
@@ -1,12 +1,5 @@
 import type { Config } from '../../types';
 
-export type GetUserData = {
-  id?: number;
-  bagId?: string;
-  wishlistId?: string;
-  userExtraInfo?: string;
-};
-
 export type GetUserResponse = {
   bagId: string;
   dateOfBirth: string;
@@ -27,7 +20,4 @@ export type GetUserResponse = {
   };
 };
 
-export type GetUser = (
-  data: GetUserData,
-  config?: Config,
-) => Promise<GetUserResponse>;
+export type GetUser = (config?: Config) => Promise<GetUserResponse>;

--- a/packages/redux/src/users/actions/__tests__/fetchUser.test.ts
+++ b/packages/redux/src/users/actions/__tests__/fetchUser.test.ts
@@ -20,8 +20,6 @@ const expectedConfig = undefined;
 let store = usersMockStore();
 
 describe('fetchUser action creator', () => {
-  const params = { userExtraInfo: 'Membership' };
-
   beforeEach(() => {
     jest.clearAllMocks();
     store = usersMockStore();
@@ -34,11 +32,11 @@ describe('fetchUser action creator', () => {
     expect.assertions(4);
 
     try {
-      await store.dispatch(fetchUser(params));
+      await store.dispatch(fetchUser());
     } catch (error) {
       expect(error).toBe(expectedError);
       expect(getUser).toHaveBeenCalledTimes(1);
-      expect(getUser).toHaveBeenCalledWith(params, expectedConfig);
+      expect(getUser).toHaveBeenCalledWith(expectedConfig);
       expect(store.getActions()).toEqual(
         expect.arrayContaining([
           { type: actionTypes.FETCH_USER_REQUEST },
@@ -54,12 +52,12 @@ describe('fetchUser action creator', () => {
   it('should create the correct actions for when the get user procedure is successful', async () => {
     (getUser as jest.Mock).mockResolvedValueOnce(mockUsersResponse);
 
-    await store.dispatch(fetchUser(params));
+    await store.dispatch(fetchUser());
 
     const actionResults = store.getActions();
 
     expect(getUser).toHaveBeenCalledTimes(1);
-    expect(getUser).toHaveBeenCalledWith(params, expectedConfig);
+    expect(getUser).toHaveBeenCalledWith(expectedConfig);
     expect(actionResults).toMatchObject([
       { type: actionTypes.FETCH_USER_REQUEST },
       {

--- a/packages/redux/src/users/actions/factories/fetchUserFactory.ts
+++ b/packages/redux/src/users/actions/factories/fetchUserFactory.ts
@@ -6,14 +6,12 @@ import {
 import { toError } from '@farfetch/blackout-client/helpers/client';
 import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
-import type {
-  GetUser,
-  GetUserData,
-} from '@farfetch/blackout-client/users/types';
+import type { GetUser } from '@farfetch/blackout-client/users/types';
 
 /**
- * @param params - Possibilities are: `bag`, `membership`, `wishlist`.
- * @param config - Custom configurations to send to the client instance (axios).
+ * @callback FetchUserThunkFactory
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
  *
  * @returns Thunk to be dispatched to the redux store.
  */
@@ -26,15 +24,13 @@ import type {
  * @returns Thunk factory.
  */
 const fetchUserFactory =
-  (getUser: GetUser) =>
-  (data: GetUserData, config?: Config) =>
-  async (dispatch: Dispatch) => {
-    try {
-      dispatch({
-        type: FETCH_USER_REQUEST,
-      });
+  (getUser: GetUser) => (config?: Config) => async (dispatch: Dispatch) => {
+    dispatch({
+      type: FETCH_USER_REQUEST,
+    });
 
-      const result = await getUser(data, config);
+    try {
+      const result = await getUser(config);
       const userEntity = {
         entities: { user: result },
         result: result.id,


### PR DESCRIPTION
## Description
Currently the FetchUserFactory action receives a data that isn’t used by the client, since the client only support a config object now. According to this, I'm removing the params from the redux action.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
