### PR TITLE
fix(blackout-client|blackout-redux): fix getFormSchemaByCode selector

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/Farfetch/blackout.git"
   },
   "dependencies": {
+    "@types/json-schema": "^7.0.11",
     "axios-token-interceptor": "^0.2.0",
     "crypto-js": "3.1.9-1",
     "deep-sort-object": "^1.0.2",

--- a/packages/client/src/forms/types/formSchema.types.ts
+++ b/packages/client/src/forms/types/formSchema.types.ts
@@ -1,14 +1,3 @@
-export type FormSchema = {
-  id: string;
-  code: string;
-  name: string;
-  tenantId: number;
-  schemaId: string;
-  active: boolean;
-  createdAt: string;
-  updatedAt: string;
-  jsonSchema: unknown;
-  processors: unknown;
-  settings: unknown;
-  uiSchema: unknown;
-};
+import type { JSONSchema4 } from 'json-schema';
+
+export type FormSchema = JSONSchema4;

--- a/packages/redux/src/forms/__tests__/reducer.test.ts
+++ b/packages/redux/src/forms/__tests__/reducer.test.ts
@@ -52,7 +52,7 @@ describe('forms redux reducer', () => {
       const errorCode = 'foo-biz';
       const state: State = {
         ...initialState,
-        error: { [errorCode]: { message: 'error' } },
+        error: { [errorCode]: { code: -1, name: 'Error', message: 'error' } },
       };
 
       expect(reducer(state, randomAction).error).toEqual(state.error);

--- a/packages/redux/src/forms/selectors.ts
+++ b/packages/redux/src/forms/selectors.ts
@@ -8,6 +8,7 @@ import {
 } from './reducer';
 import type { BlackoutError } from '@farfetch/blackout-client/types';
 import type { FormResult } from './types';
+import type { FormSchema } from '@farfetch/blackout-client/forms/types';
 import type { StoreState } from '../types';
 
 /**
@@ -98,7 +99,8 @@ export const getFormSchemas = (state: StoreState): FormResult =>
 export const getFormSchemaByCode = (
   state: StoreState,
   schemaCode: string,
-): [] => get(getFormSchemas(state)[schemaCode], 'jsonSchema', []) as [];
+): FormSchema | undefined =>
+  get(getFormSchemas(state)[schemaCode], 'jsonSchema');
 
 /**
  * Retrieves the error thrown by the postFormData request, by schemaCode.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2503,6 +2503,11 @@
   resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz#ba05426a43f9e4e30b631941e0aa17bf0c890ed5"
   integrity sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==
 
+"@types/json-schema@^7.0.11":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
 "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"


### PR DESCRIPTION
## Description

- This fixes the getFormSchemaByCode selector which was adding a default
value of an array when the schema was not found which would be
incorrect as it should return undefined in that case.
- Improved typings for FormSchema to match the type for the
json-schema package. Note: @types/form-schema is defined as a dependency
because our typings depend on it and typescript requires that we add
this as a dependency so the user of this package can browse to its
definitions.
- Fixed type errors in forms reducer testing file.


<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
