### PR TITLE
chore(client): add recovered to orderStatusError

### DIFF
--- a/packages/client/src/checkout/types/getCheckoutResponse.types.ts
+++ b/packages/client/src/checkout/types/getCheckoutResponse.types.ts
@@ -11,6 +11,7 @@ export enum OrderStatusError {
   AddressesError,
   ShippingOptionsError,
   DeliveryBundleError,
+  Recovered,
 }
 
 export type GetCheckoutResponse = {


### PR DESCRIPTION
## Description

This PR adds support for Recovered orderStatus on the get Checkout API Response

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
