### PR TITLE
feat(core): add omnitracking's product detail page tracking mappings

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -5,8 +5,8 @@
 
 import {
   generatePaymentAttemptReferenceId,
-  getLineItemsFromProductsList,
   getParameterValueFromEvent,
+  getProductLineItems,
   getValParameterForEvent,
 } from './omnitracking-helper';
 import eventTypes from '../../types/eventTypes';
@@ -481,16 +481,27 @@ export const trackEventsMapper = {
   [eventTypes.PRODUCT_LIST_VIEWED]: data => {
     return {
       tid: 2832,
-      lineItems: getLineItemsFromProductsList(data),
+      lineItems: getProductLineItems(data),
     };
   },
 };
 
-export const defaultPageViewTypeAndSubTypeMapper = {
-  [pageTypes.PRODUCT_LISTING]: {
+/**
+ * Interested events for page tracking.
+ * If there is a page event that can have specific rules or parameters,
+ * make sure to define it in this mapper.
+ */
+export const pageEventsMapper = {
+  [pageTypes.PRODUCT_DETAILS]: data => ({
+    viewType: 'Product',
+    viewSubType: 'Product',
+    lineItems: getProductLineItems(data),
+  }),
+  [pageTypes.PRODUCT_LISTING]: data => ({
     viewType: 'Listing',
     viewSubType: 'Listing',
-  },
+    lineItems: getProductLineItems(data),
+  }),
 };
 
 export const userGenderValuesMapper = {

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -483,20 +483,41 @@ export const getCLientCountryFromCulture = culture => {
  *
  * @returns {Array|undefined} - The mapped `lineItems` array.
  */
-export const getLineItemsFromProductsList = data => {
-  const productsList = data?.properties?.products;
+export const getProductLineItems = data => {
+  const properties = data?.properties || {};
+  const productsList = properties.products;
+  const productId = properties.productId;
 
   if (productsList && productsList.length) {
     const mappedProductList = productsList.map(product => ({
       productId: product.id,
       itemPromotion: product.discountValue,
       designerName: product.brand,
-      category: product.category,
+      category: (product.category || '').split('/')[0],
       itemFullPrice: product.priceWithoutDiscount,
       sizeID: product.sizeId,
+      itemQuantity: product.quantity,
+      promoCode: product.coupon,
+      storeID: product.locationId,
     }));
 
     return JSON.stringify(mappedProductList);
+  }
+
+  if (productId) {
+    return JSON.stringify([
+      {
+        productId,
+        itemPromotion: properties.discountValue,
+        designerName: properties.brand,
+        category: (properties.category || '').split('/')[0],
+        itemFullPrice: properties.priceWithoutDiscount,
+        sizeID: properties.sizeId,
+        itemQuantity: properties.quantity,
+        promoCode: properties.coupon,
+        storeID: properties.locationId,
+      },
+    ]);
   }
 
   return undefined;

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -685,19 +685,15 @@ describe('Omnitracking', () => {
       },
     );
 
-    it.each(Object.keys(definitions.defaultPageViewTypeAndSubTypeMapper))(
+    // test the pageEventsMapper globally with all default scenarios
+    it.each(Object.keys(definitions.pageEventsMapper))(
       '`%s` return should match the snapshot',
       eventMapperKey => {
         expect(
-          definitions.defaultPageViewTypeAndSubTypeMapper[eventMapperKey],
+          definitions.pageEventsMapper[eventMapperKey](mockedTrackData),
         ).toMatchSnapshot();
-        expect(
-          definitions.defaultPageViewTypeAndSubTypeMapper[eventMapperKey],
-        ).toEqual(
-          expect.objectContaining({
-            viewType: expect.any(String),
-            viewSubType: expect.any(String),
-          }),
+        expect(typeof definitions.pageEventsMapper[eventMapperKey]).toBe(
+          'function',
         );
       },
     );

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -681,8 +681,17 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`product-details\` return should match the snapshot 1`] = `
+Object {
+  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
+  "viewSubType": "Product",
+  "viewType": "Product",
+}
+`;
+
 exports[`Omnitracking definitions \`product-listing\` return should match the snapshot 1`] = `
 Object {
+  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
   "viewSubType": "Listing",
   "viewType": "Listing",
 }

--- a/packages/react/src/analytics/__tests__/context.test.js
+++ b/packages/react/src/analytics/__tests__/context.test.js
@@ -30,7 +30,7 @@ describe('context', () => {
     const secondPageLocationReferrerMock = 'https://foo.bar.biz.com/';
 
     // starts with an empty value from document.referrer
-    expect(context(trackTypes.PAGE).pageLocationReferrer).toEqual('');
+    expect(context(trackTypes.PAGE).web.pageLocationReferrer).toEqual('');
 
     delete window.location;
 
@@ -38,7 +38,7 @@ describe('context', () => {
     window.location = new URL(firstPageLocationReferrerMock);
 
     // expect that the pageLocationReferrer is the last one (which in this environment is localhost)
-    expect(context(trackTypes.PAGE).pageLocationReferrer).toEqual(
+    expect(context(trackTypes.PAGE).web.pageLocationReferrer).toEqual(
       'http://localhost/',
     );
 
@@ -48,7 +48,7 @@ describe('context', () => {
     window.location = new URL(secondPageLocationReferrerMock);
 
     // expect the pageLocationReferrer is the last one (first page)
-    expect(context(trackTypes.PAGE).pageLocationReferrer).toEqual(
+    expect(context(trackTypes.PAGE).web.pageLocationReferrer).toEqual(
       firstPageLocationReferrerMock,
     );
 
@@ -58,7 +58,7 @@ describe('context', () => {
     window.location = new URL(firstPageLocationReferrerMock);
 
     // expect the pageLocationReferrer is the last one (second page)
-    expect(context(trackTypes.PAGE).pageLocationReferrer).toEqual(
+    expect(context(trackTypes.PAGE).web.pageLocationReferrer).toEqual(
       secondPageLocationReferrerMock,
     );
   });

--- a/packages/react/src/analytics/context.js
+++ b/packages/react/src/analytics/context.js
@@ -40,10 +40,10 @@ export default function (trackEventType) {
         title: document.title,
         referrer: document.referrer,
       },
+      // Since document.referrer stays the same on single page applications,
+      // we have this alternative that will hold the previous page location
+      // based on page track calls with `analyticsWeb.page()`.
+      pageLocationReferrer: isPageEvent ? pageLocationReferrer : undefined,
     },
-    // Since document.referrer stays the same on single page applications,
-    // we have this alternative that will hold the previous page location
-    // based on page track calls with `analyticsWeb.page()`.
-    pageLocationReferrer: isPageEvent ? pageLocationReferrer : undefined,
   };
 }


### PR DESCRIPTION
## Description
This PR introduces the omnitracking's `lineItems` mapping for the product details page track.

It also introduces some changes on the omnitracking integration itself bring the `page`, `screen` and `track` flows a bit closer in terms of code logic - in essence it was simplified to use the same functions and only leave the specific logic to each type of event, which are the newly added pageEventMapper and the final process of the event structure that must follow the omnitracking service contract.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
