### PR TITLE
fix(blackout-redux): fix reset recently viewed action naming

### DIFF
--- a/packages/redux/src/entities/reducer/entitiesMapper.ts
+++ b/packages/redux/src/entities/reducer/entitiesMapper.ts
@@ -5,11 +5,11 @@ import { entitiesMapper as entitiesMapperCheckout } from '../../checkout';
 import { entitiesMapper as entitiesMapperMerchantsLocations } from '../../merchantsLocations';
 import { entitiesMapper as entitiesMapperOrders } from '../../orders';
 import { entitiesMapper as entitiesMapperPayments } from '../../payments';
-import { entitiesMapperProducts } from '../../products';
 import { entitiesMapper as entitiesMapperReturns } from '../../returns';
 import { entitiesMapper as entitiesMapperSubscriptions } from '../../subscriptions';
 import { entitiesMapper as entitiesMapperUsers } from '../../users';
 import { entitiesMapper as entitiesMapperWishlist } from '../../wishlists';
+import { productsEntitiesMapper } from '../../products';
 import createEntitiesReducer from './createEntities';
 import type { Reducer } from 'redux';
 import type { StoreState } from '../../types';
@@ -37,7 +37,7 @@ export const defaultMappers = {
   merchantsLocations: entitiesMapperMerchantsLocations,
   orders: entitiesMapperOrders,
   payments: entitiesMapperPayments,
-  products: entitiesMapperProducts,
+  products: productsEntitiesMapper,
   users: entitiesMapperUsers,
   returns: entitiesMapperReturns,
   subscriptions: entitiesMapperSubscriptions,
@@ -53,7 +53,7 @@ const entitiesMapper: EntitiesMapper = ({ ...extraMappers }) =>
     ...entitiesMapperMerchantsLocations,
     ...entitiesMapperOrders,
     ...entitiesMapperPayments,
-    ...entitiesMapperProducts,
+    ...productsEntitiesMapper,
     ...entitiesMapperUsers,
     ...entitiesMapperReturns,
     ...entitiesMapperSubscriptions,

--- a/packages/redux/src/products/actionTypes/recentlyViewedProducts.actionTypes.ts
+++ b/packages/redux/src/products/actionTypes/recentlyViewedProducts.actionTypes.ts
@@ -37,5 +37,5 @@ export const REMOVE_RECENTLY_VIEWED_PRODUCT_SUCCESS =
 /**
  * Action type dispatched when the fetch product recently viewed needs to reset.
  */
-export const RESET_RECENTLY_VIEWED_PRODUCT =
-  '@farfetch/blackout-redux/RESET_RECENTLY_VIEWED_PRODUCT';
+export const RESET_RECENTLY_VIEWED_PRODUCTS =
+  '@farfetch/blackout-redux/RESET_RECENTLY_VIEWED_PRODUCTS';

--- a/packages/redux/src/products/actions/__tests__/fetchListing.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchListing.test.ts
@@ -1,5 +1,4 @@
 import * as normalizr from 'normalizr';
-import { actionTypesProducts } from '../..';
 import { fetchListing } from '..';
 import { getListing } from '@farfetch/blackout-client';
 import { INITIAL_STATE } from '../../reducer/lists';
@@ -13,6 +12,7 @@ import {
   mockQuery,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 import thunk from 'redux-thunk';
 
 jest.mock('@farfetch/blackout-client', () => ({
@@ -95,16 +95,16 @@ describe('fetchListing() action creator', () => {
         expect(store.getActions()).toEqual([
           {
             meta: { hash: mockProductsListHash },
-            type: actionTypesProducts.SET_PRODUCTS_LIST_HASH,
+            type: productsActionTypes.SET_PRODUCTS_LIST_HASH,
           },
           {
             meta: { hash: mockProductsListHash },
-            type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+            type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
           },
           {
             meta: { hash: mockProductsListHash },
             payload: { error: expectedError },
-            type: actionTypesProducts.FETCH_PRODUCTS_LIST_FAILURE,
+            type: productsActionTypes.FETCH_PRODUCTS_LIST_FAILURE,
           },
         ]);
       });
@@ -131,16 +131,16 @@ describe('fetchListing() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { hash: mockProductsListHash },
-        type: actionTypesProducts.SET_PRODUCTS_LIST_HASH,
+        type: productsActionTypes.SET_PRODUCTS_LIST_HASH,
       },
       {
         meta: { hash: mockProductsListHash },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
       },
       {
         meta: { hash: mockProductsListHash },
         payload: mockProductsListNormalized,
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_SUCCESS,
       },
     ]);
   });
@@ -169,16 +169,16 @@ describe('fetchListing() action creator', () => {
     expect(actionResults).toEqual([
       {
         meta: { hash: mockProductsListHash },
-        type: actionTypesProducts.SET_PRODUCTS_LIST_HASH,
+        type: productsActionTypes.SET_PRODUCTS_LIST_HASH,
       },
       {
         meta: { hash: mockProductsListHash },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
       },
       {
         meta: { hash: mockProductsListHash },
         payload: mockProductsListNormalizedWithoutImageOptions,
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_SUCCESS,
       },
     ]);
   });
@@ -214,20 +214,20 @@ describe('fetchListing() action creator', () => {
     );
     expect(store.getActions()).toEqual([
       {
-        type: actionTypesProducts.RESET_PRODUCTS_LISTS_STATE,
+        type: productsActionTypes.RESET_PRODUCTS_LISTS_STATE,
       },
       {
         meta: { hash: mockProductsListHash },
-        type: actionTypesProducts.SET_PRODUCTS_LIST_HASH,
+        type: productsActionTypes.SET_PRODUCTS_LIST_HASH,
       },
       {
         meta: { hash: mockProductsListHash },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
       },
       {
         meta: { hash: mockProductsListHash },
         payload: mockProductsListNormalized,
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_SUCCESS,
       },
     ]);
   });
@@ -256,7 +256,7 @@ describe('fetchListing() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { hash: mockProductsListHash },
-        type: actionTypesProducts.DEHYDRATE_PRODUCTS_LIST,
+        type: productsActionTypes.DEHYDRATE_PRODUCTS_LIST,
       },
     ]);
   });
@@ -287,7 +287,7 @@ describe('fetchListing() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { hash: mockProductsListHash },
-        type: actionTypesProducts.SET_PRODUCTS_LIST_HASH,
+        type: productsActionTypes.SET_PRODUCTS_LIST_HASH,
       },
     ]);
   });
@@ -317,12 +317,12 @@ describe('fetchListing() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { hash: mockProductsListHash },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
       },
       {
         meta: { hash: mockProductsListHash },
         payload: mockProductsListNormalized,
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/fetchProductAttributes.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchProductAttributes.test.ts
@@ -1,5 +1,4 @@
 import * as normalizr from 'normalizr';
-import { actionTypesProducts } from '../..';
 import { fetchProductAttributes } from '..';
 import { getProductAttributes } from '@farfetch/blackout-client';
 import { INITIAL_STATE } from '../../reducer/attributes';
@@ -9,6 +8,7 @@ import {
   mockProductId,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 
 jest.mock('@farfetch/blackout-client', () => ({
   ...jest.requireActual('@farfetch/blackout-client'),
@@ -55,12 +55,12 @@ describe('fetchProductAttributes() action creator', () => {
       expect(store.getActions()).toEqual([
         {
           meta: { productId: mockProductId },
-          type: actionTypesProducts.FETCH_PRODUCT_ATTRIBUTES_REQUEST,
+          type: productsActionTypes.FETCH_PRODUCT_ATTRIBUTES_REQUEST,
         },
         {
           meta: { productId: mockProductId },
           payload: { error: expectedError },
-          type: actionTypesProducts.FETCH_PRODUCT_ATTRIBUTES_FAILURE,
+          type: productsActionTypes.FETCH_PRODUCT_ATTRIBUTES_FAILURE,
         },
       ]);
     });
@@ -84,12 +84,12 @@ describe('fetchProductAttributes() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_ATTRIBUTES_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_ATTRIBUTES_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductAttributesNormalizedResponse,
-        type: actionTypesProducts.FETCH_PRODUCT_ATTRIBUTES_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_ATTRIBUTES_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/fetchProductColorGrouping.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchProductColorGrouping.test.ts
@@ -1,5 +1,4 @@
 import * as normalizr from 'normalizr';
-import { actionTypesProducts } from '../..';
 import { fetchProductColorGrouping } from '..';
 import { getProductColorGrouping } from '@farfetch/blackout-client';
 import { INITIAL_STATE } from '../../reducer/colorGrouping';
@@ -9,6 +8,7 @@ import {
   mockProductId,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 
 jest.mock('@farfetch/blackout-client', () => ({
   ...jest.requireActual('@farfetch/blackout-client'),
@@ -57,12 +57,12 @@ describe('fetchProductColorGrouping() action creator', () => {
         expect(store.getActions()).toEqual([
           {
             meta: { productId: mockProductId },
-            type: actionTypesProducts.FETCH_PRODUCT_COLOR_GROUPING_REQUEST,
+            type: productsActionTypes.FETCH_PRODUCT_COLOR_GROUPING_REQUEST,
           },
           {
             meta: { productId: mockProductId },
             payload: { error: expectedError },
-            type: actionTypesProducts.FETCH_PRODUCT_COLOR_GROUPING_FAILURE,
+            type: productsActionTypes.FETCH_PRODUCT_COLOR_GROUPING_FAILURE,
           },
         ]);
       });
@@ -89,12 +89,12 @@ describe('fetchProductColorGrouping() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_COLOR_GROUPING_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_COLOR_GROUPING_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductColorGroupingNormalizedResponse,
-        type: actionTypesProducts.FETCH_PRODUCT_COLOR_GROUPING_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_COLOR_GROUPING_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/fetchProductDetails.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchProductDetails.test.ts
@@ -1,5 +1,4 @@
 import * as normalizr from 'normalizr';
-import { actionTypesProducts } from '../..';
 import { fetchProductDetails } from '..';
 import { getProductDetails } from '@farfetch/blackout-client';
 import { INITIAL_STATE } from '../../reducer/details';
@@ -10,6 +9,7 @@ import {
   mockResponse,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 import thunk from 'redux-thunk';
 
 jest.mock('@farfetch/blackout-client', () => ({
@@ -56,12 +56,12 @@ describe('fetchProductDetails() action creator', () => {
       expect(store.getActions()).toEqual([
         {
           meta: { productId: mockProductId },
-          type: actionTypesProducts.FETCH_PRODUCT_DETAILS_REQUEST,
+          type: productsActionTypes.FETCH_PRODUCT_DETAILS_REQUEST,
         },
         {
           meta: { productId: mockProductId },
           payload: { error: expectedError },
-          type: actionTypesProducts.FETCH_PRODUCT_DETAILS_FAILURE,
+          type: productsActionTypes.FETCH_PRODUCT_DETAILS_FAILURE,
         },
       ]);
     });
@@ -86,12 +86,12 @@ describe('fetchProductDetails() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_DETAILS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_DETAILS_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductResponseNormalized,
-        type: actionTypesProducts.FETCH_PRODUCT_DETAILS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_DETAILS_SUCCESS,
       },
     ]);
   });
@@ -121,12 +121,12 @@ describe('fetchProductDetails() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_DETAILS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_DETAILS_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductResponseNormalizedWithoutImageOptions,
-        type: actionTypesProducts.FETCH_PRODUCT_DETAILS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_DETAILS_SUCCESS,
       },
     ]);
   });
@@ -153,7 +153,7 @@ describe('fetchProductDetails() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.DEHYDRATE_PRODUCT_DETAILS,
+        type: productsActionTypes.DEHYDRATE_PRODUCT_DETAILS,
       },
     ]);
   });
@@ -186,19 +186,19 @@ describe('fetchProductDetails() action creator', () => {
       {
         meta: { productId: mockProductId },
         payload: mockProductResponseNormalized,
-        type: actionTypesProducts.DEHYDRATE_PRODUCT_DETAILS,
+        type: productsActionTypes.DEHYDRATE_PRODUCT_DETAILS,
       },
     ]);
 
     expect(actionResults).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_DETAILS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_DETAILS_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductResponseNormalized,
-        type: actionTypesProducts.FETCH_PRODUCT_DETAILS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_DETAILS_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/fetchProductFittings.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchProductFittings.test.ts
@@ -1,5 +1,4 @@
 import * as normalizr from 'normalizr';
-import { actionTypesProducts } from '../..';
 import { fetchProductFittings } from '..';
 import { getProductFittings } from '@farfetch/blackout-client';
 import { INITIAL_STATE } from '../../reducer/fittings';
@@ -9,6 +8,7 @@ import {
   mockProductId,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 
 jest.mock('@farfetch/blackout-client', () => ({
   ...jest.requireActual('@farfetch/blackout-client'),
@@ -55,12 +55,12 @@ describe('fetchProductFittings() action creator', () => {
       expect(store.getActions()).toEqual([
         {
           meta: { productId: mockProductId },
-          type: actionTypesProducts.FETCH_PRODUCT_FITTINGS_REQUEST,
+          type: productsActionTypes.FETCH_PRODUCT_FITTINGS_REQUEST,
         },
         {
           meta: { productId: mockProductId },
           payload: { error: expectedError },
-          type: actionTypesProducts.FETCH_PRODUCT_FITTINGS_FAILURE,
+          type: productsActionTypes.FETCH_PRODUCT_FITTINGS_FAILURE,
         },
       ]);
     });
@@ -86,12 +86,12 @@ describe('fetchProductFittings() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_FITTINGS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_FITTINGS_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductFittingsNormalizedResponse,
-        type: actionTypesProducts.FETCH_PRODUCT_FITTINGS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_FITTINGS_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/fetchProductGrouping.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchProductGrouping.test.ts
@@ -1,5 +1,4 @@
 import * as normalizr from 'normalizr';
-import { actionTypesProducts } from '../..';
 import { fetchProductGrouping } from '..';
 import { getProductGrouping } from '@farfetch/blackout-client/products';
 import { INITIAL_STATE } from '../../reducer/grouping';
@@ -9,6 +8,7 @@ import {
   mockProductId,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 
 jest.mock('@farfetch/blackout-client/products', () => ({
   ...jest.requireActual('@farfetch/blackout-client/products'),
@@ -55,12 +55,12 @@ describe('fetchProductGrouping() action creator', () => {
       expect(store.getActions()).toEqual([
         {
           meta: { productId: mockProductId },
-          type: actionTypesProducts.FETCH_PRODUCT_GROUPING_REQUEST,
+          type: productsActionTypes.FETCH_PRODUCT_GROUPING_REQUEST,
         },
         {
           meta: { productId: mockProductId },
           payload: { error: expectedError },
-          type: actionTypesProducts.FETCH_PRODUCT_GROUPING_FAILURE,
+          type: productsActionTypes.FETCH_PRODUCT_GROUPING_FAILURE,
         },
       ]);
     });
@@ -87,12 +87,12 @@ describe('fetchProductGrouping() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_GROUPING_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_GROUPING_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductGroupingNormalizedResponse,
-        type: actionTypesProducts.FETCH_PRODUCT_GROUPING_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_GROUPING_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/fetchProductMeasurements.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchProductMeasurements.test.ts
@@ -1,5 +1,4 @@
 import * as normalizr from 'normalizr';
-import { actionTypesProducts } from '../..';
 import { fetchProductMeasurements } from '..';
 import { getProductVariantsMeasurements } from '@farfetch/blackout-client';
 import { INITIAL_STATE } from '../../reducer/measurements';
@@ -9,6 +8,7 @@ import {
   mockProductVariantsMeasurementsNormalizedResponse,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 
 jest.mock('@farfetch/blackout-client', () => ({
   ...jest.requireActual('@farfetch/blackout-client'),
@@ -58,12 +58,12 @@ describe('fetchProductMeasurements() action creator', () => {
         expect(store.getActions()).toEqual([
           {
             meta: { productId: mockProductId },
-            type: actionTypesProducts.FETCH_PRODUCT_MEASUREMENTS_REQUEST,
+            type: productsActionTypes.FETCH_PRODUCT_MEASUREMENTS_REQUEST,
           },
           {
             meta: { productId: mockProductId },
             payload: { error: expectedError },
-            type: actionTypesProducts.FETCH_PRODUCT_MEASUREMENTS_FAILURE,
+            type: productsActionTypes.FETCH_PRODUCT_MEASUREMENTS_FAILURE,
           },
         ]);
       });
@@ -91,12 +91,12 @@ describe('fetchProductMeasurements() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_MEASUREMENTS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_MEASUREMENTS_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductVariantsMeasurementsNormalizedResponse,
-        type: actionTypesProducts.FETCH_PRODUCT_MEASUREMENTS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_MEASUREMENTS_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/fetchProductSizeGuides.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchProductSizeGuides.test.ts
@@ -1,5 +1,4 @@
 import * as normalizr from 'normalizr';
-import { actionTypesProducts } from '../..';
 import { fetchProductSizeGuides } from '..';
 import { getProductSizeGuides } from '@farfetch/blackout-client';
 import { INITIAL_STATE } from '../../reducer/sizeGuides';
@@ -10,6 +9,7 @@ import {
   mockProductSizeGuidesNormalizedResponse,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 
 jest.mock('@farfetch/blackout-client', () => ({
   ...jest.requireActual('@farfetch/blackout-client'),
@@ -47,12 +47,12 @@ describe('fetchProductSizeGuides() action creator', () => {
       expect(store.getActions()).toEqual([
         {
           meta: { productId: mockProductId },
-          type: actionTypesProducts.FETCH_PRODUCT_SIZEGUIDES_REQUEST,
+          type: productsActionTypes.FETCH_PRODUCT_SIZEGUIDES_REQUEST,
         },
         {
           meta: { productId: mockProductId },
           payload: { error: expectedError },
-          type: actionTypesProducts.FETCH_PRODUCT_SIZEGUIDES_FAILURE,
+          type: productsActionTypes.FETCH_PRODUCT_SIZEGUIDES_FAILURE,
         },
       ]);
     });
@@ -78,12 +78,12 @@ describe('fetchProductSizeGuides() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_SIZEGUIDES_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_SIZEGUIDES_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductSizeGuidesNormalizedResponse,
-        type: actionTypesProducts.FETCH_PRODUCT_SIZEGUIDES_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_SIZEGUIDES_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/fetchProductSizes.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchProductSizes.test.ts
@@ -1,5 +1,4 @@
 import * as normalizr from 'normalizr';
-import { actionTypesProducts } from '../..';
 import { fetchProductSizes } from '..';
 import { getProductSizes } from '@farfetch/blackout-client';
 import { INITIAL_STATE } from '../../reducer/sizes';
@@ -9,6 +8,7 @@ import {
   mockProductSizesNormalizedResponse,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 
 jest.mock('@farfetch/blackout-client', () => ({
   ...jest.requireActual('@farfetch/blackout-client'),
@@ -58,12 +58,12 @@ describe('fetchProductSizes() action creator', () => {
         expect(store.getActions()).toEqual([
           {
             meta: { productId: mockProductId },
-            type: actionTypesProducts.FETCH_PRODUCT_SIZES_REQUEST,
+            type: productsActionTypes.FETCH_PRODUCT_SIZES_REQUEST,
           },
           {
             meta: { productId: mockProductId },
             payload: { error: expectedError },
-            type: actionTypesProducts.FETCH_PRODUCT_SIZES_FAILURE,
+            type: productsActionTypes.FETCH_PRODUCT_SIZES_FAILURE,
           },
         ]);
       });
@@ -90,12 +90,12 @@ describe('fetchProductSizes() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_SIZES_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_SIZES_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductSizesNormalizedResponse,
-        type: actionTypesProducts.FETCH_PRODUCT_SIZES_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_SIZES_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/fetchProductVariantsByMerchantsLocations.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchProductVariantsByMerchantsLocations.test.ts
@@ -1,5 +1,4 @@
 import * as normalizr from 'normalizr';
-import { actionTypesProducts } from '../..';
 import { fetchProductVariantsByMerchantsLocations } from '..';
 import { getProductVariantsByMerchantsLocations } from '@farfetch/blackout-client';
 import { INITIAL_STATE } from '../../reducer/variantsByMerchantsLocations';
@@ -11,6 +10,7 @@ import {
   mockVariantId,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 
 jest.mock('@farfetch/blackout-client', () => ({
   ...jest.requireActual('@farfetch/blackout-client'),
@@ -53,12 +53,12 @@ describe('fetchProductVariantsByMerchantsLocations() action creator', () => {
         expect(store.getActions()).toEqual([
           {
             meta: { productId: mockProductId },
-            type: actionTypesProducts.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST,
+            type: productsActionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST,
           },
           {
             meta: { productId: mockProductId },
             payload: { error: expectedError },
-            type: actionTypesProducts.FETCH_PRODUCT_MERCHANTS_LOCATIONS_FAILURE,
+            type: productsActionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_FAILURE,
           },
         ]);
       });
@@ -89,12 +89,12 @@ describe('fetchProductVariantsByMerchantsLocations() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductVariantsByMerchantsLocationsNormalizedResponse,
-        type: actionTypesProducts.FETCH_PRODUCT_MERCHANTS_LOCATIONS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_SUCCESS,
       },
     ]);
   });
@@ -128,12 +128,12 @@ describe('fetchProductVariantsByMerchantsLocations() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { productId: mockProductId },
-        type: actionTypesProducts.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST,
       },
       {
         meta: { productId: mockProductId },
         payload: mockProductVariantsByMerchantsLocationsNormalizedResponse,
-        type: actionTypesProducts.FETCH_PRODUCT_MERCHANTS_LOCATIONS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/fetchRecentlyViewedProducts.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchRecentlyViewedProducts.test.ts
@@ -1,8 +1,8 @@
-import { actionTypesProducts } from '../../';
 import { expectedRecentlyViewedRemotePayload } from 'tests/__fixtures__/products';
 import { fetchRecentlyViewedProducts } from '../';
 import { getRecentlyViewedProducts } from '@farfetch/blackout-client';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../../';
 import find from 'lodash/find';
 import reducer from '../../reducer';
 import type { StoreState } from '../../../types';
@@ -63,10 +63,10 @@ describe('fetchRecentlyViewedProducts() action creator', () => {
     expect(store.getActions()).toEqual(
       expect.arrayContaining([
         {
-          type: actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_REQUEST,
+          type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_REQUEST,
         },
         {
-          type: actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_FAILURE,
+          type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_FAILURE,
           payload: { error: expectedError },
         },
       ]),
@@ -94,16 +94,16 @@ describe('fetchRecentlyViewedProducts() action creator', () => {
     );
     expect(actionResults).toEqual([
       {
-        type: actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_REQUEST,
+        type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_REQUEST,
       },
       {
-        type: actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
+        type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
         payload: expectedRecentlyViewedRemotePayload,
       },
     ]);
     expect(
       find(actionResults, {
-        type: actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
+        type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
       }),
     ).toMatchSnapshot('fetch recently viewed products success payload');
 

--- a/packages/redux/src/products/actions/__tests__/fetchRecommendedSet.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchRecommendedSet.test.ts
@@ -1,4 +1,3 @@
-import { actionTypesProducts } from '../..';
 import { fetchRecommendedSet } from '..';
 import { getRecommendedSet } from '@farfetch/blackout-client';
 import { INITIAL_STATE } from '../../reducer/recommendedSet';
@@ -7,6 +6,7 @@ import {
   mockRecommendedSetId,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 
 jest.mock('@farfetch/blackout-client', () => ({
   ...jest.requireActual('@farfetch/blackout-client'),
@@ -43,12 +43,12 @@ describe('fetchRecommendedSet() action creator', () => {
         expect(store.getActions()).toEqual([
           {
             meta: { recommendedSetId: mockRecommendedSetId },
-            type: actionTypesProducts.FETCH_RECOMMENDED_SET_REQUEST,
+            type: productsActionTypes.FETCH_RECOMMENDED_SET_REQUEST,
           },
           {
             meta: { recommendedSetId: mockRecommendedSetId },
             payload: { error: expectedError },
-            type: actionTypesProducts.FETCH_RECOMMENDED_SET_FAILURE,
+            type: productsActionTypes.FETCH_RECOMMENDED_SET_FAILURE,
           },
         ]);
       });
@@ -73,12 +73,12 @@ describe('fetchRecommendedSet() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { recommendedSetId: mockRecommendedSetId },
-        type: actionTypesProducts.FETCH_RECOMMENDED_SET_REQUEST,
+        type: productsActionTypes.FETCH_RECOMMENDED_SET_REQUEST,
       },
       {
         meta: { recommendedSetId: mockRecommendedSetId },
         payload: { result: mockRecommendedSet },
-        type: actionTypesProducts.FETCH_RECOMMENDED_SET_SUCCESS,
+        type: productsActionTypes.FETCH_RECOMMENDED_SET_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/fetchSet.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchSet.test.ts
@@ -1,5 +1,4 @@
 import * as normalizr from 'normalizr';
-import { actionTypesProducts } from '../..';
 import { fetchSet } from '..';
 import { getSet } from '@farfetch/blackout-client';
 import { INITIAL_STATE } from '../../reducer/lists';
@@ -11,6 +10,7 @@ import {
   mockSetId,
 } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 import thunk from 'redux-thunk';
 
 jest.mock('@farfetch/blackout-client', () => ({
@@ -89,18 +89,18 @@ describe('fetchSet() action creator', () => {
       expect(store.getActions()).toEqual([
         {
           meta: { hash: mockProductsListHashForSetsWithId },
-          type: actionTypesProducts.SET_PRODUCTS_LIST_HASH,
+          type: productsActionTypes.SET_PRODUCTS_LIST_HASH,
         },
         {
           meta: { hash: mockProductsListHashForSetsWithId },
-          type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+          type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
         },
         {
           meta: { hash: mockProductsListHashForSetsWithId },
           payload: {
             error: expectedError,
           },
-          type: actionTypesProducts.FETCH_PRODUCTS_LIST_FAILURE,
+          type: productsActionTypes.FETCH_PRODUCTS_LIST_FAILURE,
         },
       ]);
     });
@@ -121,16 +121,16 @@ describe('fetchSet() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { hash: mockProductsListHashForSetsWithId },
-        type: actionTypesProducts.SET_PRODUCTS_LIST_HASH,
+        type: productsActionTypes.SET_PRODUCTS_LIST_HASH,
       },
       {
         meta: { hash: mockProductsListHashForSetsWithId },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
       },
       {
         meta: { hash: mockProductsListHashForSetsWithId },
         payload: mockProductsListForSetsWithIdNormalized,
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_SUCCESS,
       },
     ]);
   });
@@ -151,16 +151,16 @@ describe('fetchSet() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { hash: mockProductsListHashForSetsWithId },
-        type: actionTypesProducts.SET_PRODUCTS_LIST_HASH,
+        type: productsActionTypes.SET_PRODUCTS_LIST_HASH,
       },
       {
         meta: { hash: mockProductsListHashForSetsWithId },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
       },
       {
         meta: { hash: mockProductsListHashForSetsWithId },
         payload: mockProductsListForSetsWithIdNormalizedWithoutImageOptions,
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_SUCCESS,
       },
     ]);
   });
@@ -192,20 +192,20 @@ describe('fetchSet() action creator', () => {
     expect(getSet).toHaveBeenCalledWith(mockSetId, {}, expectedConfig);
     expect(store.getActions()).toEqual([
       {
-        type: actionTypesProducts.RESET_PRODUCTS_LISTS_STATE,
+        type: productsActionTypes.RESET_PRODUCTS_LISTS_STATE,
       },
       {
         meta: { hash: mockProductsListHashForSetsWithId },
-        type: actionTypesProducts.SET_PRODUCTS_LIST_HASH,
+        type: productsActionTypes.SET_PRODUCTS_LIST_HASH,
       },
       {
         meta: { hash: mockProductsListHashForSetsWithId },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
       },
       {
         meta: { hash: mockProductsListHashForSetsWithId },
         payload: mockProductsListForSetsWithIdNormalized,
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_SUCCESS,
       },
     ]);
   });
@@ -232,7 +232,7 @@ describe('fetchSet() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { hash: mockProductsListHashForSetsWithId },
-        type: actionTypesProducts.DEHYDRATE_PRODUCTS_LIST,
+        type: productsActionTypes.DEHYDRATE_PRODUCTS_LIST,
       },
     ]);
   });
@@ -261,7 +261,7 @@ describe('fetchSet() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { hash: mockProductsListHashForSetsWithId },
-        type: actionTypesProducts.SET_PRODUCTS_LIST_HASH,
+        type: productsActionTypes.SET_PRODUCTS_LIST_HASH,
       },
     ]);
   });
@@ -291,12 +291,12 @@ describe('fetchSet() action creator', () => {
     expect(store.getActions()).toEqual([
       {
         meta: { hash: mockProductsListHashForSetsWithId },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
       },
       {
         meta: { hash: mockProductsListHashForSetsWithId },
         payload: mockProductsListForSetsWithIdNormalized,
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/removeRecentlyViewedProduct.test.ts
+++ b/packages/redux/src/products/actions/__tests__/removeRecentlyViewedProduct.test.ts
@@ -1,6 +1,6 @@
-import { actionTypesProducts } from '../..';
 import { deleteRecentlyViewedProduct } from '@farfetch/blackout-client';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 import { removeRecentlyViewedProduct } from '..';
 import reducer from '../../reducer';
 
@@ -55,12 +55,12 @@ describe('removeRecentlyViewedProduct() action creator', () => {
       expect.arrayContaining([
         {
           meta: { productId },
-          type: actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_REQUEST,
+          type: productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_REQUEST,
         },
         {
           meta: { productId },
           payload: { error: expectedError },
-          type: actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_FAILURE,
+          type: productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_FAILURE,
         },
       ]),
     );
@@ -84,11 +84,11 @@ describe('removeRecentlyViewedProduct() action creator', () => {
     expect(actionResults).toEqual([
       {
         meta: { productId },
-        type: actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_REQUEST,
+        type: productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_REQUEST,
       },
       {
         meta: { productId },
-        type: actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_SUCCESS,
+        type: productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_SUCCESS,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/resetProductDetails.test.ts
+++ b/packages/redux/src/products/actions/__tests__/resetProductDetails.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 import { resetProductDetails } from '..';
 
 describe('resetProductDetails() action creator', () => {
@@ -11,10 +11,10 @@ describe('resetProductDetails() action creator', () => {
 
     expect(store.getActions()).toEqual([
       {
-        type: actionTypesProducts.RESET_PRODUCT_DETAILS_STATE,
+        type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
       },
       {
-        type: actionTypesProducts.RESET_PRODUCT_DETAILS_ENTITIES,
+        type: productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/resetProductDetailsState.test.ts
+++ b/packages/redux/src/products/actions/__tests__/resetProductDetailsState.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 import { resetProductDetailsState } from '..';
 
 describe('resetProductDetailsState() action creator', () => {
@@ -11,7 +11,7 @@ describe('resetProductDetailsState() action creator', () => {
 
     expect(store.getActions()).toEqual([
       {
-        type: actionTypesProducts.RESET_PRODUCT_DETAILS_STATE,
+        type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/resetProductsLists.test.ts
+++ b/packages/redux/src/products/actions/__tests__/resetProductsLists.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 import { resetProductsLists } from '..';
 
 describe('resetProductsLists() action creator', () => {
@@ -11,10 +11,10 @@ describe('resetProductsLists() action creator', () => {
 
     expect(store.getActions()).toEqual([
       {
-        type: actionTypesProducts.RESET_PRODUCTS_LISTS_STATE,
+        type: productsActionTypes.RESET_PRODUCTS_LISTS_STATE,
       },
       {
-        type: actionTypesProducts.RESET_PRODUCTS_LISTS_ENTITIES,
+        type: productsActionTypes.RESET_PRODUCTS_LISTS_ENTITIES,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/resetProductsListsState.test.ts
+++ b/packages/redux/src/products/actions/__tests__/resetProductsListsState.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../..';
 import { resetProductsListsState } from '..';
 
 describe('resetProductsListsState() action creator', () => {
@@ -11,7 +11,7 @@ describe('resetProductsListsState() action creator', () => {
 
     expect(store.getActions()).toEqual([
       {
-        type: actionTypesProducts.RESET_PRODUCTS_LISTS_STATE,
+        type: productsActionTypes.RESET_PRODUCTS_LISTS_STATE,
       },
     ]);
   });

--- a/packages/redux/src/products/actions/__tests__/saveRecentlyViewedProduct.test.ts
+++ b/packages/redux/src/products/actions/__tests__/saveRecentlyViewedProduct.test.ts
@@ -1,6 +1,6 @@
-import { actionTypesProducts } from '../../';
 import { expectedRecentlyViewedLocalPayload } from 'tests/__fixtures__/products';
 import { mockStore } from '../../../../tests';
+import { productsActionTypes } from '../../';
 import { saveRecentlyViewedProduct } from '../';
 import reducer from '../../reducer';
 
@@ -31,7 +31,7 @@ describe('saveRecentlyViewedProduct() action creator', () => {
 
     expect(actionResults).toEqual([
       {
-        type: actionTypesProducts.SAVE_RECENTLY_VIEWED_PRODUCT,
+        type: productsActionTypes.SAVE_RECENTLY_VIEWED_PRODUCT,
         payload: [
           {
             productId,

--- a/packages/redux/src/products/index.ts
+++ b/packages/redux/src/products/index.ts
@@ -1,6 +1,6 @@
-import * as actionTypesProducts from './actionTypes';
-import reducer, { entitiesMapper as entitiesMapperProducts } from './reducer';
-import serverInitialStateProducts from './serverInitialState';
+import * as productsActionTypes from './actionTypes';
+import productsServerInitialState from './serverInitialState';
+import reducer, { entitiesMapper as productsEntitiesMapper } from './reducer';
 
 export * from './actions';
 export * from './selectors';
@@ -8,9 +8,9 @@ export * from './types';
 export * from './utils';
 
 export {
-  actionTypesProducts,
-  entitiesMapperProducts,
-  serverInitialStateProducts,
+  productsActionTypes,
+  productsEntitiesMapper,
+  productsServerInitialState,
 };
 
 export default reducer;

--- a/packages/redux/src/products/reducer/__tests__/attributes.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/attributes.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockProductId } from 'tests/__fixtures__/products';
+import { productsActionTypes } from '../..';
 import reducer, { getError, getIsLoading, INITIAL_STATE } from '../attributes';
 
 const mockAction = { type: 'foo' };
@@ -27,7 +27,7 @@ describe('attributes redux reducer', () => {
       const expectedResult = { [mockProductId]: undefined };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_ATTRIBUTES_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_ATTRIBUTES_REQUEST,
       });
 
       expect(state.error).toEqual(expectedResult);
@@ -37,7 +37,7 @@ describe('attributes redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error },
-        type: actionTypesProducts.FETCH_PRODUCT_ATTRIBUTES_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_ATTRIBUTES_FAILURE,
       });
 
       expect(state.error).toEqual(expectedError);
@@ -66,7 +66,7 @@ describe('attributes redux reducer', () => {
       };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_ATTRIBUTES_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_ATTRIBUTES_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -79,7 +79,7 @@ describe('attributes redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error: '' },
-        type: actionTypesProducts.FETCH_PRODUCT_ATTRIBUTES_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_ATTRIBUTES_FAILURE,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -94,7 +94,7 @@ describe('attributes redux reducer', () => {
         payload: {
           result: mockProductId,
         },
-        type: actionTypesProducts.FETCH_PRODUCT_ATTRIBUTES_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_ATTRIBUTES_SUCCESS,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);

--- a/packages/redux/src/products/reducer/__tests__/colorGrouping.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/colorGrouping.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockProductId } from 'tests/__fixtures__/products';
+import { productsActionTypes } from '../..';
 import reducer, {
   getError,
   getIsLoading,
@@ -31,7 +31,7 @@ describe('colorGrouping redux reducer', () => {
       const expectedResult = { [mockProductId]: undefined };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_COLOR_GROUPING_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_COLOR_GROUPING_REQUEST,
       });
 
       expect(state.error).toEqual(expectedResult);
@@ -41,7 +41,7 @@ describe('colorGrouping redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error },
-        type: actionTypesProducts.FETCH_PRODUCT_COLOR_GROUPING_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_COLOR_GROUPING_FAILURE,
       });
 
       expect(state.error).toEqual(expectedError);
@@ -70,7 +70,7 @@ describe('colorGrouping redux reducer', () => {
       };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_COLOR_GROUPING_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_COLOR_GROUPING_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -83,7 +83,7 @@ describe('colorGrouping redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error: '' },
-        type: actionTypesProducts.FETCH_PRODUCT_COLOR_GROUPING_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_COLOR_GROUPING_FAILURE,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -98,7 +98,7 @@ describe('colorGrouping redux reducer', () => {
         payload: {
           result: mockProductId,
         },
-        type: actionTypesProducts.FETCH_PRODUCT_COLOR_GROUPING_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_COLOR_GROUPING_SUCCESS,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);

--- a/packages/redux/src/products/reducer/__tests__/details.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/details.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockProductId, mockSetId } from 'tests/__fixtures__/products';
+import { productsActionTypes } from '../..';
 import reducer, {
   entitiesMapper,
   getError,
@@ -21,7 +21,7 @@ describe('details redux reducer', () => {
     it('should return the initial state', () => {
       expect(
         reducer(undefined, {
-          type: actionTypesProducts.RESET_PRODUCT_DETAILS_STATE,
+          type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
         }),
       ).toEqual(initialState);
     });
@@ -43,7 +43,7 @@ describe('details redux reducer', () => {
       const expectedResult = { [mockProductId]: undefined };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_DETAILS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_DETAILS_REQUEST,
       });
 
       expect(state.error).toEqual(expectedResult);
@@ -53,7 +53,7 @@ describe('details redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error },
-        type: actionTypesProducts.FETCH_PRODUCT_DETAILS_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_DETAILS_FAILURE,
       });
 
       expect(state.error).toEqual(expectedError);
@@ -81,7 +81,7 @@ describe('details redux reducer', () => {
       const expectedIsHydrated = { [mockProductId]: false };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.DEHYDRATE_PRODUCT_DETAILS,
+        type: productsActionTypes.DEHYDRATE_PRODUCT_DETAILS,
       });
 
       expect(state.isHydrated).toEqual(expectedIsHydrated);
@@ -110,7 +110,7 @@ describe('details redux reducer', () => {
       };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_DETAILS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_DETAILS_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -123,7 +123,7 @@ describe('details redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error: '' },
-        type: actionTypesProducts.FETCH_PRODUCT_DETAILS_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_DETAILS_FAILURE,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -138,7 +138,7 @@ describe('details redux reducer', () => {
         payload: {
           result: mockProductId,
         },
-        type: actionTypesProducts.FETCH_PRODUCT_DETAILS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_DETAILS_SUCCESS,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -155,7 +155,7 @@ describe('details redux reducer', () => {
   });
 
   describe('entitiesMapper', () => {
-    it(`should handle ${actionTypesProducts.RESET_PRODUCT_DETAILS_ENTITIES} action type`, () => {
+    it(`should handle ${productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES} action type`, () => {
       const state = {
         products: {
           [mockProductId]: { id: mockProductId },
@@ -181,7 +181,7 @@ describe('details redux reducer', () => {
       };
 
       expect(
-        entitiesMapper[actionTypesProducts.RESET_PRODUCT_DETAILS_ENTITIES](
+        entitiesMapper[productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES](
           state,
         ),
       ).toEqual(expectedResult);

--- a/packages/redux/src/products/reducer/__tests__/fittings.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/fittings.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockProductId } from 'tests/__fixtures__/products';
+import { productsActionTypes } from '../..';
 import reducer, { getError, getIsLoading, INITIAL_STATE } from '../fittings';
 
 const mockAction = { type: 'foo' };
@@ -27,7 +27,7 @@ describe('fittings redux reducer', () => {
       const expectedResult = { [mockProductId]: undefined };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_FITTINGS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_FITTINGS_REQUEST,
       });
 
       expect(state.error).toEqual(expectedResult);
@@ -37,7 +37,7 @@ describe('fittings redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error },
-        type: actionTypesProducts.FETCH_PRODUCT_FITTINGS_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_FITTINGS_FAILURE,
       });
 
       expect(state.error).toEqual(expectedError);
@@ -65,7 +65,7 @@ describe('fittings redux reducer', () => {
       };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_FITTINGS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_FITTINGS_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -78,7 +78,7 @@ describe('fittings redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error: '' },
-        type: actionTypesProducts.FETCH_PRODUCT_FITTINGS_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_FITTINGS_FAILURE,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -93,7 +93,7 @@ describe('fittings redux reducer', () => {
         payload: {
           result: mockProductId,
         },
-        type: actionTypesProducts.FETCH_PRODUCT_FITTINGS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_FITTINGS_SUCCESS,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);

--- a/packages/redux/src/products/reducer/__tests__/grouping.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/grouping.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockProductId } from 'tests/__fixtures__/products';
+import { productsActionTypes } from '../..';
 import reducer, { getError, getIsLoading, INITIAL_STATE } from '../grouping';
 
 const mockAction = { type: 'foo' };
@@ -27,7 +27,7 @@ describe('grouping redux reducer', () => {
       const expectedResult = { [mockProductId]: undefined };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_GROUPING_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_GROUPING_REQUEST,
       });
 
       expect(state.error).toEqual(expectedResult);
@@ -37,7 +37,7 @@ describe('grouping redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error },
-        type: actionTypesProducts.FETCH_PRODUCT_GROUPING_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_GROUPING_FAILURE,
       });
 
       expect(state.error).toEqual(expectedError);
@@ -66,7 +66,7 @@ describe('grouping redux reducer', () => {
       };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_GROUPING_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_GROUPING_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -79,7 +79,7 @@ describe('grouping redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error: '' },
-        type: actionTypesProducts.FETCH_PRODUCT_GROUPING_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_GROUPING_FAILURE,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -94,7 +94,7 @@ describe('grouping redux reducer', () => {
         payload: {
           result: mockProductId,
         },
-        type: actionTypesProducts.FETCH_PRODUCT_GROUPING_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_GROUPING_SUCCESS,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);

--- a/packages/redux/src/products/reducer/__tests__/lists.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/lists.test.ts
@@ -1,8 +1,8 @@
-import { actionTypesProducts } from '../..';
 import {
   mockProductId,
   mockProductsListHash,
 } from 'tests/__fixtures__/products';
+import { productsActionTypes } from '../..';
 import reducer, {
   entitiesMapper,
   getError,
@@ -25,7 +25,7 @@ describe('lists redux reducer', () => {
     it('should return the initial state', () => {
       expect(
         reducer(undefined, {
-          type: actionTypesProducts.RESET_PRODUCTS_LISTS_STATE,
+          type: productsActionTypes.RESET_PRODUCTS_LISTS_STATE,
         }),
       ).toEqual(initialState);
     });
@@ -47,7 +47,7 @@ describe('lists redux reducer', () => {
       const expectedResult = { [mockProductsListHash]: undefined };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
       });
 
       expect(state.error).toEqual(expectedResult);
@@ -57,7 +57,7 @@ describe('lists redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_FAILURE,
       });
 
       expect(state.error).toEqual(expectedError);
@@ -85,7 +85,7 @@ describe('lists redux reducer', () => {
     it('should handle SET_PRODUCTS_LIST_HASH action type', () => {
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.SET_PRODUCTS_LIST_HASH,
+        type: productsActionTypes.SET_PRODUCTS_LIST_HASH,
       });
 
       expect(state.hash).toBe(mockProductsListHash);
@@ -95,7 +95,7 @@ describe('lists redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error: {} },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_FAILURE,
       });
 
       expect(state.hash).toBe(initialState.hash);
@@ -123,7 +123,7 @@ describe('lists redux reducer', () => {
       const expectedIsHydrated = { [mockProductsListHash]: false };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.DEHYDRATE_PRODUCTS_LIST,
+        type: productsActionTypes.DEHYDRATE_PRODUCTS_LIST,
       });
 
       expect(state.isHydrated).toEqual(expectedIsHydrated);
@@ -152,7 +152,7 @@ describe('lists redux reducer', () => {
       const expectedIsLoading = { [mockProductsListHash]: true };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -163,7 +163,7 @@ describe('lists redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error: '' },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_FAILURE,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -174,7 +174,7 @@ describe('lists redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { result: { foo: 'bar' } },
-        type: actionTypesProducts.FETCH_PRODUCTS_LIST_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCTS_LIST_SUCCESS,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -193,7 +193,7 @@ describe('lists redux reducer', () => {
   });
 
   describe('entitiesMapper()', () => {
-    it(`should handle ${actionTypesProducts.RESET_PRODUCTS_LISTS_ENTITIES} action type`, () => {
+    it(`should handle ${productsActionTypes.RESET_PRODUCTS_LISTS_ENTITIES} action type`, () => {
       const state = {
         productsLists: {
           [mockProductsListHash]: { id: mockProductsListHash },
@@ -222,7 +222,7 @@ describe('lists redux reducer', () => {
       };
 
       expect(
-        entitiesMapper[actionTypesProducts.RESET_PRODUCTS_LISTS_ENTITIES](
+        entitiesMapper[productsActionTypes.RESET_PRODUCTS_LISTS_ENTITIES](
           state,
         ),
       ).toEqual(expectedResult);

--- a/packages/redux/src/products/reducer/__tests__/measurements.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/measurements.test.ts
@@ -1,8 +1,8 @@
-import { actionTypesProducts } from '../..';
 import {
   mockProductId,
   mockProductVariantsMeasurements,
 } from 'tests/__fixtures__/products';
+import { productsActionTypes } from '../..';
 import reducer, {
   entitiesMapper,
   getError,
@@ -36,7 +36,7 @@ describe('measurements redux reducer', () => {
       const expectedResult = { [mockProductId]: undefined };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_MEASUREMENTS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_MEASUREMENTS_REQUEST,
       });
 
       expect(state.error).toEqual(expectedResult);
@@ -46,7 +46,7 @@ describe('measurements redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error },
-        type: actionTypesProducts.FETCH_PRODUCT_MEASUREMENTS_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_MEASUREMENTS_FAILURE,
       });
 
       expect(state.error).toEqual(expectedError);
@@ -75,7 +75,7 @@ describe('measurements redux reducer', () => {
       };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_MEASUREMENTS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_MEASUREMENTS_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -88,7 +88,7 @@ describe('measurements redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error: '' },
-        type: actionTypesProducts.FETCH_PRODUCT_MEASUREMENTS_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_MEASUREMENTS_FAILURE,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -103,7 +103,7 @@ describe('measurements redux reducer', () => {
         payload: {
           result: mockProductId,
         },
-        type: actionTypesProducts.FETCH_PRODUCT_MEASUREMENTS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_MEASUREMENTS_SUCCESS,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -143,11 +143,11 @@ describe('measurements redux reducer', () => {
           entities: newMeasurements,
           result: mockProductId,
         },
-        type: actionTypesProducts.FETCH_PRODUCT_MEASUREMENTS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_MEASUREMENTS_SUCCESS,
       };
 
       expect(
-        entitiesMapper[actionTypesProducts.FETCH_PRODUCT_MEASUREMENTS_SUCCESS](
+        entitiesMapper[productsActionTypes.FETCH_PRODUCT_MEASUREMENTS_SUCCESS](
           state,
           action,
         ),

--- a/packages/redux/src/products/reducer/__tests__/recentlyViewed.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/recentlyViewed.test.ts
@@ -1,8 +1,8 @@
-import { actionTypesProducts } from '../..';
 import {
   expectedRecentlyViewedLocalPayload,
   expectedRecentlyViewedRemotePayload,
 } from 'tests/__fixtures__/products';
+import { productsActionTypes } from '../..';
 import reducer, {
   getError,
   getIsLoading,
@@ -29,9 +29,9 @@ describe('Recently Viewed reducer', () => {
       expect(state.error).toEqual(initialState.error);
     });
 
-    it(`should handle ${actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_FAILURE} action type`, () => {
+    it(`should handle ${productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_FAILURE} action type`, () => {
       const state = reducer(undefined, {
-        type: actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_FAILURE,
+        type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_FAILURE,
         payload: {
           error: expectedError,
         },
@@ -40,9 +40,9 @@ describe('Recently Viewed reducer', () => {
       expect(state.error).toEqual(expectedError);
     });
 
-    it(`should handle ${actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_FAILURE} action type`, () => {
+    it(`should handle ${productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_FAILURE} action type`, () => {
       const state = reducer(undefined, {
-        type: actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_FAILURE,
+        type: productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_FAILURE,
         payload: {
           error: expectedError,
         },
@@ -68,48 +68,48 @@ describe('Recently Viewed reducer', () => {
       expect(state.isLoading).toEqual(initialState.isLoading);
     });
 
-    it(`should handle ${actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_REQUEST} action type`, () => {
+    it(`should handle ${productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_REQUEST} action type`, () => {
       const expectedIsLoading = true;
       const state = reducer(undefined, {
-        type: actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_REQUEST,
+        type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
     });
 
-    it(`should handle ${actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_REQUEST} action type`, () => {
+    it(`should handle ${productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_REQUEST} action type`, () => {
       const expectedIsLoading = true;
       const state = reducer(undefined, {
-        type: actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_REQUEST,
+        type: productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
     });
 
-    it(`should handle ${actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS} action type`, () => {
+    it(`should handle ${productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS} action type`, () => {
       const expectedIsLoading = false;
       const state = reducer(undefined, {
-        type: actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
+        type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
         payload: expectedRecentlyViewedRemotePayload,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
     });
 
-    it(`should handle ${actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS} action type`, () => {
+    it(`should handle ${productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS} action type`, () => {
       const expectedIsLoading = false;
       const state = reducer(undefined, {
-        type: actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
+        type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
         payload: expectedRecentlyViewedRemotePayload,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
     });
 
-    it(`should handle ${actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_FAILURE} action type`, () => {
+    it(`should handle ${productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_FAILURE} action type`, () => {
       const expectedIsLoading = false;
       const state = reducer(undefined, {
-        type: actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_FAILURE,
+        type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_FAILURE,
         payload: {
           error: 'this is an error',
         },
@@ -118,10 +118,10 @@ describe('Recently Viewed reducer', () => {
       expect(state.isLoading).toEqual(expectedIsLoading);
     });
 
-    it(`should handle ${actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_FAILURE} action type`, () => {
+    it(`should handle ${productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_FAILURE} action type`, () => {
       const expectedIsLoading = false;
       const state = reducer(undefined, {
-        type: actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_FAILURE,
+        type: productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_FAILURE,
         payload: {
           error: 'this is an error',
         },
@@ -147,25 +147,25 @@ describe('Recently Viewed reducer', () => {
       expect(state.result).toEqual(initialState.result);
     });
 
-    it(`should handle ${actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS} action type`, () => {
+    it(`should handle ${productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS} action type`, () => {
       const state = reducer(undefined, {
-        type: actionTypesProducts.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
+        type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
         payload: expectedRecentlyViewedRemotePayload,
       });
 
       expect(state.result.remote).toEqual(expectedRecentlyViewedRemotePayload);
     });
 
-    it(`should handle ${actionTypesProducts.SAVE_RECENTLY_VIEWED_PRODUCT} action type`, () => {
+    it(`should handle ${productsActionTypes.SAVE_RECENTLY_VIEWED_PRODUCT} action type`, () => {
       const state = reducer(undefined, {
-        type: actionTypesProducts.SAVE_RECENTLY_VIEWED_PRODUCT,
+        type: productsActionTypes.SAVE_RECENTLY_VIEWED_PRODUCT,
         payload: expectedRecentlyViewedLocalPayload,
       });
 
       expect(state.result.computed).toEqual(expectedRecentlyViewedLocalPayload);
     });
 
-    it(`should handle ${actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_SUCCESS} action type`, () => {
+    it(`should handle ${productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_SUCCESS} action type`, () => {
       const state: State = {
         ...initialState,
         result: {
@@ -188,7 +188,7 @@ describe('Recently Viewed reducer', () => {
       expect(
         reducer(state, {
           meta: { productId },
-          type: actionTypesProducts.REMOVE_RECENTLY_VIEWED_PRODUCT_SUCCESS,
+          type: productsActionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_SUCCESS,
         }).result,
       ).toEqual(expectedResult);
     });

--- a/packages/redux/src/products/reducer/__tests__/sizeGuides.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/sizeGuides.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockProductId } from 'tests/__fixtures__/products';
+import { productsActionTypes } from '../..';
 import reducer, { getError, getIsLoading, INITIAL_STATE } from '../sizeGuides';
 
 const mockAction = { type: 'foo' };
@@ -27,7 +27,7 @@ describe('sizeGuides redux reducer', () => {
       const expectedResult = { [mockProductId]: undefined };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_SIZEGUIDES_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_SIZEGUIDES_REQUEST,
       });
 
       expect(state.error).toEqual(expectedResult);
@@ -37,7 +37,7 @@ describe('sizeGuides redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error },
-        type: actionTypesProducts.FETCH_PRODUCT_SIZEGUIDES_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_SIZEGUIDES_FAILURE,
       });
 
       expect(state.error).toEqual(expectedError);
@@ -66,7 +66,7 @@ describe('sizeGuides redux reducer', () => {
       };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_SIZEGUIDES_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_SIZEGUIDES_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -79,7 +79,7 @@ describe('sizeGuides redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error: '' },
-        type: actionTypesProducts.FETCH_PRODUCT_SIZEGUIDES_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_SIZEGUIDES_FAILURE,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -94,7 +94,7 @@ describe('sizeGuides redux reducer', () => {
         payload: {
           result: mockProductId,
         },
-        type: actionTypesProducts.FETCH_PRODUCT_SIZEGUIDES_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_SIZEGUIDES_SUCCESS,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);

--- a/packages/redux/src/products/reducer/__tests__/sizes.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/sizes.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockProductId } from 'tests/__fixtures__/products';
+import { productsActionTypes } from '../..';
 import reducer, { getError, getIsLoading, INITIAL_STATE } from '../sizes';
 
 const mockAction = { type: 'foo' };
@@ -27,7 +27,7 @@ describe('sizes redux reducer', () => {
       const expectedResult = { [mockProductId]: undefined };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_SIZES_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_SIZES_REQUEST,
       });
 
       expect(state.error).toEqual(expectedResult);
@@ -37,7 +37,7 @@ describe('sizes redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error },
-        type: actionTypesProducts.FETCH_PRODUCT_SIZES_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_SIZES_FAILURE,
       });
 
       expect(state.error).toEqual(expectedError);
@@ -66,7 +66,7 @@ describe('sizes redux reducer', () => {
       };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_SIZES_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_SIZES_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -79,7 +79,7 @@ describe('sizes redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error: '' },
-        type: actionTypesProducts.FETCH_PRODUCT_SIZES_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_SIZES_FAILURE,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -94,7 +94,7 @@ describe('sizes redux reducer', () => {
         payload: {
           result: mockProductId,
         },
-        type: actionTypesProducts.FETCH_PRODUCT_SIZES_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_SIZES_SUCCESS,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);

--- a/packages/redux/src/products/reducer/__tests__/variantsByMerchantsLocations.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/variantsByMerchantsLocations.test.ts
@@ -1,5 +1,5 @@
-import { actionTypesProducts } from '../..';
 import { mockProductId } from 'tests/__fixtures__/products';
+import { productsActionTypes } from '../..';
 import reducer, {
   getError,
   getIsLoading,
@@ -31,7 +31,7 @@ describe('variantsByMerchantsLocations redux reducer', () => {
       const expectedResult = { [mockProductId]: undefined };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST,
       });
 
       expect(state.error).toEqual(expectedResult);
@@ -41,7 +41,7 @@ describe('variantsByMerchantsLocations redux reducer', () => {
       const state = reducer(undefined, {
         meta: { productId: mockProductId },
         payload: { error },
-        type: actionTypesProducts.FETCH_PRODUCT_MERCHANTS_LOCATIONS_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_FAILURE,
       });
 
       expect(state.error).toEqual(expectedError);
@@ -70,7 +70,7 @@ describe('variantsByMerchantsLocations redux reducer', () => {
       };
       const state = reducer(undefined, {
         meta,
-        type: actionTypesProducts.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST,
+        type: productsActionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -83,7 +83,7 @@ describe('variantsByMerchantsLocations redux reducer', () => {
       const state = reducer(undefined, {
         meta,
         payload: { error: '' },
-        type: actionTypesProducts.FETCH_PRODUCT_MERCHANTS_LOCATIONS_FAILURE,
+        type: productsActionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_FAILURE,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);
@@ -98,7 +98,7 @@ describe('variantsByMerchantsLocations redux reducer', () => {
         payload: {
           result: mockProductId,
         },
-        type: actionTypesProducts.FETCH_PRODUCT_MERCHANTS_LOCATIONS_SUCCESS,
+        type: productsActionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_SUCCESS,
       });
 
       expect(state.isLoading).toEqual(expectedIsLoading);


### PR DESCRIPTION
## Description

- This fixes the naming of the `RESET_RECENTLY_VIEWED_PRODUCT` action
to `RESET_RECENTLY_VIEWED_PRODUCTS` which fixes a problem
with the reducer which was pointing to the plural name.
- Renamed exports from products folder to have the prefix of the area.

BREAKING CHANGE:

- The following exports were renamed:

```js
// Previously
import { actionTypesProducts, entitiesMapperProducts,
serverInitialStateProducts } from '@farfetch/blackout-redux';

// Now
import { productsActionTypes, productsEntitiesMapper,
productsServerInitialState } from '@farfetch/blackout-redux';
```

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
