### PR TITLE
feat(core|react): add analytics SPA page referrer context 

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.65.0](https://github.com/Farfetch/blackout/compare/@farfetch/blackout-core@1.64.0...@farfetch/blackout-core@1.65.0) (2022-07-19)
+
+
+### Bug Fixes
+
+* **core|react:** hash creation on content pages ([b5ea2b9](https://github.com/Farfetch/blackout/commit/b5ea2b9a74ac6ec3505fed4f4f5af96d3ed08735))
+
+
+### Features
+
+* **blackout-core:** add lineItems omnitracking mapping ([705e910](https://github.com/Farfetch/blackout/commit/705e910f411ee99be7f8935f0f650189aca3078f))
+
+
+
+
+
 # [1.64.0](https://github.com/Farfetch/blackout/compare/@farfetch/blackout-core@1.63.0...@farfetch/blackout-core@1.64.0) (2022-07-14)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farfetch/blackout-core",
-  "version": "1.64.0",
+  "version": "1.65.0",
   "description": "Clients to connect to the Farfetch Platform Solutions' services and modules to manage the application data layer and global state",
   "license": "MIT",
   "main": "src/index.js",

--- a/packages/core/src/analytics/Analytics.js
+++ b/packages/core/src/analytics/Analytics.js
@@ -71,14 +71,16 @@ class Analytics {
    * Getter for the context object.
    *
    * @param {string} [key] - Key to retrieve from the context. If not specified, will return the whole data stored in the context.
+   * @param {string} eventType - The type of event being tracked. Ex: page, track, onSetUser.
+   *
    * @returns {Promise<*>} Value for the key in context or the whole context data if key is not specified.
    */
-  async context(key) {
+  async context(key, eventType) {
     const externalContextData = {};
 
     for (const contextFn of this.contextFns) {
       try {
-        const contextFnResult = await contextFn();
+        const contextFnResult = await contextFn(eventType);
 
         merge(externalContextData, contextFnResult);
       } catch (error) {
@@ -540,7 +542,7 @@ class Analytics {
    * @private
    */
   async getEventData(type, additionalData, eventContext) {
-    const context = await this.context();
+    const context = await this.context(null, type);
 
     Object.assign(context, { event: eventContext });
 

--- a/packages/core/src/analytics/__fixtures__/pageData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/pageData.fixtures.js
@@ -86,6 +86,7 @@ const pageMockData = {
         title: 'Thom Browne',
         referrer: 'https://example.com',
       },
+      pageLocationReferrer: 'https://example.com',
     },
   },
   timestamp: mockCommonData.timestamp,
@@ -101,7 +102,7 @@ const getPageMockParametersForPlatform = platform => {
     parameters = {
       deviceLanguage: pageMockData.context.web.window.navigator.language,
       internalRequest: false,
-      referrer: pageMockData.context.web.document.referrer,
+      referrer: pageMockData.context.web.pageLocationReferrer,
       referrerHost: 'example.com',
       screenHeight: pageMockData.context.web.window.screen.height,
       screenWidth: pageMockData.context.web.window.screen.width,

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -138,7 +138,7 @@ const getSpecificWebParameters = data => {
   const type = get(data, 'type');
 
   if (type === analyticsTrackTypes.PAGE) {
-    const referrer = get(data, 'context.web.document.referrer', '');
+    const referrer = get(data, 'context.web.pageLocationReferrer', '');
     const location = get(data, 'context.web.window.location', {});
     const query = get(location, 'query', {});
     const internalRequest =

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.41.1](https://github.com/Farfetch/blackout/compare/@farfetch/blackout-react@0.41.0...@farfetch/blackout-react@0.41.1) (2022-07-19)
+
+
+### Bug Fixes
+
+* **core|react:** hash creation on content pages ([b5ea2b9](https://github.com/Farfetch/blackout/commit/b5ea2b9a74ac6ec3505fed4f4f5af96d3ed08735))
+
+
+
+
+
 # [0.41.0](https://github.com/Farfetch/blackout/compare/@farfetch/blackout-react@0.40.1...@farfetch/blackout-react@0.41.0) (2022-06-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farfetch/blackout-react",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "description": "React components, hooks and other tools filled with business logic to help you use Farfetch Platform Solutions' services in your web or native e-commerce app",
   "license": "MIT",
   "main": "src/index.js",

--- a/packages/react/src/analytics/__tests__/context.test.js
+++ b/packages/react/src/analytics/__tests__/context.test.js
@@ -1,3 +1,4 @@
+import { trackTypes } from '../../../../core/src/analytics';
 import context from '../context';
 import merge from 'lodash/merge';
 import parse from 'url-parse';
@@ -15,11 +16,50 @@ describe('context', () => {
           title: document.title,
           referrer: document.referrer,
         },
+        pageLocationReferrer: undefined,
       },
     };
 
     const returnedContext = context();
 
     expect(returnedContext).toEqual(expectedContext);
+  });
+
+  it('should return the correct pageLocationReferrer value when calls to the function are made between pages', async () => {
+    const firstPageLocationReferrerMock = 'https://foo.bar.com/';
+    const secondPageLocationReferrerMock = 'https://foo.bar.biz.com/';
+
+    // starts with an empty value from document.referrer
+    expect(context(trackTypes.PAGE).pageLocationReferrer).toEqual('');
+
+    delete window.location;
+
+    // simulate a URL change to the first page
+    window.location = new URL(firstPageLocationReferrerMock);
+
+    // expect that the pageLocationReferrer is the last one (which in this environment is localhost)
+    expect(context(trackTypes.PAGE).pageLocationReferrer).toEqual(
+      'http://localhost/',
+    );
+
+    delete window.location;
+
+    // simulate a URL change to the second page
+    window.location = new URL(secondPageLocationReferrerMock);
+
+    // expect the pageLocationReferrer is the last one (first page)
+    expect(context(trackTypes.PAGE).pageLocationReferrer).toEqual(
+      firstPageLocationReferrerMock,
+    );
+
+    delete window.location;
+
+    // simulate a URL change to the first page (back from the second)
+    window.location = new URL(firstPageLocationReferrerMock);
+
+    // expect the pageLocationReferrer is the last one (second page)
+    expect(context(trackTypes.PAGE).pageLocationReferrer).toEqual(
+      secondPageLocationReferrerMock,
+    );
   });
 });

--- a/packages/react/src/analytics/analytics.js
+++ b/packages/react/src/analytics/analytics.js
@@ -2,6 +2,7 @@ import Analytics, {
   trackTypes as analyticsTrackTypes,
   platformTypes,
 } from '@farfetch/blackout-core/analytics';
+import webContext from './context';
 
 /**
  * Analytics base class.
@@ -33,6 +34,8 @@ class AnalyticsWeb extends Analytics {
 
     // Stores the last page call
     this.currentPageCallData = null;
+
+    this.useContext(webContext);
   }
 
   /**
@@ -112,7 +115,7 @@ class AnalyticsWeb extends Analytics {
 }
 
 /**
- * Instance to be used to track events and pageviews.
+ * Instance to be used to track events and page views.
  *
  * @type {AnalyticsWeb}
  * @name default


### PR DESCRIPTION
## Description

Since document.referrer stays the same on single page applications,
this PR adds an alternative property called `pageLocationReferrer`
for page trackings that will hold the previous URL when navigating trough
pages.

This PR also adds the type of event that is being tracked to each `useContext`
function and calls the webContext directly on the analyticsWeb constructor.

Mapped the Omnitracking's `referrer` to the new `pageLocationReferrer`,
since the document.referrer was causing issues when analyzing user behavior.


<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
