### PR TITLE
feat(react): refactor useProductDetails hook

### DIFF
--- a/packages/react/src/products/hooks/__tests__/useProductDetails.test.tsx
+++ b/packages/react/src/products/hooks/__tests__/useProductDetails.test.tsx
@@ -8,7 +8,7 @@ import {
   mockProductsState,
 } from 'tests/__fixtures__/products';
 import { renderHook } from '@testing-library/react';
-import { withStore } from '@farfetch/blackout-react/tests/helpers';
+import { withStore } from '../../../../tests/helpers';
 import useProductDetails from '../useProductDetails';
 
 jest.mock('@farfetch/blackout-redux', () => ({
@@ -18,6 +18,8 @@ jest.mock('@farfetch/blackout-redux', () => ({
 }));
 
 describe('useProductDetails', () => {
+  beforeEach(jest.clearAllMocks);
+
   it('should return data correctly with initial state', () => {
     const { result } = renderHook(() => useProductDetails(mockProductId), {
       wrapper: withStore(mockProductsState),
@@ -141,7 +143,7 @@ describe('useProductDetails', () => {
         },
       );
 
-      expect(fetchProductDetails).not.toHaveBeenCalledWith();
+      expect(fetchProductDetails).not.toHaveBeenCalled();
     });
   });
 
@@ -157,11 +159,9 @@ describe('useProductDetails', () => {
         wrapper: withStore(mockProductsState),
       });
 
-      const productsToReset = [10000, 20000];
+      reset();
 
-      reset(productsToReset);
-
-      expect(resetProductDetails).toHaveBeenCalledWith(productsToReset);
+      expect(resetProductDetails).toHaveBeenCalledWith([mockProductId]);
     });
 
     it('should call `refetch` action successfully', () => {

--- a/packages/react/src/products/hooks/__tests__/useProductDetails.test.tsx
+++ b/packages/react/src/products/hooks/__tests__/useProductDetails.test.tsx
@@ -157,9 +157,11 @@ describe('useProductDetails', () => {
         wrapper: withStore(mockProductsState),
       });
 
-      reset();
+      const productsToReset = [10000, 20000];
 
-      expect(resetProductDetails).toHaveBeenCalled();
+      reset(productsToReset);
+
+      expect(resetProductDetails).toHaveBeenCalledWith(productsToReset);
     });
 
     it('should call `refetch` action successfully', () => {

--- a/packages/react/src/products/hooks/types/useProductDetails.ts
+++ b/packages/react/src/products/hooks/types/useProductDetails.ts
@@ -1,27 +1,14 @@
 import type {
-  BlackoutError,
-  BreadCrumb,
+  Config,
   Product,
+  ProductDetailsQuery,
 } from '@farfetch/blackout-client';
-import type {
-  GroupedEntriesAdapted,
-  ProductEntity,
-  SizesAdapted,
-} from '@farfetch/blackout-redux';
 
-export type UseProductDetails = (id: number) => {
-  availableSizes: SizesAdapted;
-  breadcrumbs: BreadCrumb[] | undefined;
-  error: BlackoutError | undefined;
-  groupedEntries: GroupedEntriesAdapted;
-  isDuplicated: boolean | undefined;
-  isFetched: boolean;
-  isHydrated: boolean | undefined;
-  isInBag: boolean;
-  isLoading: boolean | undefined;
-  isOneSize: boolean | undefined;
-  isOutOfStock: boolean | undefined;
-  labelsPrioritized: Product['result']['labels'];
-  product: ProductEntity | undefined;
-  promotions: Product['result']['promotions'];
+export type ProductId = Product['result']['id'];
+
+export type UseProductDetailsOptions = {
+  fetchConfig?: Config;
+  enableAutoFetch?: boolean;
+  fetchForceDispatch?: boolean;
+  fetchQuery?: ProductDetailsQuery;
 };

--- a/packages/react/src/products/hooks/useProductDetails.ts
+++ b/packages/react/src/products/hooks/useProductDetails.ts
@@ -25,8 +25,12 @@ const useProductDetails = (
     fetchForceDispatch = false,
   } = options;
 
-  const fetch = useAction(fetchProductDetails);
-  const reset = useAction(resetProductDetails);
+  const fetchAction = useAction(fetchProductDetails);
+  const resetAction = useAction(resetProductDetails);
+  const reset = useCallback(
+    () => resetAction([productId]),
+    [resetAction, productId],
+  );
 
   const error = useSelector((state: StoreState) =>
     getProductError(state, productId),
@@ -48,17 +52,17 @@ const useProductDetails = (
   );
 
   const refetch = useCallback(
-    () => fetch(productId, fetchQuery, fetchForceDispatch, fetchConfig),
-    [fetch, productId, fetchQuery, fetchForceDispatch, fetchConfig],
+    () => fetchAction(productId, fetchQuery, fetchForceDispatch, fetchConfig),
+    [fetchAction, productId, fetchQuery, fetchForceDispatch, fetchConfig],
   );
 
   const shouldLoadDetails = enableAutoFetch && !isLoading && !error && !product;
 
   useEffect(() => {
     shouldLoadDetails &&
-      fetch(productId, fetchQuery, fetchForceDispatch, fetchConfig);
+      fetchAction(productId, fetchQuery, fetchForceDispatch, fetchConfig);
   }, [
-    fetch,
+    fetchAction,
     productId,
     fetchQuery,
     fetchConfig,

--- a/packages/react/tests/helpers/react.tsx
+++ b/packages/react/tests/helpers/react.tsx
@@ -1,7 +1,7 @@
 import { mockStore } from './redux';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
-import React, { ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import type { StoreState } from '@farfetch/blackout-redux';
 
 /**
@@ -15,7 +15,7 @@ import type { StoreState } from '@farfetch/blackout-redux';
  * @returns - Returns an object with available functions to wrap the component in different providers
  * as well as a render function.
  */
-export const wrap = component => ({
+export const wrap = (component: ReactElement) => ({
   get component() {
     return component;
   },

--- a/packages/redux/src/products/actions/resetProductDetails.ts
+++ b/packages/redux/src/products/actions/resetProductDetails.ts
@@ -1,5 +1,6 @@
 import * as actionTypes from '../actionTypes';
 import resetProductDetailsState from './resetProductDetailsState';
+import type { ProductEntity } from '../../entities/types';
 import type {
   ResetProductDetailsEntitiesAction,
   ResetProductDetailsStateAction,
@@ -27,7 +28,7 @@ import type { ThunkDispatch } from 'redux-thunk';
  * @returns Dispatch reset details entities action.
  */
 const resetProductEntities =
-  () =>
+  (productIds?: Array<ProductEntity['id']>) =>
   (
     dispatch: ThunkDispatch<
       StoreState,
@@ -37,6 +38,7 @@ const resetProductEntities =
   ): void => {
     dispatch({
       type: actionTypes.RESET_PRODUCT_DETAILS_ENTITIES,
+      productIds,
     });
   };
 
@@ -67,7 +69,7 @@ const resetProductEntities =
  * @returns Dispatch reset details state and entities action.
  */
 const resetProductDetails =
-  () =>
+  (productIds?: Array<ProductEntity['id']>) =>
   (
     dispatch: ThunkDispatch<
       StoreState,
@@ -75,8 +77,8 @@ const resetProductDetails =
       ResetProductDetailsStateAction | ResetProductDetailsEntitiesAction
     >,
   ): void => {
-    dispatch(resetProductDetailsState());
-    dispatch(resetProductEntities());
+    dispatch(resetProductDetailsState(productIds));
+    dispatch(resetProductEntities(productIds));
   };
 
 export default resetProductDetails;

--- a/packages/redux/src/products/actions/resetProductDetailsState.ts
+++ b/packages/redux/src/products/actions/resetProductDetailsState.ts
@@ -1,5 +1,6 @@
 import * as actionTypes from '../actionTypes';
 import type { Dispatch } from 'redux';
+import type { ProductEntity } from '../../entities/types';
 import type { ResetProductDetailsStateAction } from '../types';
 
 /**
@@ -23,10 +24,11 @@ import type { ResetProductDetailsStateAction } from '../types';
  * @returns Dispatch reset details state action.
  */
 const resetProductDetailsState =
-  () =>
+  (productIds?: Array<ProductEntity['id']>) =>
   (dispatch: Dispatch<ResetProductDetailsStateAction>): void => {
     dispatch({
       type: actionTypes.RESET_PRODUCT_DETAILS_STATE,
+      productIds,
     });
   };
 

--- a/packages/redux/src/products/reducer/__tests__/details.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/details.test.ts
@@ -59,6 +59,30 @@ describe('details redux reducer', () => {
       expect(state.error).toEqual(expectedError);
     });
 
+    describe('should handle RESET_PRODUCT_DETAILS_STATE action type', () => {
+      const defaultErrorState = {
+        error: {
+          [mockProductId]: new Error(),
+          10000: new Error(),
+          20000: new Error(),
+          30000: new Error(),
+        },
+      };
+
+      it('should handle a partial reset request', () => {
+        // @ts-expect-error
+        const state = reducer(defaultErrorState, {
+          type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
+          productIds: [10000, 20000, 30000],
+        });
+
+        // Full reset product details state requests are handled by the outer reducer
+        expect(state.error).toStrictEqual({
+          [mockProductId]: expect.any(Error),
+        });
+      });
+    });
+
     it('should handle other actions by returning the previous state', () => {
       const state = {
         error: { [mockProductId]: error },
@@ -85,6 +109,30 @@ describe('details redux reducer', () => {
       });
 
       expect(state.isHydrated).toEqual(expectedIsHydrated);
+    });
+
+    describe('should handle RESET_PRODUCT_DETAILS_STATE action type', () => {
+      const defaultIsHydratedState = {
+        isHydrated: {
+          [mockProductId]: false,
+          10000: true,
+          20000: true,
+          30000: true,
+        },
+      };
+
+      it('should handle a partial reset request', () => {
+        // @ts-expect-error
+        const state = reducer(defaultIsHydratedState, {
+          type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
+          productIds: [10000, 20000, 30000],
+        });
+
+        // Full reset product details state requests are handled by the outer reducer
+        expect(state.isHydrated).toStrictEqual({
+          [mockProductId]: false,
+        });
+      });
     });
 
     it('should handle other actions by returning the previous state', () => {
@@ -144,6 +192,30 @@ describe('details redux reducer', () => {
       expect(state.isLoading).toEqual(expectedIsLoading);
     });
 
+    describe('should handle RESET_PRODUCT_DETAILS_STATE action type', () => {
+      const defaultIsLoadingState = {
+        isLoading: {
+          [mockProductId]: false,
+          10000: true,
+          20000: false,
+          30000: true,
+        },
+      };
+
+      it('should handle a partial reset request', () => {
+        // @ts-expect-error
+        const state = reducer(defaultIsLoadingState, {
+          type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
+          productIds: [10000, 20000, 30000],
+        });
+
+        // Full reset product details state requests are handled by the outer reducer
+        expect(state.isLoading).toStrictEqual({
+          [mockProductId]: false,
+        });
+      });
+    });
+
     it('should handle other actions by returning the previous state', () => {
       const state = {
         isHydrated: {},
@@ -155,10 +227,13 @@ describe('details redux reducer', () => {
   });
 
   describe('entitiesMapper', () => {
-    it(`should handle ${productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES} action type`, () => {
+    describe(`should handle ${productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES} action type`, () => {
       const state = {
         products: {
           [mockProductId]: { id: mockProductId },
+          10000: { id: 10000 },
+          20000: { id: 20000 },
+          30000: { id: 30000 },
         },
         dummy: {
           1: { id: 1 },
@@ -168,20 +243,47 @@ describe('details redux reducer', () => {
         },
       };
 
-      const expectedResult = {
-        dummy: {
-          1: { id: 1 },
-        },
-        dummy2: {
-          2: { id: 2 },
-        },
-      };
+      it('should handle full reset', () => {
+        const expectedResult = {
+          dummy: {
+            1: { id: 1 },
+          },
+          dummy2: {
+            2: { id: 2 },
+          },
+        };
 
-      expect(
-        entitiesMapper[productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES](
-          state,
-        ),
-      ).toEqual(expectedResult);
+        expect(
+          entitiesMapper[productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES](
+            state,
+            { type: productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES },
+          ),
+        ).toStrictEqual(expectedResult);
+      });
+
+      it('should handle partial reset', () => {
+        const expectedResult = {
+          products: {
+            [mockProductId]: { id: mockProductId },
+          },
+          dummy: {
+            1: { id: 1 },
+          },
+          dummy2: {
+            2: { id: 2 },
+          },
+        };
+
+        expect(
+          entitiesMapper[productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES](
+            state,
+            {
+              type: productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES,
+              productIds: [10000, 20000, 30000],
+            },
+          ),
+        ).toStrictEqual(expectedResult);
+      });
     });
   });
 

--- a/packages/redux/src/products/types/actions/productDetails.types.ts
+++ b/packages/redux/src/products/types/actions/productDetails.types.ts
@@ -44,6 +44,7 @@ export interface DehydrateProductDetailsAction extends Action {
  */
 export interface ResetProductDetailsStateAction extends Action {
   type: typeof actionTypes.RESET_PRODUCT_DETAILS_STATE;
+  productIds?: Array<ProductEntity['id']>;
 }
 
 /**
@@ -51,6 +52,7 @@ export interface ResetProductDetailsStateAction extends Action {
  */
 export interface ResetProductDetailsEntitiesAction extends Action {
   type: typeof actionTypes.RESET_PRODUCT_DETAILS_ENTITIES;
+  productIds?: Array<ProductEntity['id']>;
 }
 
 export type ResetProductDetailsAction =

--- a/tests/__fixtures__/products/state.fixtures.ts
+++ b/tests/__fixtures__/products/state.fixtures.ts
@@ -35,7 +35,7 @@ export const mockColorGroupingState = {
 export const mockDetailsState = {
   details: {
     error: {
-      [mockProductId]: { message: 'Error - Not loaded.' },
+      [mockProductId]: null,
       456: null,
     },
     isHydrated: {


### PR DESCRIPTION
## Description

This PR refactors the `useProductDetails` hook to its new interface:

- Params
    - productId
    - enabled (optional)
- Return
    - isLoading
    - error
    - isFetched
    - data
        - id
        - sizes
        - sizesWithRemainingQuantity
        - images
        - … (product entity data)
        - isOutOfStock
        - isOneSize
    - actions
        - refetch()
        - reset()

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
