### PR TITLE
fix(redux): add productImgQueryParam to checkout order items

### DIFF
--- a/packages/redux/src/entities/schemas/checkoutOrderItem.ts
+++ b/packages/redux/src/entities/schemas/checkoutOrderItem.ts
@@ -27,6 +27,7 @@ export default new schema.Entity(
         merchantName,
         merchantShoppingUrl,
         price,
+        productImgQueryParam,
         productAggregator,
         productDescription,
         productId,
@@ -52,7 +53,9 @@ export default new schema.Entity(
       if (productAggregator && productAggregator.hasOwnProperty('id')) {
         item.productAggregator = {
           ...productAggregator,
-          images: adaptProductImages(productAggregator.images.images),
+          images: adaptProductImages(productAggregator.images.images, {
+            productImgQueryParam,
+          }),
         };
       }
 
@@ -74,6 +77,7 @@ export default new schema.Entity(
         merchant, // NOTE: This prop is now redundant but I have kept it for backwards-compatibility. It might be better to remove this property (and maybe other properties) from here as they might clash when there are different order items for the same product but different merchants.
         name: productName,
         price, // NOTE: Same as merchant prop
+        productImgQueryParam,
         sizes,
         slug: productSlug,
         variants,

--- a/packages/redux/src/entities/schemas/checkoutOrderItemProduct.ts
+++ b/packages/redux/src/entities/schemas/checkoutOrderItemProduct.ts
@@ -25,14 +25,21 @@ export default new schema.Entity(
   },
   {
     processStrategy: value => {
-      const { customAttributes, images, price, sizes, variants, ...item } =
-        value;
+      const {
+        customAttributes,
+        images,
+        price,
+        sizes,
+        variants,
+        productImgQueryParam,
+        ...item
+      } = value;
       const priceToAdapt = typeof price === 'object' ? price : value;
       const imagesToAdapt = get(images, 'images') || images;
 
       return {
         customAttributes: adaptCustomAttributes(customAttributes),
-        images: adaptProductImages(imagesToAdapt),
+        images: adaptProductImages(imagesToAdapt, { productImgQueryParam }),
         price: adaptPrice(priceToAdapt),
         sizes: adaptProductSizes(sizes, variants),
         variants: adaptVariants(variants),


### PR DESCRIPTION
## Description

- This adds support to pass a `productImgQueryParam` to checkout order
items to add to their images' url, as it is being
done in other areas like bag, wishlist, orders and listing.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
