### PR TITLE
fix(core): fix omnitrackings's 'navigatedFrom' parameter logic

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
@@ -164,11 +164,11 @@ class Omnitracking extends Integration {
         }
       }
 
+      // Send the `navigatedFrom` according to the last non-pageview event,
+      // which are the ones that come with the `from` parameter filled in (if passed).
       if (this.lastFromParameter) {
         precalculatedParameters.navigatedFrom = this.lastFromParameter;
       }
-
-      this.lastFromParameter = data?.properties?.from;
 
       const { user } = data;
       const userTraits = get(user, 'traits', {});
@@ -204,6 +204,14 @@ class Omnitracking extends Integration {
       precalculatedParameters.clientCountry = clientCountry;
       precalculatedParameters.clientCulture = culture;
     }
+
+    // Always set the `lastFromParameter` with what comes from the current event (pageview or not),
+    // so if there's a pageview being tracked right after this one,
+    // it will send the correct `navigatedFrom` parameter.
+    // Here we always set the value even if it comes `undefined` or `null`,
+    // otherwise we could end up with a stale `lastFromParameter` if some events are tracked
+    // without the `from` parameter.
+    this.lastFromParameter = data?.properties?.from;
 
     precalculatedParameters.uniqueViewId = this.currentUniqueViewId;
     precalculatedParameters.viewCurrency = currencyCode;


### PR DESCRIPTION
## Description
This PR fixes a problem with the `navigatedFrom` parameter that was being calculated only on page views and it shouldn't, because pageviews don't bring a `from` parameter associated with it.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
