### PR TITLE
feat(blackout-core): add lineItems omnitracking mapping

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -16,7 +16,18 @@ const trackMockData = {
     clientId: 26000,
     tenantId: 26000,
   },
-  properties: {},
+  properties: {
+    products: [
+      {
+        id: 12345678,
+        discountValue: 1,
+        brand: 'designer name',
+        category: 'shoes',
+        priceWithoutDiscount: 1,
+        sizeId: 1,
+      },
+    ],
+  },
   platform: platformTypes.Web,
   timestamp: mockCommonData.timestamp,
   type: trackTypes.TRACK,

--- a/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
@@ -96,7 +96,7 @@ class Omnitracking extends Integration {
     this.currentUniqueViewId = null;
     this.previousUniqueViewId = null;
 
-    this.navigatedFrom = null;
+    this.lastFromParameter = null;
   }
 
   /**
@@ -164,14 +164,13 @@ class Omnitracking extends Integration {
         }
       }
 
-      if (this.navigatedFrom) {
-        precalculatedParameters.navigatedFrom = this.navigatedFrom;
+      if (this.lastFromParameter) {
+        precalculatedParameters.navigatedFrom = this.lastFromParameter;
       }
 
+      this.lastFromParameter = data?.properties?.from;
+
       const { event, user } = data;
-
-      this.navigatedFrom = event;
-
       const userTraits = get(user, 'traits', {});
 
       precalculatedParameters.userGender = get(
@@ -187,8 +186,8 @@ class Omnitracking extends Integration {
       );
 
       precalculatedParameters.searchResultCount = get(
-        data.properties,
-        'itemCount',
+        data,
+        'properties.itemCount',
       );
 
       const defaultViewTypeMapper = defaultPageViewTypeAndSubTypeMapper[event];

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -5,6 +5,7 @@
 
 import {
   generatePaymentAttemptReferenceId,
+  getLineItemsFromProductsList,
   getParameterValueFromEvent,
   getValParameterForEvent,
 } from './omnitracking-helper';
@@ -476,6 +477,12 @@ export const trackEventsMapper = {
           val,
         };
     }
+  },
+  [eventTypes.PRODUCT_LIST_VIEWED]: data => {
+    return {
+      tid: 2832,
+      lineItems: getLineItemsFromProductsList(data),
+    };
   },
 };
 

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -223,7 +223,7 @@ export const getPlatformSpecificParameters = data => {
 };
 
 /**
- * Filters the properties object with the `parameters` dictionary, so we don't pass unecessary information for the event.
+ * Filters the properties object with the `parameters` dictionary, so we don't pass unnecessary information for the event.
  * We search for parameters in many locations: context -> device -> app -> event -> properties
  * Each location can override the values of the previous one.
  *
@@ -324,7 +324,7 @@ export const generatePaymentAttemptReferenceId = data => {
 };
 
 /**
- * Filters the properties object with the `parameters` dictionary, so we don't pass unecessary information for the event.
+ * Filters the properties object with the `parameters` dictionary, so we don't pass unnecessary information for the event.
  * We search for parameters in many locations: context -> device -> app -> event -> properties
  * Each location can override the values of the previous one.
  *
@@ -474,4 +474,30 @@ export const getCLientCountryFromCulture = culture => {
   const clientCountry = cultureSplit[1];
 
   return clientCountry;
+};
+
+/**
+ * Transforms the products list payload into `lineItems` omnitracking parameter.
+ *
+ * @param {object} data - The event tracking data.
+ *
+ * @returns {Array|undefined} - The mapped `lineItems` array.
+ */
+export const getLineItemsFromProductsList = data => {
+  const productsList = data?.properties?.products;
+
+  if (productsList && productsList.length) {
+    const mappedProductList = productsList.map(product => ({
+      productId: product.id,
+      itemPromotion: product.discountValue,
+      designerName: product.brand,
+      category: product.category,
+      itemFullPrice: product.priceWithoutDiscount,
+      sizeID: product.sizeId,
+    }));
+
+    return JSON.stringify(mappedProductList);
+  }
+
+  return undefined;
 };

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -40,6 +40,13 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Product List Viewed\` return should match the snapshot 1`] = `
+Object {
+  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
+  "tid": 2832,
+}
+`;
+
 exports[`Omnitracking definitions \`Sign-up Form Viewed\` return should match the snapshot 1`] = `
 Object {
   "tid": 10097,


### PR DESCRIPTION
## Description

This PR adds a new mapping on the analytics' omnitracking integration that grabs any `products[]` and converts them into a `lineItems` JSON.
Also adds the correct TID value for the product listing event.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
