### PR TITLE
feat: add `totalQuantity` and `itemsCount` to `useBag` hook

### DIFF
--- a/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup } from '@testing-library/react';
 import {
+  mockBagId,
   mockInitialState,
   mockLoadingState,
   mockState,
@@ -50,10 +51,12 @@ describe('useBag', () => {
       isLoading: expect.any(Boolean),
       isWithAnyError: expect.any(Boolean),
       items: expect.any(Array),
+      itemsCount: expect.any(Number),
       itemsIds: expect.any(Array),
       itemsUnavailable: expect.any(Array),
       resetBag: expect.any(Function),
       resetBagState: expect.any(Function),
+      totalQuantity: expect.any(Number),
     });
   });
 
@@ -76,7 +79,7 @@ describe('useBag', () => {
     it('should call `fetchBag` action', () => {
       const { fetchBag } = getRenderedHook();
 
-      fetchBag();
+      fetchBag(mockBagId);
 
       expect(mockDispatch).toHaveBeenCalledWith({ type: 'fetch' });
     });

--- a/packages/react/src/bags/hooks/types/useBag.ts
+++ b/packages/react/src/bags/hooks/types/useBag.ts
@@ -1,18 +1,25 @@
-import type { Bag } from '@farfetch/blackout-client/src/bags/types';
+import type { Bag, Query } from '@farfetch/blackout-client/src/bags/types';
 import type { BagItemHydrated } from '@farfetch/blackout-redux/src/entities/types';
+import type { ProductTypeEnum } from '@farfetch/blackout-client/products/types';
 import type { State } from '@farfetch/blackout-redux/src/bags/types';
 
-export type UseBag = () => {
+export type UseBag = (excludeProductTypes?: ProductTypeEnum[]) => {
   bag: State['result'];
   error: State['error'] | undefined;
-  fetchBag: () => Promise<Bag>;
+  fetchBag: (
+    bagId: string,
+    query?: Query,
+    config?: Record<string, unknown>,
+  ) => Promise<Bag>;
   id: State['id'];
   isEmpty: boolean | undefined;
   isLoading: State['isLoading'];
   isWithAnyError: boolean | undefined;
   items: BagItemHydrated[];
+  itemsCount: number;
   itemsIds: BagItemHydrated['id'][] | null;
   itemsUnavailable: BagItemHydrated[] | undefined;
   resetBag: () => void;
   resetBagState: (fieldsToReset?: string[]) => void;
+  totalQuantity: number;
 };

--- a/packages/react/src/bags/hooks/types/useBagItem.ts
+++ b/packages/react/src/bags/hooks/types/useBagItem.ts
@@ -19,10 +19,7 @@ export type HandleFullUpdateType = (
 ) => void;
 export type HandleDeleteBagItemType = (from?: string) => void;
 
-export type UseBagItem = (
-  bagItemId: number,
-  from?: string,
-) => {
+export type UseBagItem = (bagItemId: number) => {
   addBagItem: (
     data: PostBagItemData,
     query?: Query,

--- a/packages/react/src/bags/hooks/useBag.ts
+++ b/packages/react/src/bags/hooks/useBag.ts
@@ -7,8 +7,10 @@ import {
   getBagError,
   getBagId,
   getBagItems,
+  getBagItemsCounter,
   getBagItemsIds,
   getBagItemsUnavailable,
+  getBagTotalQuantity,
   isBagLoading as isBagLoadingSelector,
   isBagWithAnyError,
   resetBag as resetBagAction,
@@ -22,9 +24,11 @@ import type { UseBag } from './types';
  * Provides Redux actions and state access, as well as handlers for dealing with
  * bag business logic.
  *
+ * @param excludeProductTypes - List of product types to exclude from the counters.
+ *
  * @returns All the handlers, state, actions and relevant data needed to manage any bag operation.
  */
-const useBag: UseBag = () => {
+const useBag: UseBag = excludeProductTypes => {
   // Selectors
   const bag = useSelector(getBag);
   const error = useSelector(getBagError);
@@ -34,6 +38,12 @@ const useBag: UseBag = () => {
   const items = useSelector(getBagItems);
   const itemsIds = useSelector(getBagItemsIds);
   const itemsUnavailable = useSelector(getBagItemsUnavailable);
+  const itemsCount = useSelector(state =>
+    getBagItemsCounter(state, excludeProductTypes),
+  );
+  const totalQuantity = useSelector(state =>
+    getBagTotalQuantity(state, excludeProductTypes),
+  );
   const isEmpty = items?.length === 0;
   const isLoading = (!bag && !error) || isBagLoading;
   // Actions
@@ -75,6 +85,10 @@ const useBag: UseBag = () => {
      */
     items,
     /**
+     * Count of the items in the bag.
+     */
+    itemsCount,
+    /**
      * Bag items identifiers.
      */
     itemsIds,
@@ -90,6 +104,10 @@ const useBag: UseBag = () => {
      * Resets the bag state.
      */
     resetBagState,
+    /**
+     * Total quantity of products in the bag.
+     */
+    totalQuantity,
   };
 };
 

--- a/packages/redux/src/bags/selectors.ts
+++ b/packages/redux/src/bags/selectors.ts
@@ -24,6 +24,7 @@ import type {
   CustomAttributesAdapted,
   SizeAdapted,
 } from '@farfetch/blackout-client/helpers/adapters/types';
+import type { ProductTypeEnum } from '@farfetch/blackout-client/products/types';
 import type { StoreState } from '../types';
 
 /**
@@ -238,7 +239,7 @@ export const getBagItems = createSelector(
  */
 export const getBagItemsCounter = (
   state: StoreState,
-  excludeProductTypes: number[] = [],
+  excludeProductTypes: ProductTypeEnum[] = [],
 ): number => {
   const bagItems = getBagItems(state);
 
@@ -309,7 +310,7 @@ export const getBagItemsUnavailable = createSelector([getBagItems], bagItems =>
  */
 export const getBagTotalQuantity = (
   state: StoreState,
-  excludeProductTypes: number[] = [],
+  excludeProductTypes: ProductTypeEnum[] = [],
 ): number => {
   const bagItems = getBagItems(state);
 


### PR DESCRIPTION
## Description

This adds the return values for the selectors `getBagTotalQuantity` and `getBagItemsCounter` to the hook `useBag`; the hook now receives an optional parameter `excludeProductTypes` to use on the previous selectors.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
