### PR TITLE
feat(redux): add defaultCulture and defaultSubfolder keys on locale

### DIFF
--- a/packages/redux/src/contents/__tests__/reducer.test.ts
+++ b/packages/redux/src/contents/__tests__/reducer.test.ts
@@ -1,7 +1,7 @@
 import * as fromReducer from '../reducer';
 import {
-  actionTypesContent as actionTypes,
-  reducerContent as reducer,
+  contentsActionTypes as actionTypes,
+  contentsReducer as reducer,
 } from '..';
 import {
   contentTypesResult,

--- a/packages/redux/src/contents/__tests__/serverInitialState.test.ts
+++ b/packages/redux/src/contents/__tests__/serverInitialState.test.ts
@@ -2,7 +2,7 @@ import {
   expectedNormalizedPayload,
   mockModel,
 } from 'tests/__fixtures__/contents';
-import { serverInitialStateContent as serverInitialState } from '..';
+import { contentsServerInitialState as serverInitialState } from '..';
 
 describe('contents serverInitialState()', () => {
   it('should initialize server state for the contents', () => {

--- a/packages/redux/src/contents/actions/__tests__/fetchCommercePages.test.ts
+++ b/packages/redux/src/contents/actions/__tests__/fetchCommercePages.test.ts
@@ -1,5 +1,5 @@
 import * as normalizr from 'normalizr';
-import { actionTypesContent as actionTypes } from '../..';
+import { contentsActionTypes as actionTypes } from '../..';
 import {
   commercePagesQuery,
   expectedCommercePagesNormalizedPayload,

--- a/packages/redux/src/contents/actions/__tests__/fetchContent.test.ts
+++ b/packages/redux/src/contents/actions/__tests__/fetchContent.test.ts
@@ -1,5 +1,5 @@
 import * as normalizr from 'normalizr';
-import { actionTypesContent as actionTypes } from '../..';
+import { contentsActionTypes as actionTypes } from '../..';
 import {
   contentNormalizedPayload,
   contentQuery,

--- a/packages/redux/src/contents/actions/__tests__/fetchContentTypes.test.ts
+++ b/packages/redux/src/contents/actions/__tests__/fetchContentTypes.test.ts
@@ -1,4 +1,4 @@
-import { actionTypesContent as actionTypes } from '../..';
+import { contentsActionTypes as actionTypes } from '../..';
 import { contentTypesResult, types } from 'tests/__fixtures__/contents';
 import { fetchContentTypes } from '..';
 import { getContentTypes } from '@farfetch/blackout-client/contents';

--- a/packages/redux/src/contents/actions/__tests__/fetchSEO.test.ts
+++ b/packages/redux/src/contents/actions/__tests__/fetchSEO.test.ts
@@ -1,4 +1,4 @@
-import { actionTypesContent as actionTypes } from '../..';
+import { contentsActionTypes as actionTypes } from '../..';
 import { fetchSEO } from '..';
 import { getSEO } from '@farfetch/blackout-client/contents';
 import { INITIAL_STATE_CONTENT } from '../../reducer';

--- a/packages/redux/src/contents/actions/__tests__/resetContents.test.ts
+++ b/packages/redux/src/contents/actions/__tests__/resetContents.test.ts
@@ -1,4 +1,4 @@
-import { actionTypesContent as actionTypes } from '../..';
+import { contentsActionTypes as actionTypes } from '../..';
 import { mockStore } from '../../../../tests';
 import { resetContents } from '..';
 

--- a/packages/redux/src/contents/index.ts
+++ b/packages/redux/src/contents/index.ts
@@ -1,8 +1,8 @@
-import * as actionTypesContent from './actionTypes';
-import reducerContent from './reducer';
-import serverInitialStateContent from './serverInitialState';
+import * as contentsActionTypes from './actionTypes';
+import contentsReducer from './reducer';
+import contentsServerInitialState from './serverInitialState';
 
 export * from './actions';
 export * from './selectors';
 
-export { actionTypesContent, serverInitialStateContent, reducerContent };
+export { contentsActionTypes, contentsServerInitialState, contentsReducer };

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -2,6 +2,7 @@
  * Blackout Redux.
  */
 
+export * from './contents';
 export * from './locale';
 export * from './products';
 export * from './analytics';

--- a/packages/redux/src/locale/__tests__/reducer.test.ts
+++ b/packages/redux/src/locale/__tests__/reducer.test.ts
@@ -1,5 +1,5 @@
 import * as fromReducer from '../reducer';
-import { actionTypesLocale as actionTypes, reducerLocale as reducer } from '..';
+import { localeActionTypes as actionTypes, localeReducer as reducer } from '..';
 import { mockCountryCode } from 'tests/__fixtures__/locale';
 import type { State } from '../types';
 

--- a/packages/redux/src/locale/__tests__/selectors.test.ts
+++ b/packages/redux/src/locale/__tests__/selectors.test.ts
@@ -133,7 +133,7 @@ describe('locale redux selectors', () => {
 
   describe('getCountryCultureCode()', () => {
     it('should get the culture code', () => {
-      expect(selectors.getCountryCultureCode(mockState)).toEqual(
+      expect(selectors.getCountryCulture(mockState)).toEqual(
         mockCountry.cultures[0],
       );
     });
@@ -150,7 +150,7 @@ describe('locale redux selectors', () => {
   describe('getCountryStructure()', () => {
     it('should get the subfolder', () => {
       expect(selectors.getCountryStructure(mockState)).toEqual(
-        mockCountry.structure,
+        mockCountry.defaultSubfolder,
       );
     });
   });
@@ -159,6 +159,14 @@ describe('locale redux selectors', () => {
     it('should get the list of subfolders for a given country code', () => {
       expect(selectors.getCountryStructures(mockState)).toEqual(
         mockCountry.structures,
+      );
+    });
+  });
+
+  describe('getSourceCountryCode()', () => {
+    it('should get the source country code', () => {
+      expect(selectors.getSourceCountryCode(mockState)).toEqual(
+        mockCountry.sourceCountryCode,
       );
     });
   });

--- a/packages/redux/src/locale/__tests__/serverInitialState.test.ts
+++ b/packages/redux/src/locale/__tests__/serverInitialState.test.ts
@@ -1,5 +1,5 @@
 import { mockModel } from 'tests/__fixtures__/locale';
-import { serverInitialStateLocale as serverInitialState } from '..';
+import { localeServerInitialState as serverInitialState } from '..';
 
 describe('local serverInitialState()', () => {
   it('should initialize server state for the locale', () => {
@@ -9,6 +9,7 @@ describe('local serverInitialState()', () => {
     expect(state).toEqual({
       locale: {
         countryCode: 'US',
+        sourceCountryCode: 'PT',
       },
       entities: {
         countries: {
@@ -23,7 +24,8 @@ describe('local serverInitialState()', () => {
             ],
             code: 'US',
             newsletterSubscriptionOptionDefault: false,
-            structure: '/en-us',
+            defaultSubfolder: '/en-us',
+            defaultCulture: 'en-US',
           },
         },
       },
@@ -37,6 +39,7 @@ describe('local serverInitialState()', () => {
     expect(state).toEqual({
       locale: {
         countryCode: null,
+        sourceCountryCode: null,
         cities: {
           error: null,
           isLoading: false,

--- a/packages/redux/src/locale/actions/__tests__/__snapshots__/fetchCountries.test.ts.snap
+++ b/packages/redux/src/locale/actions/__tests__/__snapshots__/fetchCountries.test.ts.snap
@@ -19,11 +19,12 @@ Object {
             "name": "United States Dollar",
           },
         ],
+        "defaultCulture": "en-US",
+        "defaultSubfolder": "/en-us",
         "isCountryDefault": true,
         "isDefault": true,
         "newsletterSubscriptionOptionDefault": true,
         "platformId": 216,
-        "structure": "/en-us",
         "structures": Array [
           "/en-us",
         ],

--- a/packages/redux/src/locale/actions/__tests__/__snapshots__/fetchCountry.test.ts.snap
+++ b/packages/redux/src/locale/actions/__tests__/__snapshots__/fetchCountry.test.ts.snap
@@ -22,11 +22,12 @@ Object {
               "name": "United States Dollar",
             },
           ],
+          "defaultCulture": "en-US",
+          "defaultSubfolder": "/en-us",
           "isCountryDefault": true,
           "isDefault": true,
           "newsletterSubscriptionOptionDefault": true,
           "platformId": 216,
-          "structure": "/en-us",
           "structures": Array [
             "/en-us",
           ],

--- a/packages/redux/src/locale/actions/__tests__/fetchCountries.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/fetchCountries.test.ts
@@ -1,7 +1,7 @@
 import * as normalizr from 'normalizr';
 import {
-  actionTypesLocale as actionTypes,
-  reducerLocale as INITIAL_STATE_LOCALE,
+  localeActionTypes as actionTypes,
+  localeReducer as INITIAL_STATE_LOCALE,
 } from '../..';
 import { fetchCountries } from '..';
 import { getCountries } from '@farfetch/blackout-client/locale';

--- a/packages/redux/src/locale/actions/__tests__/fetchCountry.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/fetchCountry.test.ts
@@ -1,7 +1,7 @@
 import * as normalizr from 'normalizr';
 import {
-  actionTypesLocale as actionTypes,
-  reducerLocale as INITIAL_STATE,
+  localeActionTypes as actionTypes,
+  localeReducer as INITIAL_STATE,
 } from '../..';
 import { fetchCountry } from '..';
 import { getCountry } from '@farfetch/blackout-client/locale';

--- a/packages/redux/src/locale/actions/__tests__/fetchCountryCities.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/fetchCountryCities.test.ts
@@ -1,7 +1,7 @@
 import * as normalizr from 'normalizr';
 import {
-  actionTypesLocale as actionTypes,
-  reducerLocale as INITIAL_STATE,
+  localeActionTypes as actionTypes,
+  localeReducer as INITIAL_STATE,
 } from '../..';
 import { fetchCountryCities } from '..';
 import { getCountryCities } from '@farfetch/blackout-client/locale';

--- a/packages/redux/src/locale/actions/__tests__/fetchCountryCurrencies.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/fetchCountryCurrencies.test.ts
@@ -1,7 +1,7 @@
 import * as normalizr from 'normalizr';
 import {
-  actionTypesLocale as actionTypes,
-  reducerLocale as INITIAL_STATE,
+  localeActionTypes as actionTypes,
+  localeReducer as INITIAL_STATE,
 } from '../..';
 import { fetchCountryCurrencies } from '..';
 import { getCountryCurrencies } from '@farfetch/blackout-client/locale';

--- a/packages/redux/src/locale/actions/__tests__/fetchCountryStates.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/fetchCountryStates.test.ts
@@ -1,7 +1,7 @@
 import * as normalizr from 'normalizr';
 import {
-  actionTypesLocale as actionTypes,
-  reducerLocale as INITIAL_STATE,
+  localeActionTypes as actionTypes,
+  localeReducer as INITIAL_STATE,
 } from '../..';
 import { fetchCountryStates } from '..';
 import { getCountryStates } from '@farfetch/blackout-client/locale';

--- a/packages/redux/src/locale/actions/__tests__/resetLocaleState.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/resetLocaleState.test.ts
@@ -1,4 +1,4 @@
-import { actionTypesLocale as actionTypes } from '../..';
+import { localeActionTypes as actionTypes } from '../..';
 import { mockStore } from '../../../../tests';
 import { resetLocaleState } from '..';
 

--- a/packages/redux/src/locale/actions/__tests__/setCountryCode.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/setCountryCode.test.ts
@@ -1,4 +1,4 @@
-import { actionTypesLocale as actionTypes } from '../..';
+import { localeActionTypes as actionTypes } from '../..';
 import { mockCountryCode } from 'tests/__fixtures__/locale';
 import { mockStore } from '../../../../tests';
 import { setCountryCode } from '..';

--- a/packages/redux/src/locale/index.ts
+++ b/packages/redux/src/locale/index.ts
@@ -1,15 +1,15 @@
-import * as actionTypesLocale from './actionTypes';
-import * as middlewaresLocale from './middlewares';
-import reducerLocale from './reducer';
-import serverInitialStateLocale from './serverInitialState';
+import * as localeActionTypes from './actionTypes';
+import * as localeMiddlewares from './middlewares';
+import localeReducer from './reducer';
+import localeServerInitialState from './serverInitialState';
 
 export * from './actions';
 export * from './actions/factories';
 export * from './selectors';
 
 export {
-  actionTypesLocale,
-  middlewaresLocale,
-  serverInitialStateLocale,
-  reducerLocale,
+  localeActionTypes,
+  localeMiddlewares,
+  localeServerInitialState,
+  localeReducer,
 };

--- a/packages/redux/src/locale/middlewares/__tests__/setCountryCode.test.ts
+++ b/packages/redux/src/locale/middlewares/__tests__/setCountryCode.test.ts
@@ -16,6 +16,7 @@ const mockState = {
       [mockCountryCode]: {
         cultures: [mockCultureCode],
         currencies: [{ isoCode: mockCurrencyCode }],
+        defaultCulture: mockInitialCultureCode,
       },
     },
   },

--- a/packages/redux/src/locale/middlewares/setCountryCode.ts
+++ b/packages/redux/src/locale/middlewares/setCountryCode.ts
@@ -46,7 +46,7 @@ const setCountryCode = (customActionTypes?: Set<string>): Middleware => {
         const result = next(action);
         const state = getState();
         const countryCode = action.payload.countryCode;
-        const cultureCode = selectors.getCountryCultureCode(state, countryCode);
+        const cultureCode = selectors.getCountryCulture(state, countryCode);
         const currencyCode = selectors.getCountryCurrencyCode(
           state,
           countryCode,

--- a/packages/redux/src/locale/reducer.ts
+++ b/packages/redux/src/locale/reducer.ts
@@ -13,6 +13,7 @@ import type {
 
 export const INITIAL_STATE_LOCALE: State = {
   countryCode: null,
+  sourceCountryCode: null,
   cities: {
     error: null,
     isLoading: false,
@@ -168,6 +169,9 @@ export const getCountriesError = (state: State): State['countries']['error'] =>
   state.countries.error;
 export const getCountryCode = (state: State): State['countryCode'] =>
   state.countryCode;
+export const getSourceCountryCode = (
+  state: State,
+): State['sourceCountryCode'] => state.sourceCountryCode;
 export const getCountryCurrenciesError = (
   state: State,
 ): State['currencies']['error'] => state.currencies.error;

--- a/packages/redux/src/locale/selectors.ts
+++ b/packages/redux/src/locale/selectors.ts
@@ -12,6 +12,7 @@ import {
   getCountryCode as getCountryCodeFromReducer,
   getCountryCurrenciesError as getCountryCurrenciesErrorFromReducer,
   getCountryStatesError as getCountryStatesErrorFromReducer,
+  getSourceCountryCode as getSourceCountryCodeFromReducer,
 } from './reducer';
 import { getCity, getCountry, getState } from '../entities/selectors';
 import get from 'lodash/get';
@@ -75,10 +76,10 @@ export const getCountryCurrencyCode = (
  *
  * @example
  * ```
- * import { getCountryCultureCode } from '@farfetch/blackout-redux/locale';
+ * import { getCountryCulture } from '@farfetch/blackout-redux/locale';
  *
  * const mapStateToProps = state => ({
- *     activeCultureCode: getCountryCultureCode(state)
+ *     activeCultureCode: getCountryCulture(state)
  * });
  * ```
  *
@@ -87,13 +88,40 @@ export const getCountryCurrencyCode = (
  *
  * @returns - The culture code for the countryCode received.
  */
-export const getCountryCultureCode = (
+export const getCountryCulture = (
   state: StoreState,
   countryCode: string | null = getCountryCode(state),
 ): string => {
   const country = countryCode && getCountry(state, countryCode);
 
-  return get(country, 'cultures[0]');
+  return get(country, 'defaultCulture');
+};
+
+/**
+ * Returns the culture list for the given countryCode. By default, returns the
+ * culture of the current country.
+ *
+ * @example
+ * ```
+ * import { getCountryCultures } from '@farfetch/blackout-redux/locale';
+ *
+ * const mapStateToProps = state => ({
+ *     activeCultureCode: getCountryCulture(state)
+ * });
+ * ```
+ *
+ * @param state       - Application state.
+ * @param countryCode - The country code to find a specific country.
+ *
+ * @returns - The list of cultures for the countryCode received.
+ */
+export const getCountryCultures = (
+  state: StoreState,
+  countryCode: string | null = getCountryCode(state),
+): string => {
+  const country = countryCode && getCountry(state, countryCode);
+
+  return get(country, 'cultures');
 };
 
 /**
@@ -120,7 +148,7 @@ export const getCountryStructure = (
 ): string => {
   const country = countryCode && getCountry(state, countryCode);
 
-  return get(country, 'structure');
+  return get(country, 'defaultSubfolder');
 };
 
 /**
@@ -149,6 +177,26 @@ export const getCountryStructures = (
 
   return get(country, 'structures');
 };
+
+/**
+ * Returns the current source country code.
+ *
+ * @example
+ * ```
+ * import { getSourceCountryCode } from '@farfetch/blackout-redux/locale';
+ *
+ * const mapStateToProps = state => ({
+ *     sourceCountryCode: getSourceCountryCode(state)
+ * });
+ * ```
+ *
+ * @param state - Application state.
+ *
+ * @returns - The current source country code used on the app.
+ */
+export const getSourceCountryCode = (
+  state: StoreState,
+): State['sourceCountryCode'] => getSourceCountryCodeFromReducer(state.locale);
 
 /**
  * Returns the country cities error.

--- a/packages/redux/src/locale/serverInitialState.ts
+++ b/packages/redux/src/locale/serverInitialState.ts
@@ -12,7 +12,11 @@ import type { ServerInitialState } from './types';
  *
  * @returns - Initial state for the locale reducer.
  */
-export default ({ model }: { model: Model }): ServerInitialState => {
+const serverInitialState = ({
+  model,
+}: {
+  model: Model;
+}): ServerInitialState => {
   if (isEmpty(model)) {
     return { locale: INITIAL_STATE_LOCALE };
   }
@@ -24,7 +28,9 @@ export default ({ model }: { model: Model }): ServerInitialState => {
     currencyCode,
     currencyCultureCode,
     newsletterSubscriptionOptionDefault,
-    subfolder,
+    sourceCountryCode,
+    defaultCulture,
+    defaultSubfolder,
   } = model;
   // Normalize it
   const { entities } = normalize(
@@ -39,7 +45,8 @@ export default ({ model }: { model: Model }): ServerInitialState => {
       ],
       newsletterSubscriptionOptionDefault,
       platformId: countryId,
-      structure: subfolder,
+      defaultCulture,
+      defaultSubfolder,
     },
     country,
   );
@@ -47,7 +54,10 @@ export default ({ model }: { model: Model }): ServerInitialState => {
   return {
     locale: {
       countryCode,
+      sourceCountryCode,
     },
     entities,
   };
 };
+
+export default serverInitialState;

--- a/packages/redux/src/locale/types/reducer.types.ts
+++ b/packages/redux/src/locale/types/reducer.types.ts
@@ -3,6 +3,7 @@ import type { CombinedState } from 'redux';
 
 export type State = CombinedState<{
   countryCode: string | null;
+  sourceCountryCode: string | null;
   cities: {
     error: BlackoutError | null;
     isLoading: boolean;

--- a/packages/redux/src/locale/types/serverInitialState.types.ts
+++ b/packages/redux/src/locale/types/serverInitialState.types.ts
@@ -12,5 +12,6 @@ export type ServerInitialState = {
   }>;
   locale: {
     countryCode: string | null;
+    sourceCountryCode: string | null;
   };
 };

--- a/packages/redux/src/types/model.types.ts
+++ b/packages/redux/src/types/model.types.ts
@@ -13,6 +13,9 @@ type Common = {
   currencyCultureCode: string;
   designers: Designers;
   newsletterSubscriptionOptionDefault: boolean;
+  sourceCountryCode: string;
+  defaultCulture: string;
+  defaultSubfolder: string;
   pageType: string;
   searchContentRequests: [
     {

--- a/tests/__fixtures__/locale/locale.fixtures.ts
+++ b/tests/__fixtures__/locale/locale.fixtures.ts
@@ -13,12 +13,13 @@ export const mockCurrencies = [
 
 export const mockCountry = {
   code: 'US',
-  structure: '/en-us',
   platformId: 216,
   cultures: ['en-US'],
   isDefault: true,
   newsletterSubscriptionOptionDefault: true,
   isCountryDefault: true,
+  defaultCulture: 'en-US',
+  defaultSubfolder: '/en-us',
   continentId: 5,
   currencies: mockCurrencies,
   structures: ['/en-us'],
@@ -85,4 +86,7 @@ export const mockModel = {
   countryId: 216,
   cultureCode: 'en-US',
   newsletterSubscriptionOptionDefault: false,
+  defaultCulture: 'en-US',
+  defaultSubfolder: '/en-us',
+  sourceCountryCode: 'PT',
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,5 @@
 {
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    "packages/client/src/siteFeatures/client/index.js",
-    "packages/client/src/siteFeatures/client/getSiteFeatures.js",
-    "packages/client/src/siteFeatures/client/__fixtures__/getSiteFeatures.fixtures.js"
-  ],
+  "include": ["**/*.ts", "**/*.tsx"],
   "extends": "./configs/typescript/tsconfig.basic.json",
   "compilerOptions": {
     "skipLibCheck": true,


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->
- created getCountryCultures


<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->
BREAKING CHANGES:
- renamed getCountryCultureCode to getCountryCulture
- changed types
- removed key structure from serverInitialState
- renamed exports to 'content*'. An example: actionTypesContent to contentActionTypes
- renamed exports to 'locale*'. An example: middlewaresLocale to localeMiddlewares

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [ ] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
