### PR TITLE
fix: change getCountries client

### DIFF
--- a/packages/client/src/locale/__fixtures__/getCountries.fixtures.ts
+++ b/packages/client/src/locale/__fixtures__/getCountries.fixtures.ts
@@ -1,11 +1,12 @@
 import { rest, RestHandler } from 'msw';
 import type { Country } from '../types';
+import type { PagedResponse } from '../../types/common/pagedResponse.types';
 
 const path = '/api/settings/v1/countries';
 
 const fixtures = {
   get: {
-    success: (response: Country[]): RestHandler =>
+    success: (response: PagedResponse<Country>): RestHandler =>
       rest.get(path, async (_req, res, ctx) =>
         res(ctx.status(200), ctx.json(response)),
       ),

--- a/packages/client/src/locale/__tests__/getCountries.test.ts
+++ b/packages/client/src/locale/__tests__/getCountries.test.ts
@@ -1,5 +1,5 @@
 import { getCountries } from '..';
-import { mockCountry, mockQuery as query } from 'tests/__fixtures__/locale';
+import { mockCountry } from 'tests/__fixtures__/locale';
 import client from '../../helpers/client';
 import fixtures from '../__fixtures__/getCountries.fixtures';
 import join from 'proper-url-join';
@@ -16,16 +16,21 @@ describe('locale client', () => {
     const spy = jest.spyOn(client, 'get');
 
     it('should handle a client request successfully', async () => {
-      const response = [mockCountry];
+      const response = {
+        number: 1,
+        totalPages: 1,
+        totalItems: 1,
+        entries: [mockCountry],
+      };
 
       mswServer.use(fixtures.get.success(response));
 
       expect.assertions(2);
 
-      await expect(getCountries(query)).resolves.toEqual(response);
+      await expect(getCountries()).resolves.toEqual(response.entries);
 
       expect(spy).toHaveBeenCalledWith(
-        join('/settings/v1/countries', { query }),
+        join('/settings/v1/countries', { query: { pageSize: 10000 } }),
         expectedConfig,
       );
     });
@@ -35,10 +40,10 @@ describe('locale client', () => {
 
       expect.assertions(2);
 
-      await expect(getCountries(query)).rejects.toMatchSnapshot();
+      await expect(getCountries()).rejects.toMatchSnapshot();
 
       expect(spy).toHaveBeenCalledWith(
-        join('/settings/v1/countries', { query }),
+        join('/settings/v1/countries', { query: { pageSize: 10000 } }),
         expectedConfig,
       );
     });

--- a/packages/client/src/locale/getCountries.ts
+++ b/packages/client/src/locale/getCountries.ts
@@ -6,15 +6,16 @@ import type { GetCountries } from './types';
 /**
  * Gets all countries.
  *
- * @param query  - Query parameters to apply to the listing.
  * @param config - Custom configurations to send to the client instance (axios).
  *
  * @returns Promise that will resolve when the call to the endpoint finishes.
  */
-const getCountries: GetCountries = (query, config) =>
+const getCountries: GetCountries = config =>
   client
-    .get(join('/settings/v1/countries', { query }), config)
-    .then(response => response.data)
+    // Right now the endpoint returns a paginated response so we need to set a big pageSize
+    // so that all countries are returned. When the endpoint is changed, remove this query parameter.
+    .get(join('/settings/v1/countries', { query: { pageSize: 10000 } }), config)
+    .then(response => response.data?.entries)
     .catch(error => {
       throw adaptError(error);
     });

--- a/packages/client/src/locale/types/countries.ts
+++ b/packages/client/src/locale/types/countries.ts
@@ -1,10 +1,4 @@
-import type { Config, PagedResponse } from '../../types';
+import type { Config } from '../../types';
 import type { Country } from './country';
-import type { LocaleQuery } from './query';
 
-export type Countries = PagedResponse<Country>;
-
-export type GetCountries = (
-  query?: LocaleQuery,
-  config?: Config,
-) => Promise<Countries>;
+export type GetCountries = (config?: Config) => Promise<Country[]>;

--- a/packages/redux/src/locale/actions/__tests__/__snapshots__/fetchCountries.test.ts.snap
+++ b/packages/redux/src/locale/actions/__tests__/__snapshots__/fetchCountries.test.ts.snap
@@ -3,34 +3,75 @@
 exports[`fetchCountries() action creator should create the correct actions for when the get countries procedure is successful: Get countries success payload 1`] = `
 Object {
   "payload": Object {
-    "entities": Object {},
-    "result": Object {
-      "0": Object {
-        "code": "US",
-        "continentId": 5,
-        "cultures": Array [
-          "en-US",
-        ],
-        "currencies": Array [
-          Object {
-            "cultureCode": "en-US",
-            "id": 2,
-            "isoCode": "USD",
-            "name": "United States Dollar",
-          },
-        ],
-        "defaultCulture": "en-US",
-        "defaultSubfolder": "/en-us",
-        "isCountryDefault": true,
-        "isDefault": true,
-        "newsletterSubscriptionOptionDefault": true,
-        "platformId": 216,
-        "structures": Array [
-          "/en-us",
-        ],
+    "entities": Object {
+      "cities": Object {
+        "515": Object {
+          "countryId": 216,
+          "id": 515,
+          "name": "Atlanta",
+          "stateId": 6,
+        },
+        "516": Object {
+          "countryId": 216,
+          "id": 516,
+          "name": "Lisbon",
+          "stateId": 3,
+        },
       },
-      "entries": [Function],
+      "countries": Object {
+        "US": Object {
+          "code": "US",
+          "continentId": 5,
+          "cultures": Array [
+            "en-US",
+          ],
+          "currencies": Array [
+            Object {
+              "cultureCode": "en-US",
+              "id": 2,
+              "isoCode": "USD",
+              "name": "United States Dollar",
+            },
+          ],
+          "defaultCulture": "en-US",
+          "defaultSubfolder": "/en-us",
+          "isCountryDefault": true,
+          "isDefault": true,
+          "newsletterSubscriptionOptionDefault": true,
+          "platformId": 216,
+          "states": Array [
+            3,
+            6,
+          ],
+          "structures": Array [
+            "/en-us",
+          ],
+        },
+      },
+      "states": Object {
+        "3": Object {
+          "cities": Array [
+            516,
+          ],
+          "code": "AL",
+          "countryId": 216,
+          "id": 3,
+          "name": "Alabama",
+        },
+        "6": Object {
+          "cities": Array [
+            515,
+          ],
+          "code": "AK",
+          "countryId": 216,
+          "id": 6,
+          "name": "Alaska",
+        },
+      },
     },
+    "result": Array [
+      "US",
+    ],
   },
   "type": "@farfetch/blackout-redux/FETCH_COUNTRIES_SUCCESS",
 }

--- a/packages/redux/src/locale/actions/__tests__/__snapshots__/fetchCountry.test.ts.snap
+++ b/packages/redux/src/locale/actions/__tests__/__snapshots__/fetchCountry.test.ts.snap
@@ -7,6 +7,20 @@ Object {
   },
   "payload": Object {
     "entities": Object {
+      "cities": Object {
+        "515": Object {
+          "countryId": 216,
+          "id": 515,
+          "name": "Atlanta",
+          "stateId": 6,
+        },
+        "516": Object {
+          "countryId": 216,
+          "id": 516,
+          "name": "Lisbon",
+          "stateId": 3,
+        },
+      },
       "countries": Object {
         "US": Object {
           "code": "US",
@@ -28,9 +42,33 @@ Object {
           "isDefault": true,
           "newsletterSubscriptionOptionDefault": true,
           "platformId": 216,
+          "states": Array [
+            3,
+            6,
+          ],
           "structures": Array [
             "/en-us",
           ],
+        },
+      },
+      "states": Object {
+        "3": Object {
+          "cities": Array [
+            516,
+          ],
+          "code": "AL",
+          "countryId": 216,
+          "id": 3,
+          "name": "Alabama",
+        },
+        "6": Object {
+          "cities": Array [
+            515,
+          ],
+          "code": "AK",
+          "countryId": 216,
+          "id": 6,
+          "name": "Alaska",
         },
       },
     },

--- a/packages/redux/src/locale/actions/__tests__/__snapshots__/fetchCountryStates.test.ts.snap
+++ b/packages/redux/src/locale/actions/__tests__/__snapshots__/fetchCountryStates.test.ts.snap
@@ -7,6 +7,20 @@ Object {
   },
   "payload": Object {
     "entities": Object {
+      "cities": Object {
+        "515": Object {
+          "countryId": 216,
+          "id": 515,
+          "name": "Atlanta",
+          "stateId": 6,
+        },
+        "516": Object {
+          "countryId": 216,
+          "id": 516,
+          "name": "Lisbon",
+          "stateId": 3,
+        },
+      },
       "countries": Object {
         "US": Object {
           "code": "US",
@@ -18,12 +32,18 @@ Object {
       },
       "states": Object {
         "3": Object {
+          "cities": Array [
+            516,
+          ],
           "code": "AL",
           "countryId": 216,
           "id": 3,
           "name": "Alabama",
         },
         "6": Object {
+          "cities": Array [
+            515,
+          ],
           "code": "AK",
           "countryId": 216,
           "id": 6,

--- a/packages/redux/src/locale/actions/__tests__/fetchCountries.test.ts
+++ b/packages/redux/src/locale/actions/__tests__/fetchCountries.test.ts
@@ -3,7 +3,13 @@ import * as normalizr from 'normalizr';
 import { Country, getCountries } from '@farfetch/blackout-client';
 import { fetchCountries } from '..';
 import { INITIAL_STATE_LOCALE } from '../../reducer';
-import { mockCountries, mockQuery } from 'tests/__fixtures__/locale';
+import {
+  mockCitiesEntities,
+  mockCountries,
+  mockCountriesEntities,
+  mockCountry,
+  mockStatesEntities,
+} from 'tests/__fixtures__/locale';
 import { mockStore } from '../../../../tests';
 import find from 'lodash/find';
 
@@ -35,11 +41,11 @@ describe('fetchCountries() action creator', () => {
     expect.assertions(4);
 
     try {
-      await store.dispatch(fetchCountries(mockQuery));
+      await store.dispatch(fetchCountries());
     } catch (error) {
       expect(error).toBe(expectedError);
       expect(getCountries).toHaveBeenCalledTimes(1);
-      expect(getCountries).toHaveBeenCalledWith(mockQuery, expectedConfig);
+      expect(getCountries).toHaveBeenCalledWith(expectedConfig);
       expect(store.getActions()).toEqual([
         {
           type: actionTypes.FETCH_COUNTRIES_REQUEST,
@@ -58,18 +64,25 @@ describe('fetchCountries() action creator', () => {
     const actionResults = store.getActions();
 
     await store
-      .dispatch(fetchCountries(mockQuery))
+      .dispatch(fetchCountries())
       .then((result: Country) => expect(result).toBe(mockCountries));
 
     expect(normalizeSpy).toHaveBeenCalledTimes(1);
     expect(getCountries).toHaveBeenCalledTimes(1);
-    expect(getCountries).toHaveBeenCalledWith(mockQuery, expectedConfig);
+    expect(getCountries).toHaveBeenCalledWith(expectedConfig);
     expect(actionResults).toEqual([
       {
         type: actionTypes.FETCH_COUNTRIES_REQUEST,
       },
       expect.objectContaining({
-        payload: expect.any(Object),
+        payload: {
+          result: [mockCountry.code],
+          entities: {
+            countries: mockCountriesEntities,
+            states: mockStatesEntities,
+            cities: mockCitiesEntities,
+          },
+        },
         type: actionTypes.FETCH_COUNTRIES_SUCCESS,
       }),
     ]);

--- a/packages/redux/src/locale/actions/factories/fetchCountriesFactory.ts
+++ b/packages/redux/src/locale/actions/factories/fetchCountriesFactory.ts
@@ -1,7 +1,7 @@
 import * as actionTypes from '../../actionTypes';
 import {
   Config,
-  Countries,
+  Country,
   GetCountries,
   toBlackoutError,
 } from '@farfetch/blackout-client';
@@ -18,18 +18,18 @@ import type { Dispatch } from 'redux';
  */
 const fetchCountriesFactory =
   (getCountries: GetCountries) =>
-  (query?: { pageIndex?: number; pageSize?: number }, config?: Config) =>
-  async (dispatch: Dispatch): Promise<Countries> => {
+  (config?: Config) =>
+  async (dispatch: Dispatch): Promise<Country[]> => {
     try {
       dispatch({
         type: actionTypes.FETCH_COUNTRIES_REQUEST,
       });
 
-      const result = await getCountries(query, config);
+      const result = await getCountries(config);
 
       dispatch({
         payload: {
-          ...normalize(result, { entries: [country] }),
+          ...normalize(result, [country]),
         },
         type: actionTypes.FETCH_COUNTRIES_SUCCESS,
       });

--- a/tests/__fixtures__/locale/locale.fixtures.ts
+++ b/tests/__fixtures__/locale/locale.fixtures.ts
@@ -1,6 +1,5 @@
 export const mockCountryCode = 'US';
 export const mockStateId = 3;
-export const mockQuery = { pageIndex: 1, pageSize: 4 };
 export const isoCode = 'PT';
 
 export const mockCurrencies = [
@@ -9,6 +8,38 @@ export const mockCurrencies = [
     name: 'United States Dollar',
     isoCode: 'USD',
     cultureCode: 'en-US',
+  },
+];
+
+export const mockCities = [
+  {
+    id: 516,
+    name: 'Lisbon',
+    stateId: 3,
+    countryId: 216,
+  },
+  {
+    id: 515,
+    name: 'Atlanta',
+    stateId: 6,
+    countryId: 216,
+  },
+];
+
+export const mockStates = [
+  {
+    code: 'AL',
+    countryId: 216,
+    id: 3,
+    name: 'Alabama',
+    cities: [mockCities[0]],
+  },
+  {
+    code: 'AK',
+    countryId: 216,
+    id: 6,
+    name: 'Alaska',
+    cities: [mockCities[1]],
   },
 ];
 
@@ -24,6 +55,7 @@ export const mockCountry = {
   continentId: 5,
   currencies: mockCurrencies,
   structures: ['/en-us'],
+  states: mockStates,
 };
 
 export const mockCountryNormalized = {
@@ -42,39 +74,11 @@ export const mockCity = {
   countryId: 216,
 };
 
-export const mockCities = [
-  {
-    id: 516,
-    name: 'Lisbon',
-    stateId: 3,
-    countryId: 216,
-  },
-  {
-    id: 515,
-    name: 'Atlanta',
-    stateId: 6,
-    countryId: 216,
-  },
-];
 export const mockCitiesEntities = {
   516: mockCities[0],
   515: mockCities[1],
 };
 
-export const mockStates = [
-  {
-    code: 'AL',
-    countryId: 216,
-    id: 3,
-    name: 'Alabama',
-  },
-  {
-    code: 'AK',
-    countryId: 216,
-    id: 6,
-    name: 'Alaska',
-  },
-];
 export const mockStatesEntities = {
   3: { ...mockStates[0], cities: [mockCities[0]?.id] },
   6: { ...mockStates[1], cities: [mockCities[1]?.id] },


### PR DESCRIPTION
## Description

- This changes the getCountries client to return all countries
transparently to the consumer instead of returning a paginated
response from the service. In the future, the service will change to
return all countries instead of return a paginated response as well.

BREAKING CHANGE: The getCountries client now does not return a paginated
response and does not accept any query parameters. The result is
an array of all the countries available.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
