### PR TITLE
feat(client|redux): export clients and actions on root

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./*": "./dist/*"
   },
+  "main": "src/index.ts",
   "files": [
     "dist",
     "src"

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,0 +1,3 @@
+export * from './contents';
+export * from './locale';
+export * from './language';

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./*": "./dist/*"
   },
+  "main": "src/index.ts",
   "files": [
     "dist",
     "src"

--- a/packages/redux/src/contents/__tests__/reducer.test.ts
+++ b/packages/redux/src/contents/__tests__/reducer.test.ts
@@ -1,19 +1,22 @@
 import * as fromReducer from '../reducer';
 import {
+  actionTypesContent as actionTypes,
+  reducerContent as reducer,
+} from '..';
+import {
   contentTypesResult,
   mockContentResult,
   seoData,
 } from 'tests/__fixtures__/contents';
-import reducer, { actionTypes } from '..';
 import type { State } from '../types';
 
-const { INITIAL_STATE } = fromReducer;
+const { INITIAL_STATE_CONTENT } = fromReducer;
 const mockAction = { type: 'foo' };
 let initialState: State;
 
 describe('contents redux reducer', () => {
   beforeEach(() => {
-    initialState = reducer(INITIAL_STATE, mockAction);
+    initialState = reducer(INITIAL_STATE_CONTENT, mockAction);
   });
 
   describe('reset handling', () => {
@@ -28,7 +31,7 @@ describe('contents redux reducer', () => {
 
   describe('searchResults() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer(INITIAL_STATE, mockAction).searchResults;
+      const state = reducer(INITIAL_STATE_CONTENT, mockAction).searchResults;
 
       expect(state).toEqual(initialState.searchResults);
       expect(state).toEqual({});
@@ -88,7 +91,7 @@ describe('contents redux reducer', () => {
 
   describe('contentTypes() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer(INITIAL_STATE, mockAction).contentTypes;
+      const state = reducer(INITIAL_STATE_CONTENT, mockAction).contentTypes;
 
       expect(state).toEqual(initialState.contentTypes);
       expect(state).toEqual({
@@ -127,7 +130,7 @@ describe('contents redux reducer', () => {
 
   describe('metadata() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer(INITIAL_STATE, mockAction).metadata;
+      const state = reducer(INITIAL_STATE_CONTENT, mockAction).metadata;
 
       expect(state).toEqual(initialState.metadata);
       expect(state).toEqual({

--- a/packages/redux/src/contents/__tests__/serverInitialState.test.ts
+++ b/packages/redux/src/contents/__tests__/serverInitialState.test.ts
@@ -2,7 +2,7 @@ import {
   expectedNormalizedPayload,
   mockModel,
 } from 'tests/__fixtures__/contents';
-import { serverInitialState } from '..';
+import { serverInitialStateContent as serverInitialState } from '..';
 
 describe('contents serverInitialState()', () => {
   it('should initialize server state for the contents', () => {

--- a/packages/redux/src/contents/actions/__tests__/fetchCommercePages.test.ts
+++ b/packages/redux/src/contents/actions/__tests__/fetchCommercePages.test.ts
@@ -1,5 +1,5 @@
 import * as normalizr from 'normalizr';
-import { actionTypes } from '../..';
+import { actionTypesContent as actionTypes } from '../..';
 import {
   commercePagesQuery,
   expectedCommercePagesNormalizedPayload,
@@ -7,7 +7,7 @@ import {
 } from 'tests/__fixtures__/contents';
 import { fetchCommercePages } from '..';
 import { getCommercePages } from '@farfetch/blackout-client/contents';
-import { INITIAL_STATE } from '../../reducer';
+import { INITIAL_STATE_CONTENT } from '../../reducer';
 import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
 
@@ -25,7 +25,7 @@ jest.mock('@farfetch/blackout-client/contents', () => ({
 const normalizeSpy = jest.spyOn(normalizr, 'normalize');
 
 const commercePagesMockStore = (state = {}) =>
-  mockStore({ contents: INITIAL_STATE }, state);
+  mockStore({ contents: INITIAL_STATE_CONTENT }, state);
 
 const expectedConfig = undefined;
 let store;

--- a/packages/redux/src/contents/actions/__tests__/fetchContent.test.ts
+++ b/packages/redux/src/contents/actions/__tests__/fetchContent.test.ts
@@ -1,5 +1,5 @@
 import * as normalizr from 'normalizr';
-import { actionTypes } from '../..';
+import { actionTypesContent as actionTypes } from '../..';
 import {
   contentNormalizedPayload,
   contentQuery,
@@ -7,7 +7,7 @@ import {
 } from 'tests/__fixtures__/contents';
 import { fetchContent } from '..';
 import { getSearchContents } from '@farfetch/blackout-client/contents';
-import { INITIAL_STATE } from '../../reducer';
+import { INITIAL_STATE_CONTENT } from '../../reducer';
 import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
 
@@ -18,7 +18,7 @@ jest.mock('@farfetch/blackout-client/contents', () => ({
 const normalizeSpy = jest.spyOn(normalizr, 'normalize');
 
 const contentsMockStore = (state = {}) =>
-  mockStore({ contents: INITIAL_STATE }, state);
+  mockStore({ contents: INITIAL_STATE_CONTENT }, state);
 
 const expectedConfig = undefined;
 let store;

--- a/packages/redux/src/contents/actions/__tests__/fetchContentTypes.test.ts
+++ b/packages/redux/src/contents/actions/__tests__/fetchContentTypes.test.ts
@@ -1,8 +1,8 @@
-import { actionTypes } from '../..';
+import { actionTypesContent as actionTypes } from '../..';
 import { contentTypesResult, types } from 'tests/__fixtures__/contents';
 import { fetchContentTypes } from '..';
 import { getContentTypes } from '@farfetch/blackout-client/contents';
-import { INITIAL_STATE } from '../../reducer';
+import { INITIAL_STATE_CONTENT } from '../../reducer';
 import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
 
@@ -12,7 +12,7 @@ jest.mock('@farfetch/blackout-client/contents', () => ({
 }));
 
 const contentTypesMockStore = (state = {}) =>
-  mockStore({ contents: INITIAL_STATE }, state);
+  mockStore({ contents: INITIAL_STATE_CONTENT }, state);
 const expectedConfig = undefined;
 const spaceCode = 'website';
 let store;

--- a/packages/redux/src/contents/actions/__tests__/fetchSEO.test.ts
+++ b/packages/redux/src/contents/actions/__tests__/fetchSEO.test.ts
@@ -1,7 +1,7 @@
-import { actionTypes } from '../..';
+import { actionTypesContent as actionTypes } from '../..';
 import { fetchSEO } from '..';
 import { getSEO } from '@farfetch/blackout-client/contents';
-import { INITIAL_STATE } from '../../reducer';
+import { INITIAL_STATE_CONTENT } from '../../reducer';
 import { mockStore } from '../../../../tests';
 import { seoQuery, seoResponse } from 'tests/__fixtures__/contents';
 import find from 'lodash/find';
@@ -11,7 +11,7 @@ jest.mock('@farfetch/blackout-client/contents', () => ({
   getSEO: jest.fn(),
 }));
 const contentsSEOMockStore = (state = {}) =>
-  mockStore({ contents: INITIAL_STATE }, state);
+  mockStore({ contents: INITIAL_STATE_CONTENT }, state);
 
 const expectedConfig = undefined;
 let store;

--- a/packages/redux/src/contents/actions/__tests__/resetContents.test.ts
+++ b/packages/redux/src/contents/actions/__tests__/resetContents.test.ts
@@ -1,4 +1,4 @@
-import { actionTypes } from '../..';
+import { actionTypesContent as actionTypes } from '../..';
 import { mockStore } from '../../../../tests';
 import { resetContents } from '..';
 

--- a/packages/redux/src/contents/index.ts
+++ b/packages/redux/src/contents/index.ts
@@ -1,10 +1,8 @@
-import * as actionTypes from './actionTypes';
-import reducer from './reducer';
-import serverInitialState from './serverInitialState';
+import * as actionTypesContent from './actionTypes';
+import reducerContent from './reducer';
+import serverInitialStateContent from './serverInitialState';
 
 export * from './actions';
 export * from './selectors';
 
-export { actionTypes, serverInitialState };
-
-export default reducer;
+export { actionTypesContent, serverInitialStateContent, reducerContent };

--- a/packages/redux/src/contents/reducer.ts
+++ b/packages/redux/src/contents/reducer.ts
@@ -9,7 +9,7 @@ import type {
 } from './types';
 import type { ReducerSwitch } from '../types';
 
-export const INITIAL_STATE: State = {
+export const INITIAL_STATE_CONTENT: State = {
   searchResults: {},
   contentTypes: {
     error: undefined,
@@ -24,7 +24,7 @@ export const INITIAL_STATE: State = {
 };
 
 const searchResults = (
-  state = INITIAL_STATE.searchResults,
+  state = INITIAL_STATE_CONTENT.searchResults,
   action: ActionFetchContent | ActionFetchCommercePages,
 ): State['searchResults'] => {
   switch (action.type) {
@@ -61,14 +61,14 @@ const searchResults = (
 };
 
 const contentTypes = (
-  state = INITIAL_STATE.contentTypes,
+  state = INITIAL_STATE_CONTENT.contentTypes,
   action: ActionFetchContentTypes,
 ): State['contentTypes'] => {
   switch (action.type) {
     case actionTypes.FETCH_CONTENT_TYPES_REQUEST:
       return {
         isLoading: true,
-        error: INITIAL_STATE.contentTypes.error,
+        error: INITIAL_STATE_CONTENT.contentTypes.error,
       };
     case actionTypes.FETCH_CONTENT_TYPES_SUCCESS:
       return {
@@ -86,7 +86,7 @@ const contentTypes = (
 };
 
 const metadata = (
-  state = INITIAL_STATE.metadata,
+  state = INITIAL_STATE_CONTENT.metadata,
   action: ActionFetchSEO,
 ): State['metadata'] => {
   switch (action.type) {
@@ -160,7 +160,7 @@ const contentsReducer: ReducerSwitch<
   ActionFetchContent | ActionFetchContentTypes | ActionFetchSEO
 > = (state, action): State => {
   if (action.type === actionTypes.RESET_CONTENTS) {
-    return reducers(INITIAL_STATE, action);
+    return reducers(INITIAL_STATE_CONTENT, action);
   }
 
   return reducers(state, action);

--- a/packages/redux/src/contents/serverInitialState.ts
+++ b/packages/redux/src/contents/serverInitialState.ts
@@ -1,6 +1,6 @@
 import { contentEntries } from '../entities/schemas/content';
 import { generateContentHash } from './utils';
-import { INITIAL_STATE } from './reducer';
+import { INITIAL_STATE_CONTENT } from './reducer';
 import { normalize } from 'normalizr';
 import get from 'lodash/get';
 import merge from 'lodash/merge';
@@ -20,7 +20,7 @@ const serverInitialState = ({
   model: Model;
 }): ServerInitialState => {
   if (!get(model, 'searchContentRequests')) {
-    return { contents: INITIAL_STATE };
+    return { contents: INITIAL_STATE_CONTENT };
   }
 
   const { searchContentRequests } = model;

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -1,0 +1,2 @@
+export * from './contents';
+export * from './locale';

--- a/packages/redux/src/locale/__tests__/reducer.test.ts
+++ b/packages/redux/src/locale/__tests__/reducer.test.ts
@@ -1,15 +1,15 @@
 import * as fromReducer from '../reducer';
+import { actionTypesLocale as actionTypes, reducerLocale as reducer } from '..';
 import { mockCountryCode } from 'tests/__fixtures__/locale';
-import reducer, { actionTypes } from '..';
 import type { State } from '../types';
 
-const { INITIAL_STATE } = fromReducer;
+const { INITIAL_STATE_LOCALE } = fromReducer;
 const mockAction = { type: 'foo' };
 let initialState: State;
 
 describe('locale redux reducer', () => {
   beforeEach(() => {
-    initialState = reducer(INITIAL_STATE, mockAction);
+    initialState = reducer(INITIAL_STATE_LOCALE, mockAction);
   });
 
   describe('reset handling', () => {
@@ -25,7 +25,7 @@ describe('locale redux reducer', () => {
 
   describe('countryCode() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer(INITIAL_STATE, mockAction).countryCode;
+      const state = reducer(INITIAL_STATE_LOCALE, mockAction).countryCode;
 
       expect(state).toBe(initialState.countryCode);
       expect(state).toBeNull();
@@ -49,7 +49,7 @@ describe('locale redux reducer', () => {
 
   describe('cities() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer(INITIAL_STATE, mockAction).cities;
+      const state = reducer(INITIAL_STATE_LOCALE, mockAction).cities;
 
       expect(state).toEqual(initialState.cities);
     });
@@ -97,7 +97,7 @@ describe('locale redux reducer', () => {
 
   describe('countries() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer(INITIAL_STATE, mockAction).countries;
+      const state = reducer(INITIAL_STATE_LOCALE, mockAction).countries;
 
       expect(state).toEqual(initialState.countries);
     });
@@ -179,7 +179,7 @@ describe('locale redux reducer', () => {
 
   describe('currencies() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer(INITIAL_STATE, mockAction).currencies;
+      const state = reducer(INITIAL_STATE_LOCALE, mockAction).currencies;
 
       expect(state).toEqual(initialState.currencies);
     });
@@ -230,7 +230,7 @@ describe('locale redux reducer', () => {
 
   describe('states() reducer', () => {
     it('should return the initial state', () => {
-      const state = reducer(INITIAL_STATE, mockAction).states;
+      const state = reducer(INITIAL_STATE_LOCALE, mockAction).states;
 
       expect(state).toEqual(initialState.states);
     });

--- a/packages/redux/src/locale/__tests__/serverInitialState.test.ts
+++ b/packages/redux/src/locale/__tests__/serverInitialState.test.ts
@@ -1,5 +1,5 @@
 import { mockModel } from 'tests/__fixtures__/locale';
-import { serverInitialState } from '..';
+import { serverInitialStateLocale as serverInitialState } from '..';
 
 describe('local serverInitialState()', () => {
   it('should initialize server state for the locale', () => {

--- a/packages/redux/src/locale/actions/__tests__/fetchCountries.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/fetchCountries.test.ts
@@ -1,14 +1,17 @@
 import * as normalizr from 'normalizr';
+import {
+  actionTypesLocale as actionTypes,
+  reducerLocale as INITIAL_STATE_LOCALE,
+} from '../..';
 import { fetchCountries } from '..';
 import { getCountries } from '@farfetch/blackout-client/locale';
 import { mockCountries, mockQuery } from 'tests/__fixtures__/locale';
 import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
-import INITIAL_STATE, { actionTypes } from '../..';
 import type { Countries } from '@farfetch/blackout-client/locale/types';
 
 const localeMockStore = (state = {}) =>
-  mockStore({ locale: INITIAL_STATE }, state);
+  mockStore({ locale: INITIAL_STATE_LOCALE }, state);
 
 jest.mock('@farfetch/blackout-client/locale', () => ({
   ...jest.requireActual('@farfetch/blackout-client/locale'),

--- a/packages/redux/src/locale/actions/__tests__/fetchCountry.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/fetchCountry.test.ts
@@ -1,10 +1,13 @@
 import * as normalizr from 'normalizr';
+import {
+  actionTypesLocale as actionTypes,
+  reducerLocale as INITIAL_STATE,
+} from '../..';
 import { fetchCountry } from '..';
 import { getCountry } from '@farfetch/blackout-client/locale';
 import { mockCountry, mockCountryCode } from 'tests/__fixtures__/locale';
 import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
-import INITIAL_STATE, { actionTypes } from '../..';
 import type { Country } from '@farfetch/blackout-client/locale/types';
 
 const localeMockStore = (state = {}) =>

--- a/packages/redux/src/locale/actions/__tests__/fetchCountryCities.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/fetchCountryCities.test.ts
@@ -1,4 +1,8 @@
 import * as normalizr from 'normalizr';
+import {
+  actionTypesLocale as actionTypes,
+  reducerLocale as INITIAL_STATE,
+} from '../..';
 import { fetchCountryCities } from '..';
 import { getCountryCities } from '@farfetch/blackout-client/locale';
 import {
@@ -8,7 +12,6 @@ import {
 } from 'tests/__fixtures__/locale';
 import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
-import INITIAL_STATE, { actionTypes } from '../..';
 import type { Cities } from '@farfetch/blackout-client/locale/types';
 
 const localeMockStore = (state = {}) =>

--- a/packages/redux/src/locale/actions/__tests__/fetchCountryCurrencies.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/fetchCountryCurrencies.test.ts
@@ -1,10 +1,13 @@
 import * as normalizr from 'normalizr';
+import {
+  actionTypesLocale as actionTypes,
+  reducerLocale as INITIAL_STATE,
+} from '../..';
 import { fetchCountryCurrencies } from '..';
 import { getCountryCurrencies } from '@farfetch/blackout-client/locale';
 import { mockCountryCode, mockCurrencies } from 'tests/__fixtures__/locale';
 import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
-import INITIAL_STATE, { actionTypes } from '../..';
 import type { Currencies } from '@farfetch/blackout-client/locale/types';
 
 const localeMockStore = (state = {}) =>

--- a/packages/redux/src/locale/actions/__tests__/fetchCountryStates.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/fetchCountryStates.test.ts
@@ -1,10 +1,13 @@
 import * as normalizr from 'normalizr';
+import {
+  actionTypesLocale as actionTypes,
+  reducerLocale as INITIAL_STATE,
+} from '../..';
 import { fetchCountryStates } from '..';
 import { getCountryStates } from '@farfetch/blackout-client/locale';
 import { mockCountryCode, mockStates } from 'tests/__fixtures__/locale';
 import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
-import INITIAL_STATE, { actionTypes } from '../..';
 import type { States } from '@farfetch/blackout-client/locale/types';
 
 const localeMockStore = (state = {}) =>

--- a/packages/redux/src/locale/actions/__tests__/resetLocaleState.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/resetLocaleState.test.ts
@@ -1,4 +1,4 @@
-import { actionTypes } from '../..';
+import { actionTypesLocale as actionTypes } from '../..';
 import { mockStore } from '../../../../tests';
 import { resetLocaleState } from '..';
 

--- a/packages/redux/src/locale/actions/__tests__/setCountryCode.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/setCountryCode.test.ts
@@ -1,4 +1,4 @@
-import { actionTypes } from '../..';
+import { actionTypesLocale as actionTypes } from '../..';
 import { mockCountryCode } from 'tests/__fixtures__/locale';
 import { mockStore } from '../../../../tests';
 import { setCountryCode } from '..';

--- a/packages/redux/src/locale/index.ts
+++ b/packages/redux/src/locale/index.ts
@@ -1,12 +1,15 @@
-import * as actionTypes from './actionTypes';
-import * as middlewares from './middlewares';
-import reducer from './reducer';
-import serverInitialState from './serverInitialState';
+import * as actionTypesLocale from './actionTypes';
+import * as middlewaresLocale from './middlewares';
+import reducerLocale from './reducer';
+import serverInitialStateLocale from './serverInitialState';
 
 export * from './actions';
 export * from './actions/factories';
 export * from './selectors';
 
-export { actionTypes, middlewares, serverInitialState };
-
-export default reducer;
+export {
+  actionTypesLocale,
+  middlewaresLocale,
+  serverInitialStateLocale,
+  reducerLocale,
+};

--- a/packages/redux/src/locale/reducer.ts
+++ b/packages/redux/src/locale/reducer.ts
@@ -11,7 +11,7 @@ import type {
   State,
 } from './types';
 
-export const INITIAL_STATE: State = {
+export const INITIAL_STATE_LOCALE: State = {
   countryCode: null,
   cities: {
     error: null,
@@ -32,35 +32,39 @@ export const INITIAL_STATE: State = {
 };
 
 const countryCode = (
-  state = INITIAL_STATE.countryCode,
+  state = INITIAL_STATE_LOCALE.countryCode,
   action: ActionSetCountryCode,
 ): State['countryCode'] => {
   switch (action.type) {
     case actionTypes.SET_COUNTRY_CODE:
-      return get(action, 'payload.countryCode', INITIAL_STATE.countryCode);
+      return get(
+        action,
+        'payload.countryCode',
+        INITIAL_STATE_LOCALE.countryCode,
+      );
     default:
       return state;
   }
 };
 
 const cities = (
-  state = INITIAL_STATE.cities,
+  state = INITIAL_STATE_LOCALE.cities,
   action: ActionFetchCountryCities,
 ): State['cities'] => {
   switch (action.type) {
     case actionTypes.FETCH_COUNTRY_CITIES_REQUEST:
       return {
         isLoading: true,
-        error: INITIAL_STATE.cities.error,
+        error: INITIAL_STATE_LOCALE.cities.error,
       };
     case actionTypes.FETCH_COUNTRY_CITIES_SUCCESS:
       return {
         ...state,
-        isLoading: INITIAL_STATE.cities.isLoading,
+        isLoading: INITIAL_STATE_LOCALE.cities.isLoading,
       };
     case actionTypes.FETCH_COUNTRY_CITIES_FAILURE:
       return {
-        isLoading: INITIAL_STATE.cities.isLoading,
+        isLoading: INITIAL_STATE_LOCALE.cities.isLoading,
         error: action.payload.error,
       };
     default:
@@ -69,7 +73,7 @@ const cities = (
 };
 
 const countries = (
-  state = INITIAL_STATE.countries,
+  state = INITIAL_STATE_LOCALE.countries,
   action: ActionFetchCountries | ActionFetchCountry,
 ): State['countries'] => {
   switch (action.type) {
@@ -77,18 +81,18 @@ const countries = (
     case actionTypes.FETCH_COUNTRIES_REQUEST:
       return {
         isLoading: true,
-        error: INITIAL_STATE.countries.error,
+        error: INITIAL_STATE_LOCALE.countries.error,
       };
     case actionTypes.FETCH_COUNTRY_SUCCESS:
     case actionTypes.FETCH_COUNTRIES_SUCCESS:
       return {
         ...state,
-        isLoading: INITIAL_STATE.countries.isLoading,
+        isLoading: INITIAL_STATE_LOCALE.countries.isLoading,
       };
     case actionTypes.FETCH_COUNTRY_FAILURE:
     case actionTypes.FETCH_COUNTRIES_FAILURE:
       return {
-        isLoading: INITIAL_STATE.countries.isLoading,
+        isLoading: INITIAL_STATE_LOCALE.countries.isLoading,
         error: action.payload.error,
       };
     default:
@@ -97,23 +101,23 @@ const countries = (
 };
 
 const currencies = (
-  state = INITIAL_STATE.currencies,
+  state = INITIAL_STATE_LOCALE.currencies,
   action: ActionFetchCountryCurrencies,
 ): State['currencies'] => {
   switch (action.type) {
     case actionTypes.FETCH_COUNTRY_CURRENCIES_REQUEST:
       return {
         isLoading: true,
-        error: INITIAL_STATE.currencies.error,
+        error: INITIAL_STATE_LOCALE.currencies.error,
       };
     case actionTypes.FETCH_COUNTRY_CURRENCIES_SUCCESS:
       return {
         ...state,
-        isLoading: INITIAL_STATE.currencies.isLoading,
+        isLoading: INITIAL_STATE_LOCALE.currencies.isLoading,
       };
     case actionTypes.FETCH_COUNTRY_CURRENCIES_FAILURE:
       return {
-        isLoading: INITIAL_STATE.currencies.isLoading,
+        isLoading: INITIAL_STATE_LOCALE.currencies.isLoading,
         error: action.payload.error,
       };
     default:
@@ -122,23 +126,23 @@ const currencies = (
 };
 
 const states = (
-  state = INITIAL_STATE.states,
+  state = INITIAL_STATE_LOCALE.states,
   action: ActionFetchCountryStates,
 ): State['states'] => {
   switch (action.type) {
     case actionTypes.FETCH_COUNTRY_STATES_REQUEST:
       return {
         isLoading: true,
-        error: INITIAL_STATE.states.error,
+        error: INITIAL_STATE_LOCALE.states.error,
       };
     case actionTypes.FETCH_COUNTRY_STATES_SUCCESS:
       return {
         ...state,
-        isLoading: INITIAL_STATE.states.isLoading,
+        isLoading: INITIAL_STATE_LOCALE.states.isLoading,
       };
     case actionTypes.FETCH_COUNTRY_STATES_FAILURE:
       return {
-        isLoading: INITIAL_STATE.states.isLoading,
+        isLoading: INITIAL_STATE_LOCALE.states.isLoading,
         error: action.payload.error,
       };
     default:
@@ -188,7 +192,7 @@ const reducers = combineReducers({
  */
 export default (state: State, action: AnyAction): State => {
   if (action.type === actionTypes.RESET_LOCALE_STATE) {
-    return reducers(INITIAL_STATE, action);
+    return reducers(INITIAL_STATE_LOCALE, action);
   }
 
   return reducers(state, action);

--- a/packages/redux/src/locale/serverInitialState.ts
+++ b/packages/redux/src/locale/serverInitialState.ts
@@ -1,4 +1,4 @@
-import { INITIAL_STATE } from './reducer';
+import { INITIAL_STATE_LOCALE } from './reducer';
 import { normalize } from 'normalizr';
 import country from '../entities/schemas/country';
 import isEmpty from 'lodash/isEmpty';
@@ -14,7 +14,7 @@ import type { ServerInitialState } from './types';
  */
 export default ({ model }: { model: Model }): ServerInitialState => {
   if (isEmpty(model)) {
-    return { locale: INITIAL_STATE };
+    return { locale: INITIAL_STATE_LOCALE };
   }
 
   const {


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

Exported client and actions of contents, locale and language on root to able developers to do imports like this:
`import { getContents } from “@farfetch/blackout-client”;`

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

BREAKING CHANGE:
renamed exports and removed default exports on contents folder.

package/redux
- removed reducer default export
- all exports are now in the following format '*Content'.
- actionTypes to actionTypesContent
- reducer to reducerContent
- serverInitialState to serverInitialStateContent


<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
