### PR TITLE
fix: fix user typings and pipeline setup

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -5,12 +5,13 @@
   "license": "MIT",
   "main": "src/index.ts",
   "scripts": {
-    "build": "yarn build:transpile && yarn build:types && yarn build:copy-package-json",
+    "build": "yarn build:transpile && yarn build:types",
     "build:transpile": "../../scripts/transpile.sh",
     "build:types": "tsc -p tsconfig.release.json",
     "build:copy-package-json": "node ../../scripts/copy-package-json.js",
     "prebuild": "rimraf dist tsconfig.release.tsbuildinfo",
-    "ci:types": "tsc -p tsconfig.ci.json"
+    "ci:types": "tsc -p tsconfig.ci.json",
+    "prepack": "yarn build:copy-package-json"
   },
   "repository": {
     "type": "git",

--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -327,7 +327,7 @@ class Analytics {
    */
   async setUser(
     userId: UserData['id'] = null,
-    traits: UserTraits = {},
+    traits: UserTraits = {} as UserTraits,
   ): Promise<this> {
     if (!this.storage) {
       logger.error(

--- a/packages/analytics/src/User.ts
+++ b/packages/analytics/src/User.ts
@@ -71,7 +71,10 @@ class User {
    * @returns Promise that will resolve with the instance that was used when calling this method to allow
    * chaining.
    */
-  async set(id: UserData['id'] = null, traits: UserTraits = {}): Promise<User> {
+  async set(
+    id: UserData['id'] = null,
+    traits: UserTraits = {} as UserTraits,
+  ): Promise<User> {
     // Generate a new localId and store it (if needed)
     await this.localId();
 

--- a/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
@@ -149,7 +149,7 @@ Object {
     "isScreenEventType": [Function],
     "isTrackEventType": [Function],
     "logger": Logger {
-      "prefix": "@farfetch/blackout-analytics@1.0.0-next.46",
+      "prefix": "@farfetch/blackout-analytics@1.0.0-next.47",
     },
     "stringifyQuery": [Function],
     "validateStorage": [Function],

--- a/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
+++ b/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
@@ -27,7 +27,7 @@ import {
   OPTION_SEARCH_QUERY_PARAMETERS,
   OPTION_TRANSFORM_PAYLOAD,
 } from './constants';
-import { postTracking } from '@farfetch/blackout-client';
+import { postTracking, User, UserGender } from '@farfetch/blackout-client';
 import { trackEventsMapper, userGenderValuesMapper } from './definitions';
 import analyticsTrackTypes from '../../types/trackTypes';
 import get from 'lodash/get';
@@ -194,7 +194,11 @@ class Omnitracking extends Integration<OmnitrackingOptions> {
 
       precalculatedPageViewParameters.userGender = get(
         userGenderValuesMapper,
-        `${userTraits.gender}`,
+        `${
+          !userTraits.isGuest
+            ? (userTraits as User).gender
+            : UserGender.NotDefined
+        }`,
         userGenderValuesMapper.NotDefined,
       );
 

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -17,7 +17,12 @@ import { v4 as uuidV4 } from 'uuid';
 import get from 'lodash/get';
 import pick from 'lodash/pick';
 import platformTypes from '../../types/platformTypes';
-import type { EventContext, EventData, TrackTypesValues } from '../..';
+import type {
+  EventContext,
+  EventData,
+  TrackTypesValues,
+  UserTraits,
+} from '../..';
 import type {
   OmnitrackingCommonEventParameters,
   OmnitrackingPageEventParameters,
@@ -285,7 +290,11 @@ export const formatPageEvent = (
   additionalParameters: OmnitrackingPageEventParameters,
 ): OmnitrackingRequestPayload<PageViewEvents> => {
   const correlationId = get(data, 'user.localId', null);
-  const user = get(data, 'user', { id: -1, traits: {}, localId: '' });
+  const user = get(data, 'user', {
+    id: -1,
+    traits: {} as UserTraits,
+    localId: '',
+  });
   const customerId = getCustomerIdFromUser(user);
   const context: EventContext = get(data, 'context', {}) as EventContext;
   const event = getPageEvent(data);
@@ -400,7 +409,11 @@ export const formatTrackEvent = (
   data: EventData<TrackTypesValues>,
   additionalParameters: OmnitrackingTrackEventParameters,
 ): OmnitrackingRequestPayload<PageActionEvents> => {
-  const user = get(data, 'user', { id: -1, traits: {}, localId: '' });
+  const user = get(data, 'user', {
+    id: -1,
+    traits: {} as UserTraits,
+    localId: '',
+  });
   const customerId = getCustomerIdFromUser(user);
   const correlationId = get(data, 'user.localId', null);
   const context = get(data, 'context', {}) as EventContext;

--- a/packages/analytics/src/types/analytics.types.ts
+++ b/packages/analytics/src/types/analytics.types.ts
@@ -3,6 +3,7 @@ import type {
   LOAD_INTEGRATION_TRACK_TYPE,
   ON_SET_USER_TRACK_TYPE,
 } from '../utils/constants';
+import type { GuestUser, User } from '@farfetch/blackout-client';
 import type { Integration } from '../integrations';
 import type trackTypes from '../types/trackTypes';
 
@@ -83,18 +84,7 @@ export interface IntegrationFactory<T extends IntegrationOptions> {
   shouldLoad(consent: ConsentData | null | undefined): boolean;
 }
 
-export type UserTraits = {
-  dateOfBirth?: string;
-  email?: string;
-  firstName?: string;
-  lastName?: string;
-  name?: string;
-  phoneNumber?: string;
-  username?: string;
-  isGuest?: boolean;
-  createdDate?: string;
-  gender?: number;
-} & Record<string, unknown>;
+export type UserTraits = Omit<GuestUser, 'id'> | Omit<User, 'id'>;
 
 export type UserData = {
   id: number | null | undefined;

--- a/packages/analytics/src/utils/hashUserData.ts
+++ b/packages/analytics/src/utils/hashUserData.ts
@@ -9,7 +9,7 @@ import type { UserData, UserTraits } from '../types/analytics.types';
  *
  * @returns The hashed result.
  */
-function hashPlainTextString(plainString?: string): string | undefined {
+function hashPlainTextString(plainString: string | undefined) {
   return plainString ? sha256(plainString).toString() : plainString;
 }
 
@@ -24,21 +24,25 @@ function hashPlainTextString(plainString?: string): string | undefined {
  */
 const hashUserData = (userData: UserData): UserData => {
   if (!isEmpty(userData)) {
-    const traits: UserTraits = userData?.traits || {};
+    const traits: UserTraits = userData?.traits || ({} as UserTraits);
 
-    return {
-      ...(userData as UserData),
-      traits: {
-        ...traits,
-        dateOfBirth: hashPlainTextString(traits.dateOfBirth),
-        email: hashPlainTextString(traits.email),
-        firstName: hashPlainTextString(traits.firstName),
-        lastName: hashPlainTextString(traits.lastName),
-        name: hashPlainTextString(traits.name),
-        phoneNumber: hashPlainTextString(traits.phoneNumber),
-        username: hashPlainTextString(traits.username),
-      },
-    };
+    if (!traits.isGuest) {
+      return {
+        ...(userData as UserData),
+        traits: {
+          ...traits,
+          dateOfBirth: hashPlainTextString(traits.dateOfBirth),
+          email: hashPlainTextString(traits.email) as string,
+          firstName: hashPlainTextString(traits.firstName),
+          lastName: hashPlainTextString(traits.lastName),
+          name: hashPlainTextString(traits.name) as string,
+          phoneNumber: hashPlainTextString(traits.phoneNumber),
+          username: hashPlainTextString(traits.username) as string,
+        },
+      };
+    }
+
+    return userData;
   }
 
   // cases where we might receive null/any other value, keep returning the same value to ensure compatibility

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,12 +5,13 @@
   "license": "MIT",
   "main": "src/index.ts",
   "scripts": {
-    "build": "yarn build:transpile && yarn build:types && yarn build:copy-package-json",
+    "build": "yarn build:transpile && yarn build:types",
     "build:transpile": "../../scripts/transpile.sh",
     "build:types": "tsc -p tsconfig.release.json",
     "build:copy-package-json": "node ../../scripts/copy-package-json.js",
     "prebuild": "rimraf dist tsconfig.release.tsbuildinfo",
-    "ci:types": "tsc -p tsconfig.ci.json"
+    "ci:types": "tsc -p tsconfig.ci.json",
+    "prepack": "yarn build:copy-package-json"
   },
   "repository": {
     "type": "git",

--- a/packages/client/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/client/src/__tests__/__snapshots__/index.test.ts.snap
@@ -381,10 +381,8 @@ Object {
     "PerStoreFlatRate": 0,
   },
   "ShippingMode": Object {
-    "0": "ByMerchant",
-    "1": "ByBundle",
-    "ByBundle": 1,
-    "ByMerchant": 0,
+    "ByBundle": "ByBundle",
+    "ByMerchant": "ByMerchant",
   },
   "ShopperInteraction": Object {
     "0": "Ecommerce",

--- a/packages/client/src/checkout/types/checkoutOrder.types.ts
+++ b/packages/client/src/checkout/types/checkoutOrder.types.ts
@@ -2,8 +2,8 @@ import type { CheckoutAddress } from '../../types/common/address.types';
 import type { CheckoutOrderItem, CheckoutOrderMerchant } from '.';
 
 export enum ShippingMode {
-  ByMerchant,
-  ByBundle,
+  ByMerchant = 'ByMerchant',
+  ByBundle = 'ByBundle',
 }
 
 export enum CheckoutOrderStatus {

--- a/packages/client/src/helpers/client/interceptors/authentication/AuthenticationTokenManager.ts
+++ b/packages/client/src/helpers/client/interceptors/authentication/AuthenticationTokenManager.ts
@@ -642,7 +642,7 @@ class AuthenticationTokenManager {
     }
   }
 
-  async onRequestSuccessfulInterceptor(result: AxiosResponse<any>) {
+  async onRequestSuccessfulInterceptor(result: AxiosResponse) {
     const { config }: { config: RequestConfig } = result;
 
     if (config[AuthenticationConfigOptions.IsGetUserProfileRequest]) {

--- a/packages/client/src/helpers/client/interceptors/authentication/errors.ts
+++ b/packages/client/src/helpers/client/interceptors/authentication/errors.ts
@@ -17,11 +17,7 @@ export class UserSessionExpiredError extends AuthenticationManagerBaseError {
   }
 }
 
-export class RefreshAccessTokenError extends AuthenticationManagerBaseError {
-  constructor(message: string, originalError: AxiosError) {
-    super(message, originalError);
-  }
-}
+export class RefreshAccessTokenError extends AuthenticationManagerBaseError {}
 
 export class RefreshGuestUserAccessTokenError extends RefreshAccessTokenError {
   constructor(originalError: AxiosError) {

--- a/packages/client/src/users/authentication/getGuestUser.ts
+++ b/packages/client/src/users/authentication/getGuestUser.ts
@@ -14,7 +14,14 @@ import type { GetGuestUser } from './types';
 const getGuestUser: GetGuestUser = (guestUserId, config) =>
   client
     .get(join('/account/v1/guestUsers', guestUserId), config)
-    .then(response => response.data)
+    .then(response => {
+      if (!response.data) {
+        return response;
+      }
+
+      // Add isGuest true to normalize with the GuestUser type
+      return { ...response.data, isGuest: true };
+    })
     .catch(error => {
       throw adaptError(error);
     });

--- a/packages/client/src/users/authentication/postGuestUser.ts
+++ b/packages/client/src/users/authentication/postGuestUser.ts
@@ -13,7 +13,14 @@ import type { PostGuestUser } from './types';
 const postGuestUser: PostGuestUser = (data, config?) =>
   client
     .post('/account/v1/guestUsers', data, config)
-    .then(response => response.data)
+    .then(response => {
+      if (!response.data) {
+        return response;
+      }
+
+      // Add isGuest true to normalize with the GuestUser type
+      return { ...response.data, isGuest: true };
+    })
     .catch(error => {
       throw adaptError(error);
     });

--- a/packages/client/src/users/authentication/types/getUser.types.ts
+++ b/packages/client/src/users/authentication/types/getUser.types.ts
@@ -1,5 +1,5 @@
 import type { Config } from '../../../types';
-import type { GuestUserNormalized } from '../..';
+import type { GuestUser } from '../..';
 import type { User } from './user.types';
 
-export type GetUser = (config?: Config) => Promise<User | GuestUserNormalized>;
+export type GetUser = (config?: Config) => Promise<User | GuestUser>;

--- a/packages/client/src/users/authentication/types/guestUser.types.ts
+++ b/packages/client/src/users/authentication/types/guestUser.types.ts
@@ -1,14 +1,3 @@
-export type GuestUser = {
-  id: number;
-  bagId: string;
-  wishlistId: string;
-  ip: string;
-  countryCode: string;
-  externalId: string;
-  friendId: string;
-  expiryDate: string;
-};
-
 export enum UserStatus {
   Inactive = 'Inactive',
   Disabled = 'Disabled',
@@ -19,19 +8,22 @@ export enum UserStatus {
   Unknown = 'Unknown',
 }
 
-// Returned by users/me request when the user is guest
-// This is the normalization of the GuestUser structure done by
-// the backend from the users/me request to match the User structure
-// returned by the users/me for registered users.
-export type GuestUserNormalized = {
+// This type is the combination of the type for values returned
+// by the users/me request and the get/post guest users. The properties
+// that are not common between the 2 types are made optional because of that.
+export type GuestUser = {
   bagId: string;
   countryCode: string;
-  guestBagItemsMerged: number;
-  phoneNumberConfirmed?: boolean;
+  expiryDate?: string;
+  externalId?: string;
+  friendId?: string;
+  guestBagItemsMerged?: number;
   id: number;
-  isExternalLogin: boolean;
+  ip?: string;
+  isExternalLogin?: boolean;
   isGuest: true;
+  phoneNumberConfirmed?: boolean;
   receiveNewsletters?: boolean;
-  status: UserStatus;
+  status?: UserStatus;
   wishlistId: string;
 };

--- a/packages/client/src/users/authentication/types/user.types.ts
+++ b/packages/client/src/users/authentication/types/user.types.ts
@@ -1,7 +1,7 @@
-import type { GuestUserNormalized } from './guestUser.types';
+import type { GuestUser } from './guestUser.types';
 import type { UserGender } from '../../../types';
 
-export type User = Omit<GuestUserNormalized, 'isGuest'> & {
+export type User = Omit<GuestUser, 'isGuest'> & {
   dateOfBirth?: string;
   email: string;
   gender?: UserGender;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,12 +5,13 @@
   "license": "MIT",
   "main": "./src/index.ts",
   "scripts": {
-    "build": "yarn build:transpile && yarn build:types && yarn build:copy-package-json",
+    "build": "yarn build:transpile && yarn build:types",
     "build:transpile": "../../scripts/transpile.sh",
     "build:types": "tsc -p tsconfig.release.json",
     "build:copy-package-json": "node ../../scripts/copy-package-json.js",
     "prebuild": "rimraf dist tsconfig.release.tsbuildinfo",
-    "ci:types": "tsc -p tsconfig.ci.json"
+    "ci:types": "tsc -p tsconfig.ci.json",
+    "prepack": "yarn build:copy-package-json"
   },
   "repository": {
     "type": "git",

--- a/packages/react/src/analytics/integrations/Castle/Castle.ts
+++ b/packages/react/src/analytics/integrations/Castle/Castle.ts
@@ -199,18 +199,21 @@ class Castle extends integrations.Integration<CastleIntegrationOptions> {
    */
   getUserData(data: TrackEventData | PageviewEventData) {
     const userData: UserData = data.user || {};
-    const userTraits: UserTraits = userData.traits || {};
+    const userTraits: UserTraits = userData.traits || ({} as UserTraits);
 
     const formattedUserData: UserParams = {
       id: userData.id?.toString() || 'USER NOT LOADED YET',
-      email: userTraits.email,
-      phone: userTraits.phoneNumber,
-      name: userTraits.name,
-      registered_at: userTraits.createdDate,
       traits: {
         isGuest: userTraits.isGuest,
       },
     };
+
+    if (!userTraits.isGuest) {
+      formattedUserData.email = userTraits.email;
+      formattedUserData.phone = userTraits.phoneNumber;
+      formattedUserData.name = userTraits.name;
+      formattedUserData.registered_at = userTraits.createdDate;
+    }
 
     // clean "falsy" values to ensure the SDK accepts the request.
     return pickBy(formattedUserData, identity) as UserParams;

--- a/packages/react/src/analytics/integrations/GA/commands.ts
+++ b/packages/react/src/analytics/integrations/GA/commands.ts
@@ -299,7 +299,8 @@ const addRefundProductsCommand = (
 /**
  * GA commands map by event name.
  */
-export default {
+
+const commands = {
   [eventTypes.PRODUCT_ADDED_TO_CART]: (
     data: EventData<TrackTypesValues>,
     customProductMappings: ProductMappings,
@@ -584,6 +585,8 @@ export default {
     ];
   },
 };
+
+export default commands;
 
 // Schema used to validate the output of command functions
 export const commandListSchema = validationSchemaBuilder

--- a/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.ts
+++ b/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.ts
@@ -288,7 +288,7 @@ const signupNewsletterSchema = yup.object({
     ),
 });
 
-export default {
+const eventSchemas = {
   [eventTypes.CHECKOUT_ABANDONED]: checkoutAbandonedSchema,
   [eventTypes.CHECKOUT_STARTED]: beginCheckoutSchema,
   [eventTypes.ORDER_COMPLETED]: purchaseAndRefundSchema,
@@ -316,3 +316,5 @@ export default {
   [eventTypes.INTERACT_CONTENT]: interactContentSchema,
   [eventTypes.SIGNUP_NEWSLETTER]: signupNewsletterSchema,
 };
+
+export default eventSchemas;

--- a/packages/react/src/analytics/integrations/GTM/utils.ts
+++ b/packages/react/src/analytics/integrations/GTM/utils.ts
@@ -10,6 +10,7 @@ import type {
   UserTraits,
 } from '@farfetch/blackout-analytics';
 import type { GTMEventContext } from './types';
+import type { User } from '@farfetch/blackout-client';
 import type URLParse from 'url-parse';
 
 /**
@@ -35,8 +36,8 @@ export const getUserParameters = (
 ): {
   id: UserData['id'];
   localId: UserData['localId'];
-  email: UserTraits['email'];
-  name: UserTraits['name'];
+  email: User['email'];
+  name: User['name'];
   isGuest: UserTraits['isGuest'];
 } => ({
   id: get(user, 'id'),

--- a/packages/react/src/analytics/integrations/shared/validation/eventValidator.ts
+++ b/packages/react/src/analytics/integrations/shared/validation/eventValidator.ts
@@ -13,7 +13,7 @@ import type { Schema } from '../types/shared.types';
  *
  * @returns The result of the validation with valid and errorMessage properties.
  */
-export default (
+const eventValidator = (
   data: EventData<TrackTypesValues>,
   validationSchema?: Schema,
 ) => {
@@ -36,3 +36,5 @@ export default (
     errorMessage: validationErrorMessage,
   };
 };
+
+export default eventValidator;

--- a/packages/react/src/authentication/contexts/AuthenticationProvider.tsx
+++ b/packages/react/src/authentication/contexts/AuthenticationProvider.tsx
@@ -141,7 +141,7 @@ function AuthenticationProvider({
     [],
   );
 
-  const previousTokenManager: AuthenticationTokenManager =
+  const previousTokenManager: AuthenticationTokenManager | undefined =
     usePrevious(tokenManager);
 
   useEffect(() => {

--- a/packages/react/src/authentication/contexts/UserProfileContext.ts
+++ b/packages/react/src/authentication/contexts/UserProfileContext.ts
@@ -1,12 +1,12 @@
 import { createContext } from 'react';
 import type { Error } from './UserProfileProvider';
-import type { GuestUserNormalized, User } from '@farfetch/blackout-client';
+import type { GuestUser, User } from '@farfetch/blackout-client';
 
 export interface UserProfileContextProps {
-  loadProfile: () => Promise<User | GuestUserNormalized> | null;
+  loadProfile: () => Promise<User | GuestUser> | null;
   isLoading: boolean;
   error: Error | null;
-  userData: User | GuestUserNormalized | null;
+  userData: User | GuestUser | null;
 }
 
 export default createContext<UserProfileContextProps>(

--- a/packages/react/src/authentication/contexts/UserProfileProvider.tsx
+++ b/packages/react/src/authentication/contexts/UserProfileProvider.tsx
@@ -1,7 +1,7 @@
 import {
   AuthenticationConfigOptions,
   getUser,
-  GuestUserNormalized,
+  GuestUser,
   User,
 } from '@farfetch/blackout-client';
 import { ProfileChangedError } from '../errors';
@@ -13,18 +13,18 @@ import UserProfileContext from './UserProfileContext';
 interface Props {
   children: React.ReactNode;
   fetchProfileOnTokenChanges: boolean;
-  onProfileChange: (response: User | GuestUserNormalized) => void;
+  onProfileChange: (response: User | GuestUser) => void;
 }
 
 interface State {
   isLoading: boolean;
   error: Error | null;
-  userData: User | GuestUserNormalized | null;
+  userData: User | GuestUser | null;
 }
 
 interface Action {
   type: string;
-  payload?: User | GuestUserNormalized | Error;
+  payload?: User | GuestUser | Error;
 }
 
 export interface Error {
@@ -60,7 +60,7 @@ const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         isLoading: false,
-        userData: action.payload as User | GuestUserNormalized,
+        userData: action.payload as User | GuestUser,
       };
     }
 
@@ -106,13 +106,11 @@ const UserProfileProvider = ({
 }: Props) => {
   const [userProfileState, dispatch] = useReducer(reducer, initialState);
   const { activeTokenData, tokenManager } = useAuthentication();
-  const currentLoadProfilePromiseRef = useRef<Promise<
-    User | GuestUserNormalized
-  > | null>(null);
+  const currentLoadProfilePromiseRef = useRef<Promise<User | GuestUser> | null>(
+    null,
+  );
 
-  const loadProfileAux = useCallback(async (): Promise<
-    User | GuestUserNormalized
-  > => {
+  const loadProfileAux = useCallback(async (): Promise<User | GuestUser> => {
     dispatch({ type: ActionTypes.GetUserRequested });
 
     let usedAccessToken = null;
@@ -122,7 +120,7 @@ const UserProfileProvider = ({
     };
 
     try {
-      const userData: User | GuestUserNormalized = await getUser({
+      const userData: User | GuestUser = await getUser({
         [AuthenticationConfigOptions.UsedAccessTokenCallback]:
           setAccessTokenRef,
         [AuthenticationConfigOptions.IsGetUserProfileRequest]: true,
@@ -151,7 +149,7 @@ const UserProfileProvider = ({
     } catch (error) {
       dispatch({
         type: ActionTypes.GetUserFailed,
-        payload: error as User | GuestUserNormalized | Error | undefined,
+        payload: error as User | GuestUser | Error | undefined,
       });
       throw error;
     }

--- a/packages/react/src/bags/hooks/types/useBag.ts
+++ b/packages/react/src/bags/hooks/types/useBag.ts
@@ -6,7 +6,11 @@ import type {
   PostBagItemQuery,
   ProductType,
 } from '@farfetch/blackout-client';
-import type { BagItemHydrated, BagsState } from '@farfetch/blackout-redux';
+import type {
+  BagItemActionMetadata,
+  BagItemHydrated,
+  BagsState,
+} from '@farfetch/blackout-redux';
 
 export type UseBag = (excludeProductTypes?: ProductType[]) => {
   bag: BagsState['result'];
@@ -14,6 +18,7 @@ export type UseBag = (excludeProductTypes?: ProductType[]) => {
   addBagItem: (
     data: PostBagItemData,
     query?: PostBagItemQuery,
+    metadata?: BagItemActionMetadata,
     config?: Config,
   ) => Promise<Bag>;
   fetchBag: (

--- a/packages/react/src/categories/hooks/useCategories.ts
+++ b/packages/react/src/categories/hooks/useCategories.ts
@@ -20,6 +20,8 @@ import { useSelector } from 'react-redux';
 import type { Category } from '@farfetch/blackout-client';
 import type { GetRootCategory, UseCategories } from './types';
 
+const categoriesDefaultValue: Record<string, never> = {} as const;
+
 /**
  * It provides actions, selectors and methods for categories data.
  *
@@ -33,7 +35,7 @@ const useCategories: UseCategories = () => {
   const areTopCategoriesLoading = useSelector(areTopCategoriesLoadingSelector);
   const areCategoriesFetched = useSelector(areCategoriesFetchedSelector);
   const areTopCategoriesFetched = useSelector(areTopCategoriesFetchedSelector);
-  const categories = useSelector(getCategories) || {};
+  const categories = useSelector(getCategories) || categoriesDefaultValue;
   const topCategories = useSelector(getTopCategories);
   /**
    * Gets a specific category by id.

--- a/packages/react/src/helpers/usePrevious.ts
+++ b/packages/react/src/helpers/usePrevious.ts
@@ -11,8 +11,8 @@ import { useEffect, useRef } from 'react';
  *
  * @returns - The previous value stored.
  */
-export default (value: any): any => {
-  const ref = useRef();
+const usePrevious = <T>(value: T): T | undefined => {
+  const ref = useRef<T>();
 
   // Store current value in ref
   useEffect(() => {
@@ -22,3 +22,5 @@ export default (value: any): any => {
   // Return previous value (happens before update in useEffect above)
   return ref.current;
 };
+
+export default usePrevious;

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -5,12 +5,13 @@
   "license": "MIT",
   "main": "src/index.ts",
   "scripts": {
-    "build": "yarn build:transpile && yarn build:types && yarn build:copy-package-json",
+    "build": "yarn build:transpile && yarn build:types",
     "build:transpile": "../../scripts/transpile.sh",
     "build:types": "tsc -p tsconfig.release.json",
     "build:copy-package-json": "node ../../scripts/copy-package-json.js",
     "prebuild": "rimraf dist tsconfig.release.tsbuildinfo",
-    "ci:types": "tsc -p tsconfig.ci.json"
+    "ci:types": "tsc -p tsconfig.ci.json",
+    "prepack": "yarn build:copy-package-json"
   },
   "repository": {
     "type": "git",

--- a/packages/redux/src/analytics/middlewares/types/setUser.types.ts
+++ b/packages/redux/src/analytics/middlewares/types/setUser.types.ts
@@ -7,17 +7,18 @@ import type {
 } from '../setUser';
 import type { StoreState } from '../../../types';
 import type { UserData, UserTraits } from '@farfetch/blackout-analytics';
-
-export type UserType = UserTraits & { id: UserData['id'] };
+import type { UserEntity } from '../../../entities';
 
 export type SetUserActionTypes = Set<string> | Array<string>;
 
 export type SetUserActionOptions = {
   [OPTION_TRIGGER_SET_USER_ACTIONS]?: Set<string>;
   [OPTION_TRIGGER_ANONYMIZE_ACTIONS]?: Set<string>;
-  [OPTION_FETCH_USER_ID_SELECTOR]?: (user: UserType | null) => UserData['id'];
-  [OPTION_FETCH_USER_SELECTOR]?: (state: StoreState) => UserType;
-  [OPTION_USER_TRAITS_PICKER]?: (user: UserType) => UserTraits;
+  [OPTION_FETCH_USER_ID_SELECTOR]?: (
+    user: UserEntity | undefined,
+  ) => UserData['id'];
+  [OPTION_FETCH_USER_SELECTOR]?: (state: StoreState) => UserEntity;
+  [OPTION_USER_TRAITS_PICKER]?: (user: UserEntity | undefined) => UserTraits;
 };
 export type SetUserMiddlewareOptions =
   | SetUserActionOptions

--- a/packages/redux/src/checkout/actions/fetchCheckoutOrderOperation.ts
+++ b/packages/redux/src/checkout/actions/fetchCheckoutOrderOperation.ts
@@ -3,11 +3,5 @@ import fetchCheckoutOrderOperationFactory from './factories/fetchCheckoutOrderOp
 
 /**
  * Fetch checkout order operation.
- *
- * @memberof module:checkout/actions
- *
- * @name fetchCheckoutOrderOperation
- *
- * @type {FetchCheckoutOrderOperationThunkFactory}
  */
 export default fetchCheckoutOrderOperationFactory(getCheckoutOrderOperation);

--- a/packages/redux/src/checkout/actions/fetchCheckoutOrderOperations.ts
+++ b/packages/redux/src/checkout/actions/fetchCheckoutOrderOperations.ts
@@ -3,11 +3,5 @@ import fetchCheckoutOrderOperationsFactory from './factories/fetchCheckoutOrderO
 
 /**
  * Fetch checkout order operations.
- *
- * @memberof module:checkout/actions
- *
- * @name fetchCheckoutOrderOperations
- *
- * @type {FetchCheckoutOrderOperationsThunkFactory}
  */
 export default fetchCheckoutOrderOperationsFactory(getCheckoutOrderOperations);

--- a/packages/redux/src/checkout/actions/resetCheckoutOrderChargeState.ts
+++ b/packages/redux/src/checkout/actions/resetCheckoutOrderChargeState.ts
@@ -1,9 +1,10 @@
 import * as actionTypes from '../actionTypes';
+import type { Dispatch } from 'redux';
 
 /**
  * Reset the charges state.
  */
-const resetCheckoutOrderChargeState = () => (dispatch: any) => {
+const resetCheckoutOrderChargeState = () => (dispatch: Dispatch) => {
   dispatch({
     type: actionTypes.RESET_CHECKOUT_ORDER_CHARGE_STATE,
   });

--- a/packages/redux/src/checkout/actions/resetCheckoutState.ts
+++ b/packages/redux/src/checkout/actions/resetCheckoutState.ts
@@ -4,9 +4,12 @@ import type { Dispatch } from 'redux';
 /**
  * Reset the checkout state.
  */
-export default () =>
+const resetCheckoutState =
+  () =>
   (dispatch: Dispatch): void => {
     dispatch({
       type: actionTypes.RESET_CHECKOUT_STATE,
     });
   };
+
+export default resetCheckoutState;

--- a/packages/redux/src/contents/actions/resetContents.ts
+++ b/packages/redux/src/contents/actions/resetContents.ts
@@ -6,9 +6,12 @@ import type { Dispatch } from 'redux';
  *
  * @returns - Dispatch reset action.
  */
-export default () =>
+const resetContents =
+  () =>
   (dispatch: Dispatch): void => {
     dispatch({
       type: actionTypes.RESET_CONTENTS,
     });
   };
+
+export default resetContents;

--- a/packages/redux/src/entities/schemas/facet.ts
+++ b/packages/redux/src/entities/schemas/facet.ts
@@ -1,8 +1,9 @@
 import { schema } from 'normalizr';
+import type { FacetGroup, FacetValue } from '@farfetch/blackout-client';
 
 export const getId = (
-  { value, valueUpperBound, groupsOn }: any,
-  { description, type: parentType }: any,
+  { value, valueUpperBound, groupsOn }: FacetValue,
+  { description, type: parentType }: FacetGroup,
 ) =>
   `${description.toLowerCase()}_${value}${
     // Special scenario when the facet type is "sizes" or "size by category"

--- a/packages/redux/src/entities/schemas/productsList.ts
+++ b/packages/redux/src/entities/schemas/productsList.ts
@@ -77,7 +77,9 @@ export default new schema.Entity(
             return {
               ...filterSegment,
               description: filterSegment.description || facet?.description,
-              facetId: facet ? getId(facet, facetGroup) : undefined,
+              facetId: facet
+                ? getId(facet, facetGroup as FacetGroup)
+                : undefined,
             };
           }
 
@@ -88,7 +90,9 @@ export default new schema.Entity(
           return {
             ...filterSegment,
             description: filterSegment.description || facet?.description,
-            facetId: facet ? getId(facet, filteredFacetGroups?.[0]) : undefined,
+            facetId: facet
+              ? getId(facet, filteredFacetGroups?.[0] as FacetGroup)
+              : undefined,
           };
         },
       );

--- a/packages/redux/src/entities/selectors/user.ts
+++ b/packages/redux/src/entities/selectors/user.ts
@@ -1,6 +1,8 @@
 import { getEntities } from './entity';
 import { USER_ID_PROPERTY } from '../constants';
 import get from 'lodash/get';
+import type { StoreState } from '../../types';
+import type { UserEntity } from '../types/user.types';
 
 /**
  * Returns the current user.
@@ -9,7 +11,7 @@ import get from 'lodash/get';
  *
  * @returns User object.
  */
-export const getUser = (state: any): any => getEntities(state, 'user');
+export const getUser = (state: StoreState) => getEntities(state, 'user');
 
 /**
  * Return the user with the specified id.
@@ -18,7 +20,8 @@ export const getUser = (state: any): any => getEntities(state, 'user');
  *
  * @returns The user id, if defined.
  */
-export const getUserId = (user: any): any => get(user, USER_ID_PROPERTY);
+export const getUserId = (user: UserEntity | undefined) =>
+  get(user, USER_ID_PROPERTY);
 
 /**
  * Return the user's email.
@@ -27,7 +30,8 @@ export const getUserId = (user: any): any => get(user, USER_ID_PROPERTY);
  *
  * @returns User email.
  */
-export const getUserEmail = (user: any): any => get(user, 'email');
+export const getUserEmail = (user: UserEntity | undefined) =>
+  get(user, 'email');
 
 /**
  * Return the user segments.
@@ -36,7 +40,8 @@ export const getUserEmail = (user: any): any => get(user, 'email');
  *
  * @returns User segments.
  */
-export const getUserSegments = (user: any): any => get(user, 'segments');
+export const getUserSegments = (user: UserEntity | undefined) =>
+  get(user, 'segments');
 
 /**
  * Return if the user is guest or not.
@@ -45,7 +50,8 @@ export const getUserSegments = (user: any): any => get(user, 'segments');
  *
  * @returns If user is guest.
  */
-export const getUserIsGuest = (user: any): any => get(user, 'isGuest');
+export const getUserIsGuest = (user: UserEntity | undefined) =>
+  get(user, 'isGuest');
 
 /**
  * Return the user's name.
@@ -54,7 +60,8 @@ export const getUserIsGuest = (user: any): any => get(user, 'isGuest');
  *
  * @returns User name.
  */
-export const getUsername = (user: any): any => get(user, 'username');
+export const getUsername = (user: UserEntity | undefined) =>
+  get(user, 'username');
 
 /**
  * Return the user's membership.
@@ -63,7 +70,8 @@ export const getUsername = (user: any): any => get(user, 'username');
  *
  * @returns User membership.
  */
-export const getUserMembership = (user: any): any => get(user, 'membership');
+export const getUserMembership = (user: UserEntity | undefined) =>
+  get(user, 'membership');
 
 /**
  * Return the user's credit.
@@ -72,7 +80,8 @@ export const getUserMembership = (user: any): any => get(user, 'membership');
  *
  * @returns User credit.
  */
-export const getUserCredit = (user: any): any => get(user, 'credit');
+export const getUserCredit = (user: UserEntity | undefined) =>
+  get(user, 'credit');
 
 /**
  * Return the user's credit movements.
@@ -81,7 +90,7 @@ export const getUserCredit = (user: any): any => get(user, 'credit');
  *
  * @returns Credit movements.
  */
-export const getUserCreditMovements = (user: any): any =>
+export const getUserCreditMovements = (user: UserEntity | undefined) =>
   get(user, 'creditMovements');
 
 /**
@@ -91,7 +100,8 @@ export const getUserCreditMovements = (user: any): any =>
  *
  * @returns User gender.
  */
-export const getUserGender = (user: any): any => get(user, 'gender');
+export const getUserGender = (user: UserEntity | undefined) =>
+  get(user, 'gender');
 
 /**
  * Return the user's bag id.
@@ -100,7 +110,8 @@ export const getUserGender = (user: any): any => get(user, 'gender');
  *
  * @returns Bag id.
  */
-export const getUserBagId = (user: any): any => get(user, 'bagId');
+export const getUserBagId = (user: UserEntity | undefined) =>
+  get(user, 'bagId');
 
 /**
  * Returns the user's title.
@@ -109,4 +120,5 @@ export const getUserBagId = (user: any): any => get(user, 'bagId');
  *
  * @returns Object containing the title details (id and value).
  */
-export const getUserTitle = (user: any): any => get(user, 'title');
+export const getUserTitle = (user: UserEntity | undefined) =>
+  get(user, 'title');

--- a/packages/redux/src/entities/types/user.types.ts
+++ b/packages/redux/src/entities/types/user.types.ts
@@ -1,6 +1,5 @@
 import type {
   GuestUser,
-  GuestUserNormalized,
   User,
   UserContact,
   UserPreference,
@@ -10,7 +9,7 @@ import type {
   UserCreditMovementsEntity,
 } from './credit.types';
 
-export type UserEntity = (User | GuestUserNormalized | GuestUser) & {
+export type UserEntity = (User | GuestUser) & {
   credit?: UserCreditEntity;
   creditMovements?: UserCreditMovementsEntity;
   preferences?: Array<UserPreference['code']>;

--- a/packages/redux/src/helpers/buildQueryStringFromObject.ts
+++ b/packages/redux/src/helpers/buildQueryStringFromObject.ts
@@ -16,7 +16,7 @@ import isEmpty from 'lodash/isEmpty';
  *
  * @returns Query string with all parameters received.
  */
-export default (
+const buildQueryStringFromObject = (
   obj: Record<string, unknown>,
   useQuestionMark = true,
 ): string => {
@@ -38,3 +38,5 @@ export default (
 
   return paramsToUrl.length ? `${prefix}${paramsToUrl.join('&')}` : '';
 };
+
+export default buildQueryStringFromObject;

--- a/packages/redux/src/helpers/createMergedObject.ts
+++ b/packages/redux/src/helpers/createMergedObject.ts
@@ -16,15 +16,15 @@ import merge from 'lodash/merge';
  * more info).
  */
 export default function createMergedObject(
-  target: { [k: string]: any },
-  source: { [k: string]: any },
+  target: Record<string, any>,
+  source: Record<string, any>,
 ) {
   if (!target) {
     return merge({}, source);
   }
 
   const properties = Object.keys(source);
-  const targetUpdatedProperties: { [k: string]: any } = {};
+  const targetUpdatedProperties: Record<string, any> = {};
 
   properties.forEach(prop => {
     const targetValue = target[prop];
@@ -32,7 +32,7 @@ export default function createMergedObject(
 
     if (isPlainObject(targetValue) && isPlainObject(sourceValue)) {
       targetUpdatedProperties[prop] = createMergedObject(
-        targetValue,
+        targetValue as Record<string, any>,
         sourceValue,
       );
     } else if (sourceValue !== undefined) {

--- a/packages/redux/src/locale/actions/resetLocaleState.ts
+++ b/packages/redux/src/locale/actions/resetLocaleState.ts
@@ -7,8 +7,10 @@ import type { Dispatch } from 'redux';
  * @returns - Dispatch reset action.
  */
 
-export default () => (dispatch: Dispatch) => {
+const resetLocaleState = () => (dispatch: Dispatch) => {
   dispatch({
     type: actionTypes.RESET_LOCALE_STATE,
   });
 };
+
+export default resetLocaleState;

--- a/packages/redux/src/locale/actions/setCountryCode.ts
+++ b/packages/redux/src/locale/actions/setCountryCode.ts
@@ -9,9 +9,11 @@ import type { Dispatch } from 'redux';
  * @returns - Dispatch set country code action.
  */
 
-export default (countryCode: string) => (dispatch: Dispatch) => {
+const setCountryCode = (countryCode: string) => (dispatch: Dispatch) => {
   dispatch({
     type: actionTypes.SET_COUNTRY_CODE,
     payload: { countryCode },
   });
 };
+
+export default setCountryCode;

--- a/packages/redux/src/search/actions/resetSearchDidYouMean.ts
+++ b/packages/redux/src/search/actions/resetSearchDidYouMean.ts
@@ -6,9 +6,12 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default () =>
+const resetSearchDidYouMean =
+  () =>
   (dispatch: Dispatch): void => {
     dispatch({
       type: actionTypes.RESET_SEARCH_DID_YOU_MEAN,
     });
   };
+
+export default resetSearchDidYouMean;

--- a/packages/redux/src/search/actions/resetSearchIntents.ts
+++ b/packages/redux/src/search/actions/resetSearchIntents.ts
@@ -6,9 +6,12 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default () =>
+const resetSearchIntents =
+  () =>
   (dispatch: Dispatch): void => {
     dispatch({
       type: actionTypes.RESET_SEARCH_INTENTS,
     });
   };
+
+export default resetSearchIntents;

--- a/packages/redux/src/search/actions/resetSearchSuggestions.ts
+++ b/packages/redux/src/search/actions/resetSearchSuggestions.ts
@@ -6,9 +6,12 @@ import type { Dispatch } from 'redux';
  *
  * @returns Thunk factory.
  */
-export default () =>
+const resetSearchSuggestions =
+  () =>
   (dispatch: Dispatch): void => {
     dispatch({
       type: actionTypes.RESET_SEARCH_SUGGESTIONS,
     });
   };
+
+export default resetSearchSuggestions;

--- a/packages/redux/src/sizeGuides/actions/resetSizeGuidesState.ts
+++ b/packages/redux/src/sizeGuides/actions/resetSizeGuidesState.ts
@@ -6,9 +6,12 @@ import type { Dispatch } from 'redux';
  *
  * @returns Dispatch reset action.
  */
-export default () =>
+const resetSizeGuidesState =
+  () =>
   (dispatch: Dispatch): void => {
     dispatch({
       type: actionTypes.RESET_SIZE_GUIDES_STATE,
     });
   };
+
+export default resetSizeGuidesState;

--- a/packages/redux/src/users/authentication/actions/__tests__/__snapshots__/createGuestUser.test.ts.snap
+++ b/packages/redux/src/users/authentication/actions/__tests__/__snapshots__/createGuestUser.test.ts.snap
@@ -12,6 +12,7 @@ Object {
         "friendId": "string",
         "id": 34923,
         "ip": "string",
+        "isGuest": true,
         "wishlistId": "string",
       },
     },

--- a/packages/redux/src/users/authentication/actions/__tests__/__snapshots__/fetchGuestUser.test.ts.snap
+++ b/packages/redux/src/users/authentication/actions/__tests__/__snapshots__/fetchGuestUser.test.ts.snap
@@ -12,6 +12,7 @@ Object {
         "friendId": "string",
         "id": 34923,
         "ip": "string",
+        "isGuest": true,
         "wishlistId": "string",
       },
     },

--- a/packages/redux/src/users/authentication/actions/factories/changePasswordFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/changePasswordFactory.ts
@@ -17,7 +17,7 @@ import type { Dispatch } from 'redux';
 const changePasswordFactory =
   (postPasswordChange: PostPasswordChange) =>
   (data: PostPasswordChangeData, config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.PASSWORD_CHANGE_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/createClientCredentialsTokenFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/createClientCredentialsTokenFactory.ts
@@ -12,7 +12,7 @@ import type { Dispatch } from 'redux';
 const createClientCredentialsTokenFactory =
   (postTokens: PostToken) =>
   (config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.CREATE_CLIENT_CREDENTIALS_TOKEN_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/createUserImpersonationFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/createUserImpersonationFactory.ts
@@ -17,7 +17,7 @@ import type { Dispatch } from 'redux';
 const createUserImpersonationFactory =
   (postUserImpersonation: PostUserImpersonation) =>
   (data: PostUserImpersonationData, config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.CREATE_USER_IMPERSONATION_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/createUserTokenFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/createUserTokenFactory.ts
@@ -17,7 +17,7 @@ import type { Dispatch } from 'redux';
 const createUserTokenFactory =
   (postTokens: PostToken) =>
   (data: PostTokenData, config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.CREATE_USER_TOKEN_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/loginFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/loginFactory.ts
@@ -2,6 +2,7 @@ import * as actionTypes from '../../actionTypes';
 import {
   Config,
   LoginData,
+  LoginResponse,
   PostLogin,
   toBlackoutError,
 } from '@farfetch/blackout-client';
@@ -20,7 +21,7 @@ const UNVERIFIED_USER = 4;
 const loginFactory =
   (postLogin: PostLogin) =>
   (data: LoginData, config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch): Promise<LoginResponse> => {
     try {
       dispatch({
         type: actionTypes.LOGIN_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/logoutFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/logoutFactory.ts
@@ -12,7 +12,7 @@ import type { Dispatch } from 'redux';
 const logoutFactory =
   (postLogout: PostLogout) =>
   (config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.LOGOUT_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/recoverPasswordFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/recoverPasswordFactory.ts
@@ -17,7 +17,7 @@ import type { Dispatch } from 'redux';
 const recoverPasswordFactory =
   (postPasswordRecover: PostPasswordRecover) =>
   (data: PostPasswordRecoverData, config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.PASSWORD_RECOVER_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/refreshEmailTokenFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/refreshEmailTokenFactory.ts
@@ -19,7 +19,7 @@ import type { Dispatch } from 'redux';
 const refreshEmailTokenFactory =
   (postRefreshEmailToken: PostRefreshEmailToken) =>
   (data: PostRefreshEmailTokenData, config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.REFRESH_EMAIL_TOKEN_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/refreshTokenFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/refreshTokenFactory.ts
@@ -12,7 +12,7 @@ import type { Dispatch } from 'redux';
 const refreshTokenFactory =
   (postToken: PostToken) =>
   (refreshToken: string, config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.REFRESH_USER_TOKEN_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/registerFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/registerFactory.ts
@@ -20,7 +20,7 @@ const UNVERIFIED_USER = 4;
 const registerFactory =
   (postRegister: PostRegister) =>
   (data: PostRegisterData, config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.REGISTER_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/removeUserImpersonationFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/removeUserImpersonationFactory.ts
@@ -16,7 +16,7 @@ import type { Dispatch } from 'redux';
 const removeUserImpersonationFactory =
   (deleteUserImpersonation: DeleteUserImpersonation) =>
   (impersonatedAccessTokenId: string, config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.DELETE_USER_IMPERSONATION_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/resetPasswordFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/resetPasswordFactory.ts
@@ -17,7 +17,7 @@ import type { Dispatch } from 'redux';
 const resetPasswordFactory =
   (postPasswordReset: PostPasswordReset) =>
   (data: PostPasswordResetData, config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.PASSWORD_RESET_REQUEST,

--- a/packages/redux/src/users/authentication/actions/factories/validateEmailFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/validateEmailFactory.ts
@@ -17,7 +17,7 @@ import type { Dispatch } from 'redux';
 const validateEmailFactory =
   (postValidateEmail: PostValidateEmail) =>
   (data: PostValidateEmailData, config?: Config) =>
-  async (dispatch: Dispatch): Promise<any> => {
+  async (dispatch: Dispatch) => {
     try {
       dispatch({
         type: actionTypes.VALIDATE_EMAIL_REQUEST,

--- a/packages/redux/src/users/authentication/selectors.ts
+++ b/packages/redux/src/users/authentication/selectors.ts
@@ -23,7 +23,7 @@ import type { UsersState } from '../types';
  * @returns IsAuthenticated.
  */
 export const isAuthenticated = (state: StoreState) =>
-  Boolean(getUser(state) && !getUser(state).isGuest && getUser(state).id);
+  Boolean(getUser(state) && !getUser(state)?.isGuest && getUser(state)?.id);
 
 /**
  * Returns the error or loading status of each sub-area.

--- a/packages/redux/src/users/reducer.ts
+++ b/packages/redux/src/users/reducer.ts
@@ -49,6 +49,11 @@ export const INITIAL_STATE: UsersState = {
 };
 
 export const entitiesMapper = {
+  ...addressesEntitiesMapper,
+  ...benefitsEntitiesMapper,
+  ...preferencesEntitiesMapper,
+  ...creditsEntitiesMapper,
+  ...contactsEntitiesMapper,
   [actionTypes.RESET_USER_ENTITIES]: (
     state: NonNullable<StoreState['entities']>,
   ) => {
@@ -57,11 +62,6 @@ export const entitiesMapper = {
       ...rest,
     };
   },
-  ...addressesEntitiesMapper,
-  ...benefitsEntitiesMapper,
-  ...preferencesEntitiesMapper,
-  ...creditsEntitiesMapper,
-  ...contactsEntitiesMapper,
   [actionTypes.LOGOUT_SUCCESS]: (
     state: NonNullable<StoreState['entities']>,
   ) => {

--- a/packages/redux/src/wishlists/actions/resetWishlistSetsState.ts
+++ b/packages/redux/src/wishlists/actions/resetWishlistSetsState.ts
@@ -9,10 +9,13 @@ import type { ResetWishlistSetsStateAction } from '../types';
  *
  * @returns Dispatch reset wishlists sets state action.
  */
-export default (fieldsToReset?: string[]) =>
+const resetWishlistSetsState =
+  (fieldsToReset?: string[]) =>
   (dispatch: Dispatch<ResetWishlistSetsStateAction>): void => {
     dispatch({
       payload: { fieldsToReset },
       type: actionTypes.RESET_WISHLIST_SETS_STATE,
     });
   };
+
+export default resetWishlistSetsState;

--- a/tests/__fixtures__/users/guestUsers.fixtures.ts
+++ b/tests/__fixtures__/users/guestUsers.fixtures.ts
@@ -7,6 +7,7 @@ export const mockGuestUserResponse = {
   countryCode: 'string',
   externalId: 'string',
   friendId: 'string',
+  isGuest: true,
   expiryDate: '2020-03-31T15:21:55.109Z',
 };
 

--- a/tsconfig.release.base.json
+++ b/tsconfig.release.base.json
@@ -30,11 +30,11 @@
     "composite": true,
 
     /* Emit */
-    "declarationMap": true,
+    "declarationMap": false,
     "importHelpers": true,
     "importsNotUsedAsValues": "error",
     "noEmitOnError": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "stripInternal": true,
     "emitDeclarationOnly": true,
 


### PR DESCRIPTION
## Description

- This commit unifies the types `GuestUser` and `GuestUserNormalized`
to make development easier. This distinction existed because
the `getGuestUser` and `postGuestUser` clients return a
different type than the one returned by the `getUser` endpoint when the
user is guest. With this change it will
be easier to interact with user values.
- Fix release pipeline to copy the package.json to the dist folder after
lerna updates the package.json of the packages with the new calculated
version.
- Remove source maps and declaration maps option for
compilation as they are useless because we are not publishing the
source code of the package.
- Fix some uses of `any` for the right type.
- Fix some lint warnings.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
