### PR TITLE
fix(react): fix GA4 integration not firing PRODUCT_UPDATED.CHANGE_QUANTITY when quantity is 0

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/commands.js
+++ b/packages/react/src/analytics/integrations/GA4/commands.js
@@ -12,6 +12,7 @@ import ga4EventNameMapping, {
   getEventProperties,
   InternalEventTypes,
 } from './eventMapping';
+import isFinite from 'lodash/isFinite';
 
 const genericCommandsBuilder = data => {
   const eventName = ga4EventNameMapping[data.event];
@@ -24,7 +25,7 @@ const getProductUpdatedEventList = data => {
   const dispatchGA4EventList = [];
 
   if (
-    eventProperties.quantity &&
+    isFinite(eventProperties.quantity) &&
     eventProperties.oldQuantity !== eventProperties.quantity
   ) {
     dispatchGA4EventList.push(

--- a/packages/react/src/analytics/integrations/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/__tests__/GA4.test.js
@@ -1317,6 +1317,26 @@ describe('GA4 Integration', () => {
           expect(ga4Spy.mock.calls).toMatchSnapshot();
         });
 
+        it('Should trigger ga4 change_quantity event when quantity is 0', async () => {
+          ga4Instance = await createGA4InstanceAndLoad(validOptions, loadData);
+
+          const ga4Spy = getWindowGa4Spy();
+          const clonedEvent = cloneDeep(
+            validTrackEvents[eventTypes.PRODUCT_UPDATED],
+          );
+
+          clonedEvent.properties.quantity = 0;
+
+          // delete unwanted case scenarios
+          delete clonedEvent.properties.oldSize;
+          delete clonedEvent.properties.size;
+          delete clonedEvent.properties.oldColour;
+          delete clonedEvent.properties.colour;
+
+          await ga4Instance.track(clonedEvent);
+          expect(ga4Spy.mock.calls).toMatchSnapshot();
+        });
+
         it('Should trigger ga4 change_size event', async () => {
           ga4Instance = await createGA4InstanceAndLoad(validOptions, loadData);
 

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
@@ -899,6 +899,22 @@ Array [
 ]
 `;
 
+exports[`GA4 Integration GA4 instance When it is instantiated correctly Update Product events Should trigger ga4 change_quantity event when quantity is 0 1`] = `
+Array [
+  Array [
+    "event",
+    "change_quantity",
+    Object {
+      "from": "Bag",
+      "item_id": "507f1f77bcf86cd799439011",
+      "item_name": "Gareth McConnell Dreamscape T-Shirt",
+      "old_quantity": undefined,
+      "quantity": 0,
+    },
+  ],
+]
+`;
+
 exports[`GA4 Integration GA4 instance When it is instantiated correctly Update Product events Should trigger ga4 change_size event 1`] = `
 Array [
   Array [


### PR DESCRIPTION
## Description

While implementing GA4 integration we received feedback that we should fire event `change_quantity` "when a user removes the last item from a product from the cart". Meaning firing `eventTypes.PRODUCT_UPDATED` with `oldQuantity` as previous added quantity and `quantity` as 0.

Since 0 is falsy, it will never fire this event because of the verification. So instead I think using lodash's `isFinite` is a better verification than just falsy check, as this makes it possible to fire `change_quantity` with `quantity` 0.

Reference to: https://github.com/Farfetch/blackout/pull/414
@AceBunny

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
