### PR TITLE
feat(core): add currency to omnitracking's pre-calculated parameters

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.61.0](https://github.com/Farfetch/blackout/compare/@farfetch/blackout-core@1.60.0...@farfetch/blackout-core@1.61.0) (2022-06-28)
+
+
+### Features
+
+* **core:** add new client contentpages ([c21896c](https://github.com/Farfetch/blackout/commit/c21896c80a4b0afecfc57c53b0ed09d443cbe077))
+
+
+
+
+
 # [1.60.0](https://github.com/Farfetch/blackout/compare/@farfetch/blackout-core@1.59.0...@farfetch/blackout-core@1.60.0) (2022-06-22)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farfetch/blackout-core",
-  "version": "1.60.0",
+  "version": "1.61.0",
   "description": "Clients to connect to the Farfetch Platform Solutions' services and modules to manage the application data layer and global state",
   "license": "MIT",
   "main": "src/index.js",

--- a/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
@@ -139,6 +139,7 @@ class Omnitracking extends Integration {
     const isPageOrScreenEvent =
       type === analyticsTrackTypes.PAGE || type === analyticsTrackTypes.SCREEN;
     const precalculatedParameters = {};
+    const { culture, currencyCode } = data.context;
 
     // First we check if we need to change the values
     // of the uniqueViewId and previousUniqueViewId
@@ -178,7 +179,6 @@ class Omnitracking extends Integration {
         userTraits.hasOwnProperty('isGuest') && !userTraits.isGuest;
       precalculatedParameters.basketId = userTraits.bagId;
 
-      const { culture } = data.context;
       let clientLanguage = '';
       let clientCountry = '';
 
@@ -191,6 +191,7 @@ class Omnitracking extends Integration {
     }
 
     precalculatedParameters.uniqueViewId = this.currentUniqueViewId;
+    precalculatedParameters.viewCurrency = currencyCode;
 
     return precalculatedParameters;
   }

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -206,6 +206,24 @@ describe('Omnitracking', () => {
       });
     });
 
+    describe('currency', () => {
+      it('Should send the correct viewCurrency when a currency is passed', async () => {
+        const data = generateMockData();
+        // force a currencyCode context value
+        data.context.currencyCode = 'USD';
+
+        await omnitracking.track(data);
+
+        expect(postTrackingsSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            parameters: expect.objectContaining({
+              viewCurrency: 'USD',
+            }),
+          }),
+        );
+      });
+    });
+
     it('Should return the formatted object for the `GenericPageVisited` event', async () => {
       const data = generateMockData();
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.41.0](https://github.com/Farfetch/blackout/compare/@farfetch/blackout-react@0.40.1...@farfetch/blackout-react@0.41.0) (2022-06-28)
+
+
+### Features
+
+* **core:** add new client contentpages ([c21896c](https://github.com/Farfetch/blackout/commit/c21896c80a4b0afecfc57c53b0ed09d443cbe077))
+
+
+
+
+
 ## [0.40.1](https://github.com/Farfetch/blackout/compare/@farfetch/blackout-react@0.40.0...@farfetch/blackout-react@0.40.1) (2022-06-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farfetch/blackout-react",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "description": "React components, hooks and other tools filled with business logic to help you use Farfetch Platform Solutions' services in your web or native e-commerce app",
   "license": "MIT",
   "main": "src/index.js",


### PR DESCRIPTION
## Description

This PR adds the `viewCurrency` omnitracking parameter, calculated from the event context.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
