### PR TITLE
feat(core): add omnitracking's product list page missing parameters

### DIFF
--- a/packages/core/src/analytics/__fixtures__/pageData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/pageData.fixtures.js
@@ -7,6 +7,13 @@ import pageTypes from '../types/pageTypes';
 import platformTypes from '../types/platformTypes';
 import trackTypes from '../types/trackTypes';
 
+const expectedCommonPageParameters = {
+  ...expectedCommonParameters,
+  uuid: 213123, // uuid is in expectedCommonParameters but as it is defined in the pageMockData.properties, it will override the default value
+  searchResultCount: 1,
+  viewGender: 'Women',
+};
+
 const pageMockData = {
   type: trackTypes.PAGE,
   properties: {
@@ -14,6 +21,8 @@ const pageMockData = {
     cenas: 123123,
     uuid: 213123,
     didYouMean: 1123123,
+    itemCount: 1,
+    gender: 'Women',
   },
   event: pageTypes.HOMEPAGE,
   user: {
@@ -133,8 +142,7 @@ export const expectedPagePayloadWeb = {
 
   parameters: {
     storeId: 123123,
-    ...expectedCommonParameters,
-    uuid: 213123, // uuid is in expectedCommonParameters but as it is defined in the pageMockData.properties, it will override the default value
+    ...expectedCommonPageParameters,
     ...getPageMockParametersForPlatform(platformTypes.Web),
   },
 };
@@ -148,8 +156,7 @@ export const expectedPagePayloadMobile = {
 
   parameters: {
     storeId: 123123,
-    ...expectedCommonParameters,
-    uuid: 213123, // uuid is in expectedCommonParameters but as it is defined in the pageMockData.properties, it will override the default value
+    ...expectedCommonPageParameters,
     ...getPageMockParametersForPlatform(platformTypes.Mobile),
   },
 };
@@ -163,8 +170,7 @@ export const expectedPagePayloadUnknown = {
 
   parameters: {
     storeId: 123123,
-    ...expectedCommonParameters,
-    uuid: 213123, // uuid is in expectedCommonParameters but as it is defined in the pageMockData.properties, it will override the default value
+    ...expectedCommonPageParameters,
     ...getPageMockParametersForPlatform('Dummy'),
   },
 };

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -479,6 +479,13 @@ export const trackEventsMapper = {
   },
 };
 
+export const defaultPageViewTypeAndSubTypeMapper = {
+  [pageTypes.PRODUCT_LISTING]: {
+    viewType: 'Listing',
+    viewSubType: 'Listing',
+  },
+};
+
 export const userGenderValuesMapper = {
   0: 'NotDefined',
   1: 'Male',
@@ -487,4 +494,11 @@ export const userGenderValuesMapper = {
   NotDefined: 'NotDefined',
   Male: 'Male',
   Female: 'Female',
+};
+
+export const viewGenderValuesMapper = {
+  Kids: 'Kids',
+  Men: 'Men',
+  Women: 'Women',
+  Undefined: 'Undefined',
 };

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -19,6 +19,7 @@ import mockedPageData, {
 import mockedTrackData, {
   expectedTrackPayload,
 } from '../../__fixtures__/trackData.fixtures';
+import pageTypes from '../../types/pageTypes';
 import platformTypes from '../../types/platformTypes';
 import uuid from 'uuid';
 
@@ -683,6 +684,23 @@ describe('Omnitracking', () => {
         );
       },
     );
+
+    it.each(Object.keys(definitions.defaultPageViewTypeAndSubTypeMapper))(
+      '`%s` return should match the snapshot',
+      eventMapperKey => {
+        expect(
+          definitions.defaultPageViewTypeAndSubTypeMapper[eventMapperKey],
+        ).toMatchSnapshot();
+        expect(
+          definitions.defaultPageViewTypeAndSubTypeMapper[eventMapperKey],
+        ).toEqual(
+          expect.objectContaining({
+            viewType: expect.any(String),
+            viewSubType: expect.any(String),
+          }),
+        );
+      },
+    );
   });
 
   describe('options', () => {
@@ -904,6 +922,24 @@ describe('Omnitracking', () => {
           parameters: expect.objectContaining({
             previousUniqueViewId: null,
             uniqueViewId: mockUniqueViewId,
+          }),
+        }),
+      );
+    });
+
+    it('Should map the default page view type and subtype', async () => {
+      omnitracking = new Omnitracking();
+      const pageEventData = generateMockData({
+        event: pageTypes.PRODUCT_LISTING,
+      });
+
+      await omnitracking.track(pageEventData);
+
+      expect(postTrackingsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: expect.objectContaining({
+            viewType: 'Listing',
+            viewSubType: 'Listing',
           }),
         }),
       );

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -674,6 +674,13 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`product-listing\` return should match the snapshot 1`] = `
+Object {
+  "viewSubType": "Listing",
+  "viewType": "Listing",
+}
+`;
+
 exports[`Omnitracking definitions \`trackDefinitions\` should match snapshot 1`] = `
 Array [
   "advertiserId",


### PR DESCRIPTION
## Description
This PR adds some missing parameters necessary for the tracking of Product Listing pages on Omnitracking.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
