### PR TITLE
Feat add omnitracking edit checkout step track

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -2,6 +2,7 @@ import {
   expectedCommonParameters,
   mockCommonData,
 } from './commonData.fixtures';
+import eventTypes from '../types/eventTypes';
 import mockedPageData from './pageData.fixtures';
 import platformTypes from '../types/platformTypes';
 import trackTypes from '../types/trackTypes';
@@ -37,6 +38,12 @@ const trackMockData = {
     localId: mockCommonData.userLocalId,
     id: 4789996,
     traits: { gender: 0, isGuest: true, name: null, email: null },
+  },
+};
+
+export const customTrackMockData = {
+  [eventTypes.CHECKOUT_STEP_EDITING]: {
+    step: 2,
   },
 };
 

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -486,6 +486,10 @@ export const trackEventsMapper = {
   [eventTypes.CHECKOUT_ABANDONED]: () => ({
     tid: 2084,
   }),
+  [eventTypes.CHECKOUT_STEP_EDITING]: data => ({
+    tid: 2923,
+    checkoutStep: data.properties.step,
+  }),
 };
 
 /**

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -18,6 +18,7 @@ import mockedPageData, {
   expectedPagePayloadWeb,
 } from '../../__fixtures__/pageData.fixtures';
 import mockedTrackData, {
+  customTrackMockData,
   expectedTrackPayload,
 } from '../../__fixtures__/trackData.fixtures';
 import pageTypes from '../../types/pageTypes';
@@ -677,8 +678,12 @@ describe('Omnitracking', () => {
     it.each(Object.keys(definitions.trackEventsMapper))(
       '`%s` return should match the snapshot',
       eventMapperKey => {
+        const mockedData = merge(mockedTrackData, {
+          properties: customTrackMockData[eventMapperKey],
+        });
+
         expect(
-          definitions.trackEventsMapper[eventMapperKey](mockedTrackData),
+          definitions.trackEventsMapper[eventMapperKey](mockedData),
         ).toMatchSnapshot();
         expect(typeof definitions.trackEventsMapper[eventMapperKey]).toBe(
           'function',

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -6,6 +6,13 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Checkout Step Editing\` return should match the snapshot 1`] = `
+Object {
+  "checkoutStep": 2,
+  "tid": 2923,
+}
+`;
+
 exports[`Omnitracking definitions \`Checkout Step Viewed\` return should match the snapshot 1`] = `
 Object {
   "tid": 10097,


### PR DESCRIPTION
## Description

- Added edit checkout step event to omnitracking mapppers.

### Dependencies

https://github.com/Farfetch/blackout/pull/444

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
