### PR TITLE
fix(redux): remove setUser middleware mandatory parameter

### DIFF
--- a/packages/redux/src/analytics/middlewares/setUser.ts
+++ b/packages/redux/src/analytics/middlewares/setUser.ts
@@ -90,7 +90,7 @@ let currentUser: UserType | null;
  */
 const setUserMiddleware = (
   analyticsInstance: Analytics,
-  actionTypesOrOptions: SetUserMiddlewareOptions,
+  actionTypesOrOptions?: SetUserMiddlewareOptions,
 ): Middleware => {
   if (!analyticsInstance || !(analyticsInstance instanceof Analytics)) {
     logger.error(


### PR DESCRIPTION


## Description

- Removed middleware mandatory parameter because middleware always
extends the tenant options, applying a default in cases of empty parameter.

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
