### PR TITLE
fix(redux): update keys on locale serverInitialState

### DIFF
--- a/packages/redux/src/locale/serverInitialState.ts
+++ b/packages/redux/src/locale/serverInitialState.ts
@@ -25,8 +25,7 @@ const localeServerInitialState: ServerInitialState = ({ model }) => {
     currencyCultureCode,
     newsletterSubscriptionOptionDefault,
     sourceCountryCode,
-    defaultCulture,
-    defaultSubfolder,
+    subfolder,
   } = model;
   // Normalize it
   const { entities } = normalize(
@@ -41,8 +40,8 @@ const localeServerInitialState: ServerInitialState = ({ model }) => {
       ],
       newsletterSubscriptionOptionDefault,
       platformId: countryId,
-      defaultCulture,
-      defaultSubfolder,
+      defaultCulture: cultureCode,
+      defaultSubfolder: subfolder,
     },
     country,
   );


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->
update keys on locale serverInitialState
defaultCulture and defaultSubfolder was changed to match data from first render and client.
<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
