### PR TITLE
fix(blackout-redux): set customActionTypes as optional

### DIFF
--- a/packages/redux/src/locale/middlewares/setCountryCode.ts
+++ b/packages/redux/src/locale/middlewares/setCountryCode.ts
@@ -12,7 +12,7 @@ const DEFAULT_ACTION_TYPES = new Set([actionTypes.SET_COUNTRY_CODE]);
  *
  * @returns Set of action types to apply.
  */
-const getActionTypes = (actionTypes: Set<string>): Set<string> => {
+const getActionTypes = (actionTypes?: Set<string>): Set<string> => {
   if (actionTypes) {
     if (actionTypes instanceof Set) {
       return actionTypes;
@@ -34,7 +34,7 @@ const getActionTypes = (actionTypes: Set<string>): Set<string> => {
  *
  * @returns Redux middleware.
  */
-const setCountryCode = (customActionTypes: Set<string>): Middleware => {
+const setCountryCode = (customActionTypes?: Set<string>): Middleware => {
   const actionTypes = getActionTypes(customActionTypes);
 
   return ({ getState }: MiddlewareAPI) =>


### PR DESCRIPTION
## Description

Set customActionTypes argument in setCountryCode as optional.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
