### PR TITLE
feat(core): add omnitracking's checkout page tracking mappings

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -27,6 +27,8 @@ const trackMockData = {
         sizeId: 1,
       },
     ],
+    total: 100,
+    shipping: 10,
   },
   platform: platformTypes.Web,
   timestamp: mockCommonData.timestamp,

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -512,6 +512,12 @@ export const pageEventsMapper = {
       0,
     ),
   }),
+  [pageTypes.CHECKOUT]: data => ({
+    viewType: 'Checkout SPA',
+    viewSubType: 'Checkout SPA',
+    orderValue: data.properties?.total,
+    shippingTotalValue: data.properties?.shipping,
+  }),
 };
 
 export const userGenderValuesMapper = {

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -60,6 +60,15 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`checkout\` return should match the snapshot 1`] = `
+Object {
+  "orderValue": 100,
+  "shippingTotalValue": 10,
+  "viewSubType": "Checkout SPA",
+  "viewType": "Checkout SPA",
+}
+`;
+
 exports[`Omnitracking definitions \`pageDefinitions\` should match snapshot 1`] = `
 Object {
   "CheckoutPageVisited": Array [


### PR DESCRIPTION
## Description

- Added checkout event to omnitracking mapppers.

### Dependencies

https://github.com/Farfetch/blackout/pull/435

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
