### PR TITLE
chore: add missing query param in getProductGrouping jsdoc

### DIFF
--- a/packages/core/src/products/details/client/getProductGrouping.js
+++ b/packages/core/src/products/details/client/getProductGrouping.js
@@ -11,6 +11,9 @@ import join from 'proper-url-join';
  * the backend side.
  * @property {number} [pageSize=10] - Size of each page, as a number. The
  * default is 10 on the backend side.
+ * @property {string} [properties] - Get product variations for specific
+ * properties, identified by their type (propertyType:attributeValueId),
+ * separated by commas.
  */
 
 /**

--- a/packages/core/src/products/details/redux/actions/doGetProductGrouping.js
+++ b/packages/core/src/products/details/redux/actions/doGetProductGrouping.js
@@ -13,6 +13,9 @@ import productSchema from '../../../../entities/schemas/product';
  * the backend side.
  * @property {number} [pageSize=10] - Size of each page, as a number -
  * defaults to 10 on the backend side.
+ * @property {string} [properties] - Get product variations for specific
+ * properties, identified by their type (propertyType:attributeValueId),
+ * separated by commas.
  */
 
 /**


### PR DESCRIPTION
## Description
This adds the property "properties" in the jsdoc of the query params
of the getProductGrouping client and doGetProductGrouping action.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
