### PR TITLE
chore(redux): export inline types

### DIFF
--- a/packages/client/src/authentication/types/deleteTokens.types.ts
+++ b/packages/client/src/authentication/types/deleteTokens.types.ts
@@ -1,3 +1,6 @@
 import type { Config } from '../../types';
 
-export type DeleteTokens = (id: string, config: Config) => Promise<number>;
+export type DeleteTokens = (
+  id: string | number,
+  config?: Config,
+) => Promise<number>;

--- a/packages/client/src/authentication/types/login.types.ts
+++ b/packages/client/src/authentication/types/login.types.ts
@@ -15,7 +15,7 @@ export type LoginResponse = {
   whishlistId: string;
   isExternalLogin: boolean;
   isGuest: boolean;
-  status: string;
+  status: string | number;
   lastName: string;
   firstName: string;
   countryCode: string;

--- a/packages/client/src/authentication/types/postPasswordChange.types.ts
+++ b/packages/client/src/authentication/types/postPasswordChange.types.ts
@@ -1,7 +1,7 @@
 import type { AxiosResponse } from 'axios';
 import type { Config } from '../../types';
 
-interface Data {
+export interface PostPasswordChangeData {
   oldPassword: string;
   newPassword: string;
   userId: number;
@@ -9,6 +9,6 @@ interface Data {
 }
 
 export type PostPasswordChange = (
-  data: Data,
+  data: PostPasswordChangeData,
   config?: Config,
 ) => Promise<AxiosResponse>;

--- a/packages/client/src/authentication/types/postPasswordRecover.types.ts
+++ b/packages/client/src/authentication/types/postPasswordRecover.types.ts
@@ -1,11 +1,11 @@
 import type { AxiosResponse } from 'axios';
 import type { Config } from '../../types';
 
-interface Data {
+export interface PostPasswordRecoverData {
   username: string;
 }
 
 export type PostPasswordRecover = (
-  data: Data,
+  data: PostPasswordRecoverData,
   config?: Config,
 ) => Promise<AxiosResponse>;

--- a/packages/client/src/authentication/types/postPasswordReset.types.ts
+++ b/packages/client/src/authentication/types/postPasswordReset.types.ts
@@ -1,13 +1,13 @@
 import type { AxiosResponse } from 'axios';
 import type { Config } from '../../types';
 
-interface Data {
+export interface PostPasswordResetData {
   username: string;
   token: string;
   password: string;
 }
 
 export type PostPasswordReset = (
-  data: Data,
+  data: PostPasswordResetData,
   config?: Config,
 ) => Promise<AxiosResponse>;

--- a/packages/client/src/authentication/types/postRefreshEmailToken.types.ts
+++ b/packages/client/src/authentication/types/postRefreshEmailToken.types.ts
@@ -1,11 +1,11 @@
 import type { AxiosResponse } from 'axios';
 import type { Config } from '../../types';
 
-interface Data {
+export interface PostRefreshEmailTokenData {
   username: string;
 }
 
 export type PostRefreshEmailToken = (
-  data: Data,
+  data: PostRefreshEmailTokenData,
   config?: Config,
 ) => Promise<AxiosResponse>;

--- a/packages/client/src/authentication/types/postRegister.types.ts
+++ b/packages/client/src/authentication/types/postRegister.types.ts
@@ -1,7 +1,7 @@
 import type { Config } from '../../types';
 import type { RegisterResponse } from './register.types';
 
-interface Data {
+export interface PostRegisterData {
   countryCode: string;
   email: string;
   password: string;
@@ -15,6 +15,6 @@ interface Data {
 }
 
 export type PostRegister = (
-  data: Data,
+  data: PostRegisterData,
   config?: Config,
 ) => Promise<RegisterResponse>;

--- a/packages/client/src/authentication/types/postTokens.types.ts
+++ b/packages/client/src/authentication/types/postTokens.types.ts
@@ -1,14 +1,14 @@
 import type { Config } from '../../types';
 import type { PostTokenResponse } from './tokens.types';
 
-interface Data {
-  username: string;
-  password: string;
-  grantType: string;
-  refreshToken: string;
+export interface PostTokensData {
+  username?: string;
+  password?: string;
+  grantType?: string;
+  refreshToken?: string;
 }
 
 export type PostTokens = (
-  data: Data,
-  config: Config,
+  data: PostTokensData,
+  config?: Config,
 ) => Promise<PostTokenResponse>;

--- a/packages/client/src/authentication/types/postUserImpersonation.types.ts
+++ b/packages/client/src/authentication/types/postUserImpersonation.types.ts
@@ -1,13 +1,13 @@
 import type { Config } from '../../types';
 import type { PostTokenResponse } from './tokens.types';
 
-interface Data {
+export interface PostUserImpersonationData {
   impersonatorUserName: string;
   impersonatorPassword: string;
   impersonateeUserName: string;
 }
 
 export type PostUserImpersonation = (
-  data: Data,
+  data: PostUserImpersonationData,
   config?: Config,
 ) => Promise<PostTokenResponse>;

--- a/packages/client/src/authentication/types/postValidateEmail.types.ts
+++ b/packages/client/src/authentication/types/postValidateEmail.types.ts
@@ -1,12 +1,12 @@
 import type { AxiosResponse } from 'axios';
 import type { Config } from '../../types';
 
-interface Data {
+export interface PostValidateEmailData {
   username: string;
   token: string;
 }
 
 export type PostValidateEmail = (
-  data: Data,
+  data: PostValidateEmailData,
   config?: Config,
 ) => Promise<AxiosResponse>;

--- a/packages/client/src/authentication/types/register.types.ts
+++ b/packages/client/src/authentication/types/register.types.ts
@@ -15,7 +15,7 @@ export type RegisterResponse = {
   whishlistId: string;
   isExternalLogin: boolean;
   isGuest: boolean;
-  status: string;
+  status: string | number;
   lastName: string;
   firstName: string;
   countryCode: string;

--- a/packages/redux/src/authentication/actions/factories/changePasswordFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/changePasswordFactory.ts
@@ -4,7 +4,12 @@ import {
   PASSWORD_CHANGE_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type {
+  PostPasswordChange,
+  PostPasswordChangeData,
+} from '@farfetch/blackout-client/authentication/types';
 
 /**
  * @param data   - Password details.
@@ -20,16 +25,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (postPasswordChange: any) =>
-  (
-    data: {
-      oldPassword: string;
-      newPassword: string;
-      userId: string;
-      username: string;
-    },
-    config?: { [k: string]: any },
-  ) =>
+export default (postPasswordChange: PostPasswordChange) =>
+  (data: PostPasswordChangeData, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/createClientCredentialsTokenFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/createClientCredentialsTokenFactory.ts
@@ -4,7 +4,9 @@ import {
   CREATE_CLIENT_CREDENTIALS_TOKEN_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type { PostTokens } from '@farfetch/blackout-client/authentication/types';
 
 /**
  * @param config - Custom configurations to send to the client instance (axios).
@@ -20,8 +22,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (postTokens: any) =>
-  (config?: { [k: string]: any }) =>
+export default (postTokens: PostTokens) =>
+  (config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/createUserImpersonationFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/createUserImpersonationFactory.ts
@@ -4,7 +4,12 @@ import {
   CREATE_USER_IMPERSONATION_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type {
+  PostUserImpersonation,
+  PostUserImpersonationData,
+} from '@farfetch/blackout-client/authentication/types';
 
 /**
  * @param data   - The impersonate data.
@@ -20,17 +25,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (postUserImpersonation: any) =>
-  (
-    data: {
-      username: string;
-      password: string;
-      impersonateeUserName: string;
-    },
-    config?: {
-      [k: string]: any;
-    },
-  ) =>
+export default (postUserImpersonation: PostUserImpersonation) =>
+  (data: PostUserImpersonationData, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/createUserTokenFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/createUserTokenFactory.ts
@@ -4,7 +4,12 @@ import {
   CREATE_USER_TOKEN_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type {
+  PostTokens,
+  PostTokensData,
+} from '@farfetch/blackout-client/authentication/types';
 
 /**
  * @param data   - Request data.
@@ -20,18 +25,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (postTokens: any) =>
-  (
-    data: {
-      username: string;
-      password: string;
-      grantType: string;
-      refreshToken: string;
-    },
-    config?: {
-      [k: string]: any;
-    },
-  ) =>
+export default (postTokens: PostTokens) =>
+  (data: PostTokensData, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/loginFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/loginFactory.ts
@@ -1,7 +1,12 @@
 import { LOGIN_FAILURE, LOGIN_REQUEST, LOGIN_SUCCESS } from '../../actionTypes';
 import { loginMethodParameterTypes } from '@farfetch/blackout-analytics';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type {
+  LoginData,
+  PostLogin,
+} from '@farfetch/blackout-client/authentication/types';
 
 const UNVERIFIED_USER = 4;
 
@@ -19,17 +24,8 @@ const UNVERIFIED_USER = 4;
  *
  * @returns Thunk factory.
  */
-export default (postLogin: any) =>
-  (
-    data: {
-      username: string;
-      password: string;
-      rememberMe: boolean;
-    },
-    config?: {
-      [k: string]: any;
-    },
-  ) =>
+export default (postLogin: PostLogin) =>
+  (data: LoginData, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/logoutFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/logoutFactory.ts
@@ -4,7 +4,9 @@ import {
   LOGOUT_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type { PostLogout } from '@farfetch/blackout-client/authentication/types';
 
 /**
  * @param config - Custom configurations to send to the client instance (axios).
@@ -19,8 +21,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (postLogout: any) =>
-  (config?: { [k: string]: any }) =>
+export default (postLogout: PostLogout) =>
+  (config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/recoverPasswordFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/recoverPasswordFactory.ts
@@ -4,7 +4,12 @@ import {
   PASSWORD_RECOVER_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type {
+  PostPasswordRecover,
+  PostPasswordRecoverData,
+} from '@farfetch/blackout-client/authentication/types';
 
 /**
  * @param data   - User details.
@@ -20,16 +25,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (postPasswordRecover: any) =>
-  (
-    data: {
-      username: string;
-      uri: string;
-    },
-    config?: {
-      [k: string]: any;
-    },
-  ) =>
+export default (postPasswordRecover: PostPasswordRecover) =>
+  (data: PostPasswordRecoverData, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/refreshEmailTokenFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/refreshEmailTokenFactory.ts
@@ -4,7 +4,12 @@ import {
   REFRESH_EMAIL_TOKEN_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type {
+  PostRefreshEmailToken,
+  PostRefreshEmailTokenData,
+} from '@farfetch/blackout-client/authentication/types';
 
 /**
  * @param data   - Details to refresh the user's validation token.
@@ -22,15 +27,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (postRefreshEmailToken: any) =>
-  (
-    data: {
-      username: string;
-    },
-    config?: {
-      [k: string]: any;
-    },
-  ) =>
+export default (postRefreshEmailToken: PostRefreshEmailToken) =>
+  (data: PostRefreshEmailTokenData, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/refreshTokenFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/refreshTokenFactory.ts
@@ -4,7 +4,9 @@ import {
   REFRESH_USER_TOKEN_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type { PostTokens } from '@farfetch/blackout-client/authentication/types';
 
 /**
  * @param refreshToken - Refresh Token.
@@ -21,13 +23,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (postTokens: any) =>
-  (
-    refreshToken: string,
-    config?: {
-      [k: string]: any;
-    },
-  ) =>
+export default (postTokens: PostTokens) =>
+  (refreshToken: string, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/registerFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/registerFactory.ts
@@ -5,7 +5,12 @@ import {
   REGISTER_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type {
+  PostRegister,
+  PostRegisterData,
+} from '@farfetch/blackout-client/authentication/types';
 
 const UNVERIFIED_USER = 4;
 
@@ -23,24 +28,8 @@ const UNVERIFIED_USER = 4;
  *
  * @returns Thunk factory.
  */
-export default (postRegister: any) =>
-  (
-    data: {
-      countryCode: string;
-      email: string;
-      password: string;
-      username: string;
-      name: string;
-      phoneNumber?: string;
-      titleId?: string;
-      firstName?: string;
-      lastName?: string;
-      receiveNewsletters?: boolean;
-    },
-    config?: {
-      [k: string]: any;
-    },
-  ) =>
+export default (postRegister: PostRegister) =>
+  (data: PostRegisterData, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/removeUserImpersonationFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/removeUserImpersonationFactory.ts
@@ -4,6 +4,8 @@ import {
   DELETE_USER_IMPERSONATION_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
+import type { DeleteUserImpersonation } from '@farfetch/blackout-client/authentication/types';
 import type { Dispatch } from 'redux';
 
 /**
@@ -20,13 +22,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (deleteUserImpersonation: any) =>
-  (
-    impersonatedAccessTokenId: string,
-    config?: {
-      [k: string]: any;
-    },
-  ) =>
+export default (deleteUserImpersonation: DeleteUserImpersonation) =>
+  (impersonatedAccessTokenId: number, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/removeUserTokenFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/removeUserTokenFactory.ts
@@ -4,6 +4,8 @@ import {
   DELETE_USER_TOKEN_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
+import type { DeleteTokens } from '@farfetch/blackout-client/authentication/types';
 import type { Dispatch } from 'redux';
 
 /**
@@ -20,13 +22,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (deleteTokens: any) =>
-  (
-    userTokenId: number,
-    config?: {
-      [k: string]: any;
-    },
-  ) =>
+export default (deleteTokens: DeleteTokens) =>
+  (userTokenId: number, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/resetPasswordFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/resetPasswordFactory.ts
@@ -4,7 +4,12 @@ import {
   PASSWORD_RESET_SUCCESS,
 } from '../../actionTypes';
 import { toError } from '@farfetch/blackout-client/helpers/client';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type {
+  PostPasswordReset,
+  PostPasswordResetData,
+} from '@farfetch/blackout-client/authentication/types';
 
 /**
  * @param data   - User details.
@@ -20,17 +25,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (postPasswordReset: any) =>
-  (
-    data: {
-      username: string;
-      token: string;
-      password: string;
-    },
-    config?: {
-      [k: string]: any;
-    },
-  ) =>
+export default (postPasswordReset: PostPasswordReset) =>
+  (data: PostPasswordResetData, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({

--- a/packages/redux/src/authentication/actions/factories/validateEmailFactory.ts
+++ b/packages/redux/src/authentication/actions/factories/validateEmailFactory.ts
@@ -4,7 +4,12 @@ import {
   VALIDATE_EMAIL_REQUEST,
   VALIDATE_EMAIL_SUCCESS,
 } from '../../actionTypes';
+import type { Config } from '@farfetch/blackout-client/types';
 import type { Dispatch } from 'redux';
+import type {
+  PostValidateEmail,
+  PostValidateEmailData,
+} from '@farfetch/blackout-client/authentication/types';
 
 /**
  * @param data   - Details to validate user's e-mail.
@@ -20,16 +25,8 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default (postValidateEmail: any) =>
-  (
-    data: {
-      username: string;
-      token: string;
-    },
-    config?: {
-      [k: string]: any;
-    },
-  ) =>
+export default (postValidateEmail: PostValidateEmail) =>
+  (data: PostValidateEmailData, config?: Config) =>
   async (dispatch: Dispatch): Promise<any> => {
     try {
       dispatch({


### PR DESCRIPTION
## Description
This PR is exporting inline declared types on blackout redux. i.e. loginFactory in inline typed but the type objects are not exported.

This is useful for tenants to import them and to apply in their sides.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
