### PR TITLE
feat(core): add omnitracking's bag page tracking mappings

### DIFF
--- a/packages/core/src/analytics/__fixtures__/pageData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/pageData.fixtures.js
@@ -23,6 +23,24 @@ const pageMockData = {
     didYouMean: 1123123,
     itemCount: 1,
     gender: 'Women',
+    products: [
+      {
+        id: 12345678,
+        discountValue: 1,
+        brand: 'designer name',
+        category: 'shoes',
+        priceWithoutDiscount: 1,
+        sizeId: 1,
+      },
+      {
+        id: 98765,
+        discountValue: 1,
+        brand: 'shirt designer name',
+        category: 'shirt',
+        priceWithoutDiscount: 1,
+        sizeId: 1,
+      },
+    ],
   },
   event: pageTypes.HOMEPAGE,
   user: {
@@ -93,7 +111,19 @@ const pageMockData = {
   platform: platformTypes.Web,
 };
 
-export default pageMockData;
+export const customPageMockData = {
+  [pageTypes.WISHLIST]: {
+    products: [{ quantity: 2 }, { quantity: 3 }],
+  },
+  [pageTypes.BAG]: {
+    products: [{ quantity: 5 }, { quantity: 3 }],
+    value: 100,
+  },
+  [pageTypes.CHECKOUT]: {
+    total: 100,
+    shipping: 10,
+  },
+};
 
 const getPageMockParametersForPlatform = platform => {
   let parameters;
@@ -175,3 +205,5 @@ export const expectedPagePayloadUnknown = {
     ...getPageMockParametersForPlatform('Dummy'),
   },
 };
+
+export default pageMockData;

--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -40,8 +40,6 @@ const trackMockData = {
   },
 };
 
-export default trackMockData;
-
 export const expectedTrackPayload = {
   clientId: trackMockData.context.clientId,
   tenantId: trackMockData.context.tenantId,
@@ -52,3 +50,5 @@ export const expectedTrackPayload = {
     ...expectedCommonParameters,
   },
 };
+
+export default trackMockData;

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -7,6 +7,7 @@ import {
   generatePaymentAttemptReferenceId,
   getParameterValueFromEvent,
   getProductLineItems,
+  getProductLineItemsQuantity,
   getValParameterForEvent,
 } from './omnitracking-helper';
 import eventTypes from '../../types/eventTypes';
@@ -507,16 +508,19 @@ export const pageEventsMapper = {
     viewType: 'Wishlist',
     viewSubType: 'Wishlist',
     lineItems: getProductLineItems(data),
-    wishlistQuantity: (data.properties.products || []).reduce(
-      (acc, curr) => acc + (curr.quantity || 0),
-      0,
-    ),
+    wishlistQuantity: getProductLineItemsQuantity(data.properties.products),
   }),
   [pageTypes.CHECKOUT]: data => ({
     viewType: 'Checkout SPA',
     viewSubType: 'Checkout SPA',
     orderValue: data.properties?.total,
     shippingTotalValue: data.properties?.shipping,
+  }),
+  [pageTypes.BAG]: data => ({
+    viewType: 'Shopping Bag',
+    viewSubType: 'Bag',
+    lineItems: getProductLineItems(data),
+    basketQuantity: getProductLineItemsQuantity(data.properties.products),
   }),
 };
 

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -522,3 +522,17 @@ export const getProductLineItems = data => {
 
   return undefined;
 };
+
+/**
+ * Obtain sum all quantities from product line item list.
+ *
+ * @param {object} productList - The item list with quantity inside each element.
+ *
+ * @returns {number} - The sum of all product quantities.
+ */
+export const getProductLineItemsQuantity = productList => {
+  return (productList || []).reduce(
+    (acc, curr) => acc + (curr.quantity || 0),
+    0,
+  );
+};

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -12,6 +12,7 @@ import eventTypes from '../../types/eventTypes';
 import fromParameterTypes from '../../types/fromParameterTypes';
 import merge from 'lodash/merge';
 import mockedPageData, {
+  customPageMockData,
   expectedPagePayloadMobile,
   expectedPagePayloadUnknown,
   expectedPagePayloadWeb,
@@ -689,8 +690,12 @@ describe('Omnitracking', () => {
     it.each(Object.keys(definitions.pageEventsMapper))(
       '`%s` return should match the snapshot',
       eventMapperKey => {
+        const mockedData = merge(mockedPageData, {
+          properties: customPageMockData[eventMapperKey],
+        });
+
         expect(
-          definitions.pageEventsMapper[eventMapperKey](mockedTrackData),
+          definitions.pageEventsMapper[eventMapperKey](mockedData),
         ).toMatchSnapshot();
         expect(typeof definitions.pageEventsMapper[eventMapperKey]).toBe(
           'function',

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -60,6 +60,15 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`bag\` return should match the snapshot 1`] = `
+Object {
+  "basketQuantity": 8,
+  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"itemQuantity\\":5},{\\"productId\\":98765,\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"itemQuantity\\":3}]",
+  "viewSubType": "Bag",
+  "viewType": "Shopping Bag",
+}
+`;
+
 exports[`Omnitracking definitions \`checkout\` return should match the snapshot 1`] = `
 Object {
   "orderValue": 100,
@@ -698,7 +707,7 @@ Object {
 
 exports[`Omnitracking definitions \`product-details\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
+  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1},{\\"productId\\":98765,\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
   "viewSubType": "Product",
   "viewType": "Product",
 }
@@ -706,7 +715,7 @@ Object {
 
 exports[`Omnitracking definitions \`product-listing\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
+  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1},{\\"productId\\":98765,\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
   "viewSubType": "Listing",
   "viewType": "Listing",
 }
@@ -827,9 +836,9 @@ Array [
 
 exports[`Omnitracking definitions \`wishlist\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
+  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"itemQuantity\\":2},{\\"productId\\":98765,\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"itemQuantity\\":3}]",
   "viewSubType": "Wishlist",
   "viewType": "Wishlist",
-  "wishlistQuantity": 0,
+  "wishlistQuantity": 5,
 }
 `;


### PR DESCRIPTION
## Description

- Added bag event to omnitracking mapppers.
<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

https://github.com/Farfetch/blackout/pull/440

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
