### PR TITLE
fix: added reset function to reset auth state on react-core 

### DIFF
--- a/packages/react/src/authentication/hooks/__tests__/useAuthentication.test.js
+++ b/packages/react/src/authentication/hooks/__tests__/useAuthentication.test.js
@@ -69,6 +69,7 @@ describe('useAuthentication', () => {
       isLoading: expect.any(Boolean),
       isLoggedIn: expect.any(Boolean),
       login: expect.any(Function),
+      reset: expect.any(Function),
       logout: expect.any(Function),
       resetGuestTokensContext: expect.any(Function),
       setGuestUserClaims: expect.any(Function),

--- a/packages/react/src/authentication/hooks/useUserAuthState.js
+++ b/packages/react/src/authentication/hooks/useUserAuthState.js
@@ -17,6 +17,7 @@ export const ActionTypes = {
   LoginRequested: 'LOGIN_REQUESTED',
   LoginSucceeded: 'LOGIN_SUCCEEDED',
   LoginFailed: 'LOGIN_FAILED',
+  LoginReset: 'LOGIN_RESET',
   LogoutRequested: 'LOGOUT_REQUESTED',
   LogoutSucceeded: 'LOGOUT_SUCCEEDED',
   LogoutFailed: 'LOGOUT_FAILED',
@@ -57,7 +58,9 @@ const reducer = (state, action) => {
         },
       };
     }
-
+    case ActionTypes.LoginReset: {
+      return initialState;
+    }
     default:
       return state;
   }
@@ -81,6 +84,10 @@ const useUserAuthState = ({ activeTokenData, tokenManager }) => {
       throw new PendingUserOperationError();
     }
   }, [state]);
+
+  const reset = useCallback(() => {
+    dispatch({ type: ActionTypes.LoginReset });
+  }, [dispatch]);
 
   const login = useCallback(
     async data => {
@@ -154,6 +161,7 @@ const useUserAuthState = ({ activeTokenData, tokenManager }) => {
     login,
     logout,
     isLoggedIn,
+    reset,
     ...state,
   };
 };


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->
Added a function to reset auth reducer to initial state.
<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
