### PR TITLE
feat(core): add omnitracking's checkout abandoned event mappings

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -478,12 +478,13 @@ export const trackEventsMapper = {
         };
     }
   },
-  [eventTypes.PRODUCT_LIST_VIEWED]: data => {
-    return {
-      tid: 2832,
-      lineItems: getProductLineItems(data),
-    };
-  },
+  [eventTypes.PRODUCT_LIST_VIEWED]: data => ({
+    tid: 2832,
+    lineItems: getProductLineItems(data),
+  }),
+  [eventTypes.CHECKOUT_ABANDONED]: () => ({
+    tid: 2084,
+  }),
 };
 
 /**

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Omnitracking definitions \`Checkout Abandoned\` return should match the snapshot 1`] = `
+Object {
+  "tid": 2084,
+}
+`;
+
 exports[`Omnitracking definitions \`Checkout Step Viewed\` return should match the snapshot 1`] = `
 Object {
   "tid": 10097,


### PR DESCRIPTION
## Description

- Added checkout abandoned event for omnitracking.

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
