### PR TITLE
fix: added isLoading to content page hook to prevent infinite loops

### DIFF
--- a/packages/react/src/content/hooks/useContentPage.js
+++ b/packages/react/src/content/hooks/useContentPage.js
@@ -51,8 +51,9 @@ export default (slug, contentType, strategy = 'default') => {
   }, [action, slug, contentType, strategy]);
 
   useEffect(() => {
-    !contentPage && fetchContent();
-  }, [contentPage, slug, fetchContent]);
+    !contentPage && !isLoading && fetchContent();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contentPage, slug]);
 
   return {
     /**


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

Rollback of a change that remove comment of exhaustive-deps and changes useEffect.
This change cause an infinite loop in a page.
<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
