### PR TITLE
fix(core|redux): fix hash creation for pagination props and commerce pages

### DIFF
--- a/packages/core/src/contents/__tests__/utils.test.js
+++ b/packages/core/src/contents/__tests__/utils.test.js
@@ -107,7 +107,7 @@ describe('getRankedCommercePage', () => {
 describe('buildContentGroupHash', () => {
   it('should correctly construct the correct hash a query object', () => {
     const mockQuery = { codes: 'abc', contentTypeCode: 'pages' };
-    const expectedResult = 'pages!abc';
+    const expectedResult = 'pages!abc!1';
     const result = buildContentGroupHash(mockQuery);
 
     expect(result).toBe(expectedResult);
@@ -131,7 +131,7 @@ describe('buildContentGroupHash', () => {
 
   it('should return an hash with codes "all" when query received doesnt include codes', () => {
     const mockQuery = { contentTypeCode: 'pages' };
-    const expectedResult = 'pages!all';
+    const expectedResult = 'pages!all!1';
     const result = buildContentGroupHash(mockQuery);
 
     expect(result).toBe(expectedResult);
@@ -139,15 +139,42 @@ describe('buildContentGroupHash', () => {
 
   it('should return an hash with contentType "all" when query received doesnt include contentTypeCode', () => {
     const mockQuery = { codes: 'abc' };
-    const expectedResult = 'all!abc';
+    const expectedResult = 'all!abc!1';
+    const result = buildContentGroupHash(mockQuery);
+
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should return an hash with page and pageSize on the end when query received include page and pageSize', () => {
+    const mockQuery = { contentTypeCode: 'pages', page: 1, pageSize: 2 };
+    const expectedResult = 'pages!all!1,2';
+    const result = buildContentGroupHash(mockQuery);
+
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should return an hash with page on the end when query received include page', () => {
+    const mockQuery = { contentTypeCode: 'pages', page: 1 };
+    const expectedResult = 'pages!all!1';
     const result = buildContentGroupHash(mockQuery);
 
     expect(result).toBe(expectedResult);
   });
 
   it('should return an hash with pageSize on the end when query received include pageSize', () => {
-    const mockQuery = { contentTypeCode: 'pages', pageSize: 2 };
-    const expectedResult = 'pages!all!2';
+    const mockQuery = { contentTypeCode: 'pages', page: 1, pageSize: 2 };
+    const expectedResult = 'pages!all!1,2';
+    const result = buildContentGroupHash(mockQuery);
+
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should return an hash of commerce pages without pagination data', () => {
+    const mockQuery = {
+      contentTypeCode: 'commerce_pages',
+      codes: '/shopping/woman',
+    };
+    const expectedResult = 'commerce_pages!/shopping/woman!1';
     const result = buildContentGroupHash(mockQuery);
 
     expect(result).toBe(expectedResult);

--- a/packages/core/src/contents/redux/actions/__tests__/__snapshots__/doGetContent.test.js.snap
+++ b/packages/core/src/contents/redux/actions/__tests__/__snapshots__/doGetContent.test.js.snap
@@ -15,12 +15,12 @@ Object {
   "payload": Object {
     "entities": Object {
       "contentGroups": Object {
-        "pages!cttpage,boutiques": Object {
+        "pages!cttpage,boutiques!1": Object {
           "entries": Array [
             "1fa65fb0-49bf-43b3-902e-78d104f160a3",
             "01b7783c-1b9d-4d5d-915b-17a30c85082d",
           ],
-          "hash": "pages!cttpage,boutiques",
+          "hash": "pages!cttpage,boutiques!1",
           "number": 1,
           "totalItems": 2,
           "totalPages": 1,
@@ -79,8 +79,8 @@ Object {
         },
       },
     },
-    "hash": "pages!cttpage,boutiques",
-    "result": "pages!cttpage,boutiques",
+    "hash": "pages!cttpage,boutiques!1",
+    "result": "pages!cttpage,boutiques!1",
   },
   "type": "@farfetch/blackout-core/GET_CONTENT_SUCCESS",
 }

--- a/packages/core/src/contents/redux/actions/doGetContentPages.js
+++ b/packages/core/src/contents/redux/actions/doGetContentPages.js
@@ -34,7 +34,7 @@ export default getContentPages =>
   async dispatch => {
     const hash = buildContentGroupHash({
       contentTypeCode: 'content_pages',
-      codes: slug,
+      codes: slug.split('?')[0],
     });
 
     const query = {

--- a/packages/core/src/contents/redux/serverInitialState.js
+++ b/packages/core/src/contents/redux/serverInitialState.js
@@ -31,7 +31,10 @@ export default ({ model }) => {
       filters: { codes, contentTypeCode },
       searchResponse,
     } = item;
-    const hash = buildContentGroupHash({ codes, contentTypeCode });
+    const slugWithoutJson = stripSlugSubfolderJsonTrue(slug, subfolder);
+    const slugNormalized = slugWithoutJson.split('?')[0];
+    const code = contentTypeCode === 'commerce_pages' ? slugNormalized : codes;
+    const hash = buildContentGroupHash({ codes: code, contentTypeCode });
     const { entities } = {
       ...normalize({ hash, ...searchResponse }, contentGroup),
     };

--- a/packages/core/src/contents/utils.js
+++ b/packages/core/src/contents/utils.js
@@ -221,7 +221,8 @@ export const getRankedCommercePage = (result, strategy) => {
  * @param {object} query - Object with query parameters applied to search contents.
  * @param {string | string[]} [query.codes] - List of codes that representing the content code (about-us|today-news|header|productId...).
  * @param {object} [query.contentTypeCode] - The content type unique code (page|post|menu|pages|posts|widgets|waterproof...).
- * @param {object} [query.pageSize] - Size of each page, as a number between 1 and 180. The default is 60.
+ * @param {number} [query.page] - Number of the page to get, starting at 1. The default is 1.
+ * @param {number} [query.pageSize] - Size of each page, as a number between 1 and 180. The default is 60.
  *
  * @returns {string} - Hash built to identify a content group.
  *
@@ -239,9 +240,11 @@ export const buildContentGroupHash = query => {
 
   const contentType = get(query, 'contentTypeCode', 'all');
   const codes = get(query, 'codes', 'all');
+  const page = get(query, 'page', 1);
   const pageSize = get(query, 'pageSize', '');
+  const pagesQuery = `${pageSize && `,${pageSize}`}`;
 
-  return `${contentType}!${codes}${pageSize && `!${pageSize}`}`;
+  return `${contentType}!${codes}!${page}${pagesQuery}`;
 };
 
 /**

--- a/packages/react/src/content/hooks/useContentPage.js
+++ b/packages/react/src/content/hooks/useContentPage.js
@@ -35,7 +35,7 @@ export default (slug, contentType, strategy = 'default') => {
     }
 
     return {
-      codes: slug,
+      codes: slug.split('?')[0],
       contentTypeCode: 'content_pages',
     };
   }, [slug]);
@@ -51,7 +51,7 @@ export default (slug, contentType, strategy = 'default') => {
   }, [action, slug, contentType, strategy]);
 
   useEffect(() => {
-    !contentPage && fetchContent();
+    !contentPage && !isLoading && fetchContent();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contentPage, slug]);
 

--- a/packages/react/src/content/hooks/useContentPage.js
+++ b/packages/react/src/content/hooks/useContentPage.js
@@ -51,9 +51,8 @@ export default (slug, contentType, strategy = 'default') => {
   }, [action, slug, contentType, strategy]);
 
   useEffect(() => {
-    !contentPage && !isLoading && fetchContent();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [contentPage, slug]);
+    !contentPage && fetchContent();
+  }, [contentPage, slug, fetchContent]);
 
   return {
     /**

--- a/tests/__fixtures__/contents/contents.fixtures.js
+++ b/tests/__fixtures__/contents/contents.fixtures.js
@@ -427,11 +427,11 @@ export const expectedNormalizedPayload = {
   },
   contents: {
     isLoading: {
-      'careers!all': false,
-      'careers!test-career': false,
-      'navbars!footer': false,
-      'pages!cttpage,boutiques': false,
-      'widgets!newsletter-terms-and-conditions-widget': false,
+      'careers!all!1': false,
+      'careers!test-career!1': false,
+      'navbars!footer!1': false,
+      'pages!cttpage,boutiques!1': false,
+      'widgets!newsletter-terms-and-conditions-widget!1': false,
     },
     error: {},
     metadata: {
@@ -460,10 +460,10 @@ export const mockContentsLoadingState = {
   entities: {},
   contents: {
     isLoading: {
-      'careers!all': true,
-      'navbars!footer': true,
-      'pages!cttpage,boutiques': true,
-      'widgets!newsletter-terms-and-conditions-widget': true,
+      'careers!all!1': true,
+      'navbars!footer!1': true,
+      'pages!cttpage,boutiques!1': true,
+      'widgets!newsletter-terms-and-conditions-widget!1': true,
     },
     error: {},
   },
@@ -473,22 +473,22 @@ export const mockContentsErrorState = {
   entities: {},
   contents: {
     isLoading: {
-      'careers!all': false,
-      'navbars!footer': false,
-      'pages!cttpage,boutiques': false,
-      'widgets!newsletter-terms-and-conditions-widget': false,
+      'careers!all!1': false,
+      'navbars!footer!1': false,
+      'pages!cttpage,boutiques!1': false,
+      'widgets!newsletter-terms-and-conditions-widget!1': false,
     },
     error: {
-      'careers!all': {
+      'careers!all!1': {
         message: 'Error',
       },
-      'navbars!footer': {
+      'navbars!footer!1': {
         message: 'Error',
       },
-      'pages!cttpage,boutiques': {
+      'pages!cttpage,boutiques!1': {
         message: 'Error',
       },
-      'widgets!newsletter-terms-and-conditions-widget': {
+      'widgets!newsletter-terms-and-conditions-widget!1': {
         message: 'Error',
       },
     },


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->
fix hash creation for pagination props and commerce pages:

- removed subfolder and queryString on slug for commercepages hash on serverinitialstate
- added page property with default value on hash builder
- changed hash format to '${contentType}!${codes}!${page}${pageSize}'
- pageSize property is optional and if its have value will be split by commas like:
posts!all!1,5

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
