### PR TITLE
feat: add `addBagItem` to `useBag`

### DIFF
--- a/packages/client/src/bags/__tests__/patchBagItem.test.ts
+++ b/packages/client/src/bags/__tests__/patchBagItem.test.ts
@@ -1,7 +1,7 @@
 import {
   mockBagId,
+  mockBagItemData,
   mockBagItemId,
-  mockData,
   mockResponse,
 } from 'tests/__fixtures__/bags';
 import { patchBagItem } from '../';
@@ -21,12 +21,12 @@ describe('patchBagItem', () => {
     expect.assertions(2);
 
     await expect(
-      patchBagItem(mockBagId, mockBagItemId, mockData),
+      patchBagItem(mockBagId, mockBagItemId, mockBagItemData),
     ).resolves.toEqual(mockResponse);
 
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/bags/${mockBagId}/items/${mockBagItemId}`,
-      mockData,
+      mockBagItemData,
       expectedConfig,
     );
   });
@@ -37,12 +37,12 @@ describe('patchBagItem', () => {
     expect.assertions(2);
 
     await expect(
-      patchBagItem(mockBagId, mockBagItemId, mockData),
+      patchBagItem(mockBagId, mockBagItemId, mockBagItemData),
     ).rejects.toMatchSnapshot();
 
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/bags/${mockBagId}/items/${mockBagItemId}`,
-      mockData,
+      mockBagItemData,
       expectedConfig,
     );
   });

--- a/packages/client/src/bags/__tests__/postBagItem.test.ts
+++ b/packages/client/src/bags/__tests__/postBagItem.test.ts
@@ -1,4 +1,8 @@
-import { mockBagId, mockData, mockResponse } from 'tests/__fixtures__/bags';
+import {
+  mockBagId,
+  mockBagItemData,
+  mockResponse,
+} from 'tests/__fixtures__/bags';
 import { postBagItem } from '../';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/postBagItem.fixtures';
@@ -15,13 +19,13 @@ describe('postBagItem', () => {
 
     expect.assertions(2);
 
-    await expect(postBagItem(mockBagId, mockData)).resolves.toEqual(
+    await expect(postBagItem(mockBagId, mockBagItemData)).resolves.toEqual(
       mockResponse,
     );
 
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/bags/${mockBagId}/items`,
-      mockData,
+      mockBagItemData,
       expectedConfig,
     );
   });
@@ -31,11 +35,13 @@ describe('postBagItem', () => {
 
     expect.assertions(2);
 
-    await expect(postBagItem(mockBagId, mockData)).rejects.toMatchSnapshot();
+    await expect(
+      postBagItem(mockBagId, mockBagItemData),
+    ).rejects.toMatchSnapshot();
 
     expect(spy).toHaveBeenCalledWith(
       `/commerce/v1/bags/${mockBagId}/items`,
-      mockData,
+      mockBagItemData,
       expectedConfig,
     );
   });

--- a/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, renderHook } from '@testing-library/react';
 import {
   mockBagId,
+  mockData,
   mockInitialState,
   mockLoadingState,
   mockState,
@@ -12,6 +13,7 @@ import useBag from '../useBag';
 
 jest.mock('@farfetch/blackout-redux/bags', () => ({
   ...jest.requireActual('@farfetch/blackout-redux/bags'),
+  addBagItem: jest.fn(() => ({ type: 'add-bag-item' })),
   fetchBag: jest.fn(() => ({ type: 'fetch' })),
   resetBag: jest.fn(() => ({ type: 'reset' })),
   resetBagState: jest.fn(() => ({ type: 'resetState' })),
@@ -44,6 +46,7 @@ describe('useBag', () => {
     expect(current).toStrictEqual({
       bag: expect.any(Object),
       error: expect.any(Object),
+      addBagItem: expect.any(Function),
       fetchBag: expect.any(Function),
       id: expect.any(String),
       isEmpty: expect.any(Boolean),
@@ -75,6 +78,14 @@ describe('useBag', () => {
   });
 
   describe('actions', () => {
+    it('should call `addBagItem` action', () => {
+      const { addBagItem } = getRenderedHook();
+
+      addBagItem(mockData);
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'add-bag-item' });
+    });
+
     it('should call `fetchBag` action', () => {
       const { fetchBag } = getRenderedHook();
 

--- a/packages/react/src/bags/hooks/__tests__/useBagItem.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useBagItem.test.tsx
@@ -45,7 +45,6 @@ describe('useBagItem', () => {
     const current = getRenderedHook();
 
     expect(current).toStrictEqual({
-      addBagItem: expect.any(Function),
       bagItem: expect.any(Object),
       deleteBagItem: expect.any(Function),
       error: undefined,
@@ -74,14 +73,6 @@ describe('useBagItem', () => {
 
   describe('actions', () => {
     const mockData = {};
-
-    it('should call `add` action', () => {
-      const { addBagItem } = getRenderedHook();
-
-      addBagItem(mockData);
-
-      expect(mockDispatch).toHaveBeenCalledWith({ type: 'add' });
-    });
 
     it('should call `delete` action', () => {
       const { deleteBagItem } = getRenderedHook();

--- a/packages/react/src/bags/hooks/types/useBag.ts
+++ b/packages/react/src/bags/hooks/types/useBag.ts
@@ -1,4 +1,8 @@
-import type { Bag, Query } from '@farfetch/blackout-client/src/bags/types';
+import type {
+  Bag,
+  PostBagItemData,
+  Query,
+} from '@farfetch/blackout-client/src/bags/types';
 import type { BagItemHydrated } from '@farfetch/blackout-redux/src/entities/types';
 import type { ProductTypeEnum } from '@farfetch/blackout-client/products/types';
 import type { State } from '@farfetch/blackout-redux/src/bags/types';
@@ -6,6 +10,11 @@ import type { State } from '@farfetch/blackout-redux/src/bags/types';
 export type UseBag = (excludeProductTypes?: ProductTypeEnum[]) => {
   bag: State['result'];
   error: State['error'] | undefined;
+  addBagItem: (
+    data: PostBagItemData,
+    query?: Query,
+    config?: Record<string, unknown>,
+  ) => Promise<Bag>;
   fetchBag: (
     bagId: string,
     query?: Query,

--- a/packages/react/src/bags/hooks/types/useBagItem.ts
+++ b/packages/react/src/bags/hooks/types/useBagItem.ts
@@ -1,7 +1,6 @@
 import type {
   Bag,
   PatchBagItemData,
-  PostBagItemData,
   Query,
 } from '@farfetch/blackout-client/bags/types';
 import type { BagItemHydrated } from '@farfetch/blackout-redux/entities/types';
@@ -20,11 +19,6 @@ export type HandleFullUpdateType = (
 export type HandleDeleteBagItemType = (from?: string) => void;
 
 export type UseBagItem = (bagItemId: number) => {
-  addBagItem: (
-    data: PostBagItemData,
-    query?: Query,
-    config?: Record<string, unknown>,
-  ) => Promise<Bag>;
   deleteBagItem: (
     bagItemId: number,
     data?: PatchBagItemData,

--- a/packages/react/src/bags/hooks/useBag.ts
+++ b/packages/react/src/bags/hooks/useBag.ts
@@ -2,6 +2,7 @@
  * Hook to provide all kinds of data for the business logic attached to the bag.
  */
 import {
+  addBagItem as addBagItemAction,
   fetchBag as fetchBagAction,
   getBag,
   getBagError,
@@ -47,6 +48,7 @@ const useBag: UseBag = excludeProductTypes => {
   const isEmpty = items?.length === 0;
   const isLoading = (!bag && !error) || isBagLoading;
   // Actions
+  const addBagItem = useAction(addBagItemAction);
   const fetchBag = useAction(fetchBagAction);
   const resetBag = useAction(resetBagAction);
   const resetBagState = useAction(resetBagStateAction);
@@ -60,6 +62,10 @@ const useBag: UseBag = excludeProductTypes => {
      * Bag error.
      */
     error,
+    /**
+     * Add item to bag.
+     */
+    addBagItem,
     /**
      * Fetches the bag.
      */

--- a/packages/react/src/bags/hooks/useBagItem.ts
+++ b/packages/react/src/bags/hooks/useBagItem.ts
@@ -269,10 +269,6 @@ const useBagItem: UseBagItem = bagItemId => {
 
   return {
     /**
-     * Adds a specific product to the bag.
-     */
-    addBagItem,
-    /**
      * Deletes a specific item from the bag.
      */
     deleteBagItem,

--- a/packages/redux/src/bags/actions/__tests__/__snapshots__/addBagItem.test.ts.snap
+++ b/packages/redux/src/bags/actions/__tests__/__snapshots__/addBagItem.test.ts.snap
@@ -4,17 +4,11 @@ exports[`addBagItem() action creator should create the correct actions for when 
 Object {
   "meta": Object {
     "bagId": "7894746",
-    "merchant": Object {
-      "id": 1,
-    },
-    "product": Object {
-      "id": 1,
-    },
-    "quantity": 1,
-    "scale": "1",
-    "size": Object {
-      "id": 1,
-    },
+    "merchantId": 4,
+    "productId": 1,
+    "quantity": 99,
+    "scale": 3,
+    "size": 2,
   },
   "payload": Object {
     "entities": Object {
@@ -215,17 +209,11 @@ exports[`addBagItem() action creator should create the correct actions for when 
 Object {
   "meta": Object {
     "bagId": "7894746",
-    "merchant": Object {
-      "id": 1,
-    },
-    "product": Object {
-      "id": 1,
-    },
-    "quantity": 1,
-    "scale": "1",
-    "size": Object {
-      "id": 1,
-    },
+    "merchantId": 4,
+    "productId": 1,
+    "quantity": 99,
+    "scale": 3,
+    "size": 2,
   },
   "payload": Object {
     "entities": Object {

--- a/packages/redux/src/bags/actions/__tests__/__snapshots__/updateBagItem.test.ts.snap
+++ b/packages/redux/src/bags/actions/__tests__/__snapshots__/updateBagItem.test.ts.snap
@@ -5,17 +5,11 @@ Object {
   "meta": Object {
     "bagId": "7894746",
     "bagItemId": 134,
-    "merchant": Object {
-      "id": 1,
-    },
-    "product": Object {
-      "id": 1,
-    },
-    "quantity": 1,
-    "scale": "1",
-    "size": Object {
-      "id": 1,
-    },
+    "merchantId": 4,
+    "productId": 1,
+    "quantity": 99,
+    "scale": 3,
+    "size": 2,
   },
   "payload": Object {
     "entities": Object {
@@ -217,17 +211,11 @@ Object {
   "meta": Object {
     "bagId": "7894746",
     "bagItemId": 134,
-    "merchant": Object {
-      "id": 1,
-    },
-    "product": Object {
-      "id": 1,
-    },
-    "quantity": 1,
-    "scale": "1",
-    "size": Object {
-      "id": 1,
-    },
+    "merchantId": 4,
+    "productId": 1,
+    "quantity": 99,
+    "scale": 3,
+    "size": 2,
   },
   "payload": Object {
     "entities": Object {

--- a/packages/redux/src/bags/actions/__tests__/addBagItem.test.ts
+++ b/packages/redux/src/bags/actions/__tests__/addBagItem.test.ts
@@ -3,7 +3,7 @@ import { addBagItem } from '..';
 import { INITIAL_STATE } from '../../reducer';
 import {
   mockBagId,
-  mockData,
+  mockBagItemData,
   mockNormalizedPayload,
   mockResponse,
   mockState,
@@ -38,7 +38,7 @@ describe('addBagItem() action creator', () => {
     store = bagMockStore({ bag: { id: null } });
     expect.assertions(2);
 
-    await store.dispatch(addBagItem(mockData)).catch(error => {
+    await store.dispatch(addBagItem(mockBagItemData)).catch(error => {
       expect(error).toMatchSnapshot();
       expect(store.getActions()).toHaveLength(1);
     });
@@ -52,12 +52,12 @@ describe('addBagItem() action creator', () => {
 
     expect.assertions(4);
 
-    await store.dispatch(addBagItem(mockData)).catch(error => {
+    await store.dispatch(addBagItem(mockBagItemData)).catch(error => {
       expect(error).toBe(expectedError);
       expect(postBagItem).toHaveBeenCalledTimes(1);
       expect(postBagItem).toHaveBeenCalledWith(
         mockBagId,
-        mockData,
+        mockBagItemData,
         expectedQuery,
         expectedConfig,
       );
@@ -65,14 +65,14 @@ describe('addBagItem() action creator', () => {
         {
           type: actionTypes.ADD_BAG_ITEM_REQUEST,
           meta: {
-            ...mockData,
+            ...mockBagItemData,
             bagId: mockBagId,
           },
         },
         {
           payload: { error: expectedError },
           meta: {
-            ...mockData,
+            ...mockBagItemData,
             bagId: mockBagId,
           },
           type: actionTypes.ADD_BAG_ITEM_FAILURE,
@@ -87,7 +87,7 @@ describe('addBagItem() action creator', () => {
 
     expect.assertions(5);
 
-    await store.dispatch(addBagItem(mockData)).then(clientResult => {
+    await store.dispatch(addBagItem(mockBagItemData)).then(clientResult => {
       expect(clientResult).toBe(mockResponse);
     });
 
@@ -96,7 +96,7 @@ describe('addBagItem() action creator', () => {
     expect(postBagItem).toHaveBeenCalledTimes(1);
     expect(postBagItem).toHaveBeenCalledWith(
       mockBagId,
-      mockData,
+      mockBagItemData,
       expectedQuery,
       expectedConfig,
     );
@@ -104,7 +104,7 @@ describe('addBagItem() action creator', () => {
       {
         type: actionTypes.ADD_BAG_ITEM_REQUEST,
         meta: {
-          ...mockData,
+          ...mockBagItemData,
           bagId: mockBagId,
         },
       },
@@ -112,7 +112,7 @@ describe('addBagItem() action creator', () => {
         payload: mockNormalizedPayload,
         type: actionTypes.ADD_BAG_ITEM_SUCCESS,
         meta: {
-          ...mockData,
+          ...mockBagItemData,
           bagId: mockBagId,
         },
       },
@@ -130,7 +130,7 @@ describe('addBagItem() action creator', () => {
 
     expect.assertions(5);
 
-    await store.dispatch(addBagItem(mockData)).then(clientResult => {
+    await store.dispatch(addBagItem(mockBagItemData)).then(clientResult => {
       expect(clientResult).toBe(mockResponse);
     });
 
@@ -139,7 +139,7 @@ describe('addBagItem() action creator', () => {
     expect(postBagItem).toHaveBeenCalledTimes(1);
     expect(postBagItem).toHaveBeenCalledWith(
       mockBagId,
-      mockData,
+      mockBagItemData,
       expectedQuery,
       expectedConfig,
     );
@@ -147,7 +147,7 @@ describe('addBagItem() action creator', () => {
       {
         type: actionTypes.ADD_BAG_ITEM_REQUEST,
         meta: {
-          ...mockData,
+          ...mockBagItemData,
           bagId: mockBagId,
         },
       },
@@ -155,7 +155,7 @@ describe('addBagItem() action creator', () => {
         payload: mockNormalizedPayload,
         type: actionTypes.ADD_BAG_ITEM_SUCCESS,
         meta: {
-          ...mockData,
+          ...mockBagItemData,
           bagId: mockBagId,
         },
       },

--- a/packages/redux/src/bags/actions/__tests__/updateBagItem.test.ts
+++ b/packages/redux/src/bags/actions/__tests__/updateBagItem.test.ts
@@ -2,8 +2,8 @@ import { actionTypes } from '../..';
 import { INITIAL_STATE } from '../../reducer';
 import {
   mockBagId,
+  mockBagItemData,
   mockBagItemId,
-  mockData,
   mockNormalizedPayload,
   mockResponse,
   mockState,
@@ -46,14 +46,14 @@ describe('updateBagItem() action creator', () => {
     expect.assertions(4);
 
     await store
-      .dispatch(updateBagItem(mockBagItemId, mockData))
+      .dispatch(updateBagItem(mockBagItemId, mockBagItemData))
       .catch(error => {
         expect(error).toBe(expectedError);
         expect(patchBagItem).toHaveBeenCalledTimes(1);
         expect(patchBagItem).toHaveBeenCalledWith(
           mockBagId,
           mockBagItemId,
-          mockData,
+          mockBagItemData,
           expectedQuery,
           expectedConfig,
         );
@@ -61,7 +61,7 @@ describe('updateBagItem() action creator', () => {
           expect.arrayContaining([
             {
               meta: {
-                ...mockData,
+                ...mockBagItemData,
                 bagId: mockBagId,
                 bagItemId: mockBagItemId,
               },
@@ -72,7 +72,7 @@ describe('updateBagItem() action creator', () => {
                 error: expectedError,
               },
               meta: {
-                ...mockData,
+                ...mockBagItemData,
                 bagId: mockBagId,
                 bagItemId: mockBagItemId,
               },
@@ -89,7 +89,7 @@ describe('updateBagItem() action creator', () => {
     expect.assertions(5);
 
     await store
-      .dispatch(updateBagItem(mockBagItemId, mockData))
+      .dispatch(updateBagItem(mockBagItemId, mockBagItemData))
       .then(clientResult => {
         expect(clientResult).toBe(mockResponse);
       });
@@ -100,7 +100,7 @@ describe('updateBagItem() action creator', () => {
     expect(patchBagItem).toHaveBeenCalledWith(
       mockBagId,
       mockBagItemId,
-      mockData,
+      mockBagItemData,
       expectedQuery,
       expectedConfig,
     );
@@ -110,7 +110,7 @@ describe('updateBagItem() action creator', () => {
         payload: mockNormalizedPayload,
         type: actionTypes.UPDATE_BAG_ITEM_SUCCESS,
         meta: {
-          ...mockData,
+          ...mockBagItemData,
           bagId: mockBagId,
           bagItemId: mockBagItemId,
         },
@@ -131,7 +131,7 @@ describe('updateBagItem() action creator', () => {
     expect.assertions(5);
 
     await store
-      .dispatch(updateBagItem(mockBagItemId, mockData))
+      .dispatch(updateBagItem(mockBagItemId, mockBagItemData))
       .then(clientResult => {
         expect(clientResult).toBe(mockResponse);
       });
@@ -142,7 +142,7 @@ describe('updateBagItem() action creator', () => {
     expect(patchBagItem).toHaveBeenCalledWith(
       mockBagId,
       mockBagItemId,
-      mockData,
+      mockBagItemData,
       expectedQuery,
       expectedConfig,
     );
@@ -152,7 +152,7 @@ describe('updateBagItem() action creator', () => {
         payload: mockNormalizedPayload,
         type: actionTypes.UPDATE_BAG_ITEM_SUCCESS,
         meta: {
-          ...mockData,
+          ...mockBagItemData,
           bagId: mockBagId,
           bagItemId: mockBagItemId,
         },

--- a/tests/__fixtures__/bags/bag.fixtures.ts
+++ b/tests/__fixtures__/bags/bag.fixtures.ts
@@ -11,12 +11,12 @@ export const mockError = {
   message: 'Unexpected Error',
 };
 
-export const mockData = {
-  merchant: { id: 1 },
-  product: { id: 1 },
-  size: { id: 1 },
-  scale: '1',
-  quantity: 1,
+export const mockBagItemData = {
+  productId: 1,
+  size: 2,
+  scale: 3,
+  merchantId: 4,
+  quantity: 99,
 };
 
 export const mockInitialState = {


### PR DESCRIPTION
## Description
This adds the `addBagItem` action to the `useBag` hook.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
