### PR TITLE
feat(react): refactor useWishlist

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: true,
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ['**/src/**/*.{js,jsx,ts,tsx}'],
+  collectCoverageFrom: ['**/src/**/*.{js,jsx,ts,tsx}', '!**/.vscode/**/*'],
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {

--- a/packages/react/src/wishlists/hooks/types/useWishlist.ts
+++ b/packages/react/src/wishlists/hooks/types/useWishlist.ts
@@ -1,28 +1,3 @@
-import type { Config, Wishlist } from '@farfetch/blackout-client';
-import type {
-  PostWishlistItemActionData,
-  WishlistItemHydrated,
-  WishlistsState,
-} from '@farfetch/blackout-redux';
-
-export type UseWishlist = () => {
-  error: WishlistsState['error'] | undefined;
-  fetchWishlist: (
-    wishlistId: Wishlist['id'],
-    config?: Config,
-  ) => Promise<Wishlist | undefined>;
-  addWishlistItem: (
-    data: PostWishlistItemActionData,
-    config?: Config,
-  ) => Promise<Wishlist | undefined>;
-  id: WishlistsState['id'];
-  isEmpty: boolean;
-  isLoading: boolean;
-  itemCount: number;
-  items: WishlistItemHydrated[] | undefined;
-  itemsWithSetsInfo: WishlistItemHydrated[] | undefined;
-  resetWishlist: () => void;
-  resetWishlistState: (fieldsToReset?: string[]) => void;
-  totalQuantity: number;
-  wishlist: WishlistsState['result'];
+export type UseWishlistOptions = {
+  enableAutoFetch?: boolean;
 };

--- a/packages/react/src/wishlists/hooks/types/useWishlistItem.ts
+++ b/packages/react/src/wishlists/hooks/types/useWishlistItem.ts
@@ -1,25 +1,3 @@
-import type {
-  Config,
-  PatchWishlistItemData,
-  Wishlist,
-  WishlistItem,
-} from '@farfetch/blackout-client';
-import type {
-  WishlistItemHydrated,
-  WishlistsState,
-} from '@farfetch/blackout-redux';
+import type { WishlistItem } from '@farfetch/blackout-client';
 
-export type UseWishlistItem = (wishlistItemId: number) => {
-  error: WishlistsState['error'] | undefined;
-  isLoading: WishlistsState['isLoading'] | undefined;
-  item: WishlistItemHydrated | undefined;
-  updateWishlistItem: (
-    wishlistItemId: WishlistItem['id'],
-    data: PatchWishlistItemData,
-    config?: Config,
-  ) => Promise<Wishlist | undefined>;
-  removeWishlistItem: (
-    wishlistItemId: WishlistItem['id'],
-    config?: Config,
-  ) => Promise<Wishlist | undefined>;
-};
+export type WishlistItemId = WishlistItem['id'];

--- a/packages/react/src/wishlists/hooks/useWishlist.ts
+++ b/packages/react/src/wishlists/hooks/useWishlist.ts
@@ -3,21 +3,22 @@
  * wishlists.
  */
 import {
-  addWishlistItem as addWishlistItemAction,
-  fetchWishlist as fetchWishlistAction,
+  addWishlistItem,
+  fetchWishlist,
+  getUser,
   getWishlist,
   getWishlistError,
-  getWishlistId,
   getWishlistItems,
-  getWishlistItemsCounter,
-  getWishlistTotalQuantity,
-  isWishlistLoading as isWishlistLoadingSelector,
-  resetWishlist as resetWishlistAction,
-  resetWishlistState as resetWishlistStateAction,
+  isWishlistLoading,
+  removeWishlistItem,
+  resetWishlist,
+  updateWishlistItem,
 } from '@farfetch/blackout-redux';
 import { useAction } from '../../helpers';
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import type { UseWishlist } from './types';
+// Types
+import type { UseWishlistOptions } from './types';
 
 /**
  * Provides Redux actions and state access, as well as handlers for dealing with
@@ -25,83 +26,48 @@ import type { UseWishlist } from './types';
  *
  * @returns All the handlers, state, actions and relevant data needed to manage any wishlist operation.
  */
-const useWishlist: UseWishlist = () => {
+const useWishlist = (options: UseWishlistOptions = {}) => {
+  const { enableAutoFetch = false } = options;
   // Selectors
   const error = useSelector(getWishlistError);
-  const id = useSelector(getWishlistId);
-  const isWishlistLoading = useSelector(isWishlistLoadingSelector);
-  const itemCount = useSelector(getWishlistItemsCounter);
+  const isLoading = useSelector(isWishlistLoading);
   const items = useSelector(getWishlistItems);
-  const itemsWithSetsInfo = useSelector(state => getWishlistItems(state, true));
-  const totalQuantity = useSelector(getWishlistTotalQuantity);
   const wishlist = useSelector(getWishlist);
+  const userWishlistId = useSelector(getUser)?.wishlistId;
   // Actions
-  const addWishlistItem = useAction(addWishlistItemAction);
-  const fetchWishlist = useAction(fetchWishlistAction);
-  const resetWishlist = useAction(resetWishlistAction);
-  const resetWishlistState = useAction(resetWishlistStateAction);
+  const addItem = useAction(addWishlistItem);
+  const updateItem = useAction(updateWishlistItem);
+  const removeItem = useAction(removeWishlistItem);
+  const fetch = useAction(fetchWishlist);
+  const reset = useAction(resetWishlist);
   // Data with some logic
-  const isEmpty = totalQuantity === 0;
-  // If there is no wishlist and there is no error (with `isWishlistLoading === false`),
-  // it means the wishlist hasn't started fetching, so it's considered loading
-  const isLoading = (!wishlist && !error) || isWishlistLoading;
+  const count = wishlist.count;
+  const isEmpty = count === 0;
+  const isFetched = !!wishlist.id;
+
+  useEffect(() => {
+    if (!isLoading && !error && enableAutoFetch && userWishlistId) {
+      fetch(userWishlistId);
+    }
+  }, [enableAutoFetch, error, fetch, isLoading, userWishlistId]);
 
   return {
-    /**
-     * Add item to wishlist.
-     */
-    addWishlistItem,
-    /**
-     * Error state of the fetched wishlist.
-     */
-    error,
-    /**
-     * Fetches the wishlist.
-     */
-    fetchWishlist,
-    /**
-     * Identifier of the fetched wishlist.
-     */
-    id,
-    /**
-     * Whether the wishlist is empty, ie, with no items.
-     */
-    isEmpty,
-    /**
-     * Whether the wishlist is loading.
-     */
     isLoading,
-    /**
-     * The number of different items in the wishlist, regardless of each one's
-     * quantity.
-     */
-    itemCount,
-    /**
-     * Wishlist items of the fetched wishlist.
-     */
-    items,
-    /**
-     * Wishlist items of the fetched wishlist, with the respective parent wishlist set
-     * data.
-     */
-    itemsWithSetsInfo,
-    /**
-     * Resets the wishlist.
-     */
-    resetWishlist,
-    /**
-     * Resets the wishlist state.
-     */
-    resetWishlistState,
-    /**
-     * The total quantity of products in the current user's wishlist, accounting with
-     * each item's quantity.
-     */
-    totalQuantity,
-    /**
-     * Fetched wishlist data.
-     */
-    wishlist,
+    error,
+    isFetched,
+    actions: {
+      fetch,
+      reset,
+      addItem,
+      updateItem,
+      removeItem,
+    },
+    data: {
+      ...wishlist,
+      count,
+      isEmpty,
+      items,
+    },
   };
 };
 

--- a/packages/react/src/wishlists/hooks/useWishlistItem.ts
+++ b/packages/react/src/wishlists/hooks/useWishlistItem.ts
@@ -5,13 +5,13 @@ import {
   getWishlistItem,
   getWishlistItemError,
   isWishlistItemLoading,
-  removeWishlistItem as removeWishlistItemAction,
   StoreState,
-  updateWishlistItem as updateWishlistItemAction,
 } from '@farfetch/blackout-redux';
-import { useAction } from '../../helpers';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import type { UseWishlistItem } from './types';
+import useWishlist from './useWishlist';
+import type { PatchWishlistItemData } from '@farfetch/blackout-client';
+import type { WishlistItemId } from './types/useWishlistItem';
 
 /**
  * Provides Redux actions and state access for dealing with wishlist item business
@@ -21,7 +21,10 @@ import type { UseWishlistItem } from './types';
  *
  * @returns All the state, actions and relevant data needed to manage a wishlist item operation.
  */
-const useWishlistItem: UseWishlistItem = wishlistItemId => {
+const useWishlistItem = (wishlistItemId: WishlistItemId) => {
+  const {
+    actions: { updateItem, removeItem },
+  } = useWishlist();
   // Selectors
   const error = useSelector((state: StoreState) =>
     getWishlistItemError(state, wishlistItemId),
@@ -32,31 +35,26 @@ const useWishlistItem: UseWishlistItem = wishlistItemId => {
   const item = useSelector((state: StoreState) =>
     getWishlistItem(state, wishlistItemId),
   );
-  // Actions
-  const removeWishlistItem = useAction(removeWishlistItemAction);
-  const updateWishlistItem = useAction(updateWishlistItemAction);
+
+  const update = useCallback(
+    (data: PatchWishlistItemData) => updateItem(wishlistItemId, data),
+    [updateItem, wishlistItemId],
+  );
+
+  const remove = useCallback(
+    () => removeItem(wishlistItemId),
+    [removeItem, wishlistItemId],
+  );
 
   return {
-    /**
-     * Error state of the fetched wishlist item.
-     */
-    error,
-    /**
-     * Whether the wishlist item is loading.
-     */
     isLoading,
-    /**
-     * Fetched wishlist item.
-     */
-    item,
-    /**
-     * Updates the wishlist item.
-     */
-    updateWishlistItem,
-    /**
-     * Removes the wishlist items.
-     */
-    removeWishlistItem,
+    error,
+    isFetched: !!item,
+    data: item,
+    actions: {
+      update,
+      remove,
+    },
   };
 };
 

--- a/packages/react/tests/helpers/react.tsx
+++ b/packages/react/tests/helpers/react.tsx
@@ -1,7 +1,8 @@
 import { mockStore } from './redux';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
-import React from 'react';
+import React, { ReactNode } from 'react';
+import type { StoreState } from '@farfetch/blackout-redux';
 
 /**
  * Testing helper class to chain Providers as needed. Start by passing the original
@@ -40,3 +41,8 @@ export const wrap = component => ({
     return wrap(<Provider store={mockStore(state)}>{component}</Provider>);
   },
 });
+
+export const withStore =
+  (state: StoreState = {}): React.FC<{ children: ReactNode }> =>
+  props =>
+    <Provider store={mockStore(state)} {...props} />;

--- a/packages/redux/src/wishlists/selectors/wishlists.ts
+++ b/packages/redux/src/wishlists/selectors/wishlists.ts
@@ -231,7 +231,7 @@ export const getWishlistItems = createSelector(
  * @returns Error information, `undefined` if there are no errors.
  */
 export const getWishlistError = (state: StoreState) =>
-  fromWishlistReducer.getError(state.wishlist as WishlistsState) || undefined;
+  fromWishlistReducer.getError(state.wishlist as WishlistsState);
 
 /**
  * Retrieves the loading status of the wishlist.

--- a/packages/redux/src/wishlists/types/state.types.ts
+++ b/packages/redux/src/wishlists/types/state.types.ts
@@ -24,7 +24,7 @@ export type WishlistsState = CombinedState<{
   error: BlackoutError | null;
   id: Wishlist['id'] | null;
   isLoading: boolean;
-  result: WishlistNormalized | Record<string, never>;
+  result: WishlistNormalized | Record<string, undefined>;
   items: {
     ids: Array<WishlistItemEntity['id']> | null;
     item: {

--- a/tests/__fixtures__/wishlists/wishlists.fixtures.ts
+++ b/tests/__fixtures__/wishlists/wishlists.fixtures.ts
@@ -1,4 +1,4 @@
-import type { WishlistItem } from '@farfetch/blackout-client/wishlists/types';
+import type { WishlistItem } from '@farfetch/blackout-client';
 
 export const mockWishlistId = 'b1a13891-6084-489f-96ed-300eed45b948';
 export const mockWishlistItemId = 481426747;
@@ -66,7 +66,7 @@ export const mockWishlistNormalizedPayload = {
 
 export const mockWishlistState = {
   wishlist: {
-    error: undefined,
+    error: null,
     id: mockWishlistId,
     isLoading: false,
     items: {
@@ -86,6 +86,7 @@ export const mockWishlistState = {
     result: {
       id: mockWishlistId,
       items: [mockWishlistItemId],
+      count: 4,
     },
     sets: {
       error: null,


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

This PR is part of the work being developed in order to achieve consistent interfaces among all the react hooks (provided in the `blackout-react` package).

The `useWishlist` hook is now exposing the following interface:
- Params
    - enableAutoFetch (optional)
- Return
    - isLoading
    - error
    - isFetched
    - data
        - id
        - count
        - items
        - isEmpty
    - actions
        - fetch()
        - reset()
        - addItem(productId, {sizeId, quantity})
        - updateItem(wishlistItemId, {sizeId, quantity})
        - removeItem(wishlistItemId) 

The `useWishlistItem` hook is now exposing the following interface:
- Params
    - enableAutoFetch (optional)
- Return
    - isLoading
    - error
    - isFetched
    - data
        - id
        - quantity
        - size
        - product
        - ...
    - actions
        - update({sizeId, quantity})
        - remove() 

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

Depends on #411 

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
