### PR TITLE
fix(redux): merge entities and run duplicate keys

### DIFF
--- a/packages/redux/src/entities/reducer/__tests__/entitiesMapper.test.ts
+++ b/packages/redux/src/entities/reducer/__tests__/entitiesMapper.test.ts
@@ -1,0 +1,23 @@
+import { EntityMapper, mergeEntitiesMapper } from '../entitiesMapper';
+
+describe('entitiesMapper', () => {
+  it('should return the correct result for mergeEntitiesMapper when receiving duplicated action keys', () => {
+    const state = {};
+    const action = { type: 'actionTypeName' };
+    const firstSpy = jest.fn();
+    const secondSpy = jest.fn();
+    const entitiesMappers: EntityMapper[] = [
+      {
+        actionTypeName: (state, action) => firstSpy(state, action),
+      },
+      {
+        actionTypeName: (state, action) => secondSpy(state, action),
+      },
+    ];
+    const mergedEntitiesMapper = mergeEntitiesMapper(entitiesMappers);
+    mergedEntitiesMapper['actionTypeName']?.(state, action);
+
+    expect(firstSpy).toBeCalled();
+    expect(secondSpy).toBeCalled();
+  });
+});

--- a/packages/redux/src/returns/__tests__/reducer.test.ts
+++ b/packages/redux/src/returns/__tests__/reducer.test.ts
@@ -289,13 +289,12 @@ describe('returns reducer', () => {
       ).toEqual(state);
     });
 
-    it('should handle LOGOUT_SUCCESS', () => {
-      expect(
-        entitiesMapper[LOGOUT_SUCCESS as keyof typeof entitiesMapper](state, {
-          meta: { resetEntities: false },
-          type: LOGOUT_SUCCESS,
-        }),
-      ).toEqual(state);
+    it('should handle LOGOUT_SUCCESS action type', () => {
+      const { returns, returnItems, ...rest } = state;
+
+      expect(fromReducer.entitiesMapper[LOGOUT_SUCCESS](state)).toEqual({
+        ...rest,
+      });
     });
   });
 

--- a/packages/redux/src/returns/reducer.ts
+++ b/packages/redux/src/returns/reducer.ts
@@ -164,19 +164,12 @@ export const entitiesMapper = {
 
     return state;
   },
-  [LOGOUT_SUCCESS]: (state, action) => {
-    const {
-      meta: { resetEntities },
-    } = action;
+  [LOGOUT_SUCCESS]: (state: State) => {
     const { returns, returnItems, ...rest } = state;
 
-    if (resetEntities) {
-      return {
-        ...rest,
-      };
-    }
-
-    return state;
+    return {
+      ...rest,
+    };
   },
 };
 


### PR DESCRIPTION
## Description

- Merge entities mappers without removing duplicated keys.
When calling LOGOUT_SUCCESS it will correctly clear all entities with that action.

BREAKING CHANGE:

- entitiesMapper signature has changed. Now it receives an array
of extraMappers instead of an object.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
