### PR TITLE
feat(react): add useProductSizeGuides hook

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
@@ -183,6 +183,7 @@ Object {
   "useLocale": [Function],
   "usePrevious": [Function],
   "useProductDetails": [Function],
+  "useProductSizeGuides": [Function],
   "useProductsList": [Function],
   "useSearchIntents": [Function],
   "useUser": [Function],

--- a/packages/react/src/products/hooks/__tests__/useProductSizeGuides.test.tsx
+++ b/packages/react/src/products/hooks/__tests__/useProductSizeGuides.test.tsx
@@ -1,0 +1,151 @@
+import { fetchProductSizeGuides } from '@farfetch/blackout-redux';
+import {
+  mockProductId,
+  mockProductSizeGuides,
+  mockProductsState,
+} from 'tests/__fixtures__/products';
+import { renderHook } from '@testing-library/react';
+import { withStore } from '../../../../tests/helpers';
+import useProductSizeGuides from '../useProductSizeGuides';
+
+jest.mock('@farfetch/blackout-redux', () => ({
+  ...jest.requireActual('@farfetch/blackout-redux'),
+  fetchProductSizeGuides: jest.fn(() => () => Promise.resolve()),
+}));
+
+describe('useProductSizeGuides', () => {
+  beforeEach(jest.clearAllMocks);
+
+  it('should return data correctly with initial state', () => {
+    const { result } = renderHook(() => useProductSizeGuides(mockProductId), {
+      wrapper: withStore(mockProductsState),
+    });
+
+    expect(result.current).toStrictEqual({
+      error: null,
+      isFetched: true,
+      isLoading: false,
+      data: mockProductSizeGuides,
+      actions: {
+        refetch: expect.any(Function),
+      },
+    });
+  });
+
+  it('should return error state', () => {
+    const errorMockProductsState = {
+      entities: {},
+      products: {
+        sizeGuides: {
+          error: {
+            [mockProductId]: 'Error - Not loaded.',
+          },
+          isLoading: {
+            [mockProductId]: false,
+          },
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useProductSizeGuides(mockProductId), {
+      wrapper: withStore(errorMockProductsState),
+    });
+
+    expect(result.current).toStrictEqual({
+      error: 'Error - Not loaded.',
+      isFetched: true,
+      isLoading: false,
+      data: undefined,
+      actions: {
+        refetch: expect.any(Function),
+      },
+    });
+  });
+
+  it('should return loading state', () => {
+    const loadingMockProductsState = {
+      entities: {},
+      products: {
+        sizeGuides: {
+          error: {},
+          isLoading: {
+            [mockProductId]: true,
+          },
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useProductSizeGuides(mockProductId), {
+      wrapper: withStore(loadingMockProductsState),
+    });
+
+    expect(result.current).toStrictEqual({
+      error: undefined,
+      isFetched: false,
+      isLoading: true,
+      data: undefined,
+      actions: {
+        refetch: expect.any(Function),
+      },
+    });
+  });
+
+  describe('options', () => {
+    it('should fetch data if `enableAutoFetch` option is true', () => {
+      const initialMockProductsState = {
+        entities: {},
+        products: {
+          sizeGuides: {
+            error: {},
+            isLoading: {},
+          },
+        },
+      };
+
+      const options = {
+        fetchConfig: { headers: { 'X-Test-Header': 'test' } },
+      };
+
+      renderHook(() => useProductSizeGuides(mockProductId, options), {
+        wrapper: withStore(initialMockProductsState),
+      });
+
+      expect(fetchProductSizeGuides).toHaveBeenCalledWith(
+        mockProductId,
+        options.fetchConfig,
+      );
+    });
+
+    it('should not fetch data if `enableAutoFetch` option is false', () => {
+      renderHook(
+        () => useProductSizeGuides(mockProductId, { enableAutoFetch: false }),
+        {
+          wrapper: withStore(mockProductsState),
+        },
+      );
+
+      expect(fetchProductSizeGuides).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('actions', () => {
+    it('should call `refetch` action successfully', () => {
+      const {
+        result: {
+          current: {
+            actions: { refetch },
+          },
+        },
+      } = renderHook(() => useProductSizeGuides(mockProductId), {
+        wrapper: withStore(mockProductsState),
+      });
+
+      refetch();
+
+      expect(fetchProductSizeGuides).toHaveBeenCalledWith(
+        mockProductId,
+        undefined,
+      );
+    });
+  });
+});

--- a/packages/react/src/products/hooks/index.ts
+++ b/packages/react/src/products/hooks/index.ts
@@ -4,3 +4,4 @@
 
 export { default as useProductDetails } from './useProductDetails';
 export { default as useProductsList } from './useProductsList';
+export { default as useProductSizeGuides } from './useProductSizeGuides';

--- a/packages/react/src/products/hooks/types/index.ts
+++ b/packages/react/src/products/hooks/types/index.ts
@@ -1,2 +1,3 @@
 export * from './useProductDetails';
 export * from './useProductsList';
+export * from './useProductSizeGuides';

--- a/packages/react/src/products/hooks/types/useProductSizeGuides.ts
+++ b/packages/react/src/products/hooks/types/useProductSizeGuides.ts
@@ -1,0 +1,6 @@
+import type { Config } from '@farfetch/blackout-client';
+
+export type UseProductSizeGuidesOptions = {
+  fetchConfig?: Config;
+  enableAutoFetch?: boolean;
+};

--- a/packages/react/src/products/hooks/useProductSizeGuides.ts
+++ b/packages/react/src/products/hooks/useProductSizeGuides.ts
@@ -1,0 +1,58 @@
+import {
+  areProductSizeGuidesFetched,
+  areProductSizeGuidesLoading,
+  fetchProductSizeGuides,
+  getProductSizeGuides,
+  getProductSizeGuidesError,
+  ProductEntity,
+  StoreState,
+} from '@farfetch/blackout-redux';
+import { useAction } from '../../helpers';
+import { useCallback, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import type { UseProductSizeGuidesOptions } from './types';
+
+const useProductSizeGuides = (
+  productId: ProductEntity['id'],
+  options: UseProductSizeGuidesOptions = {},
+) => {
+  const { fetchConfig, enableAutoFetch = true } = options;
+  const fetchAction = useAction(fetchProductSizeGuides);
+
+  const error = useSelector((state: StoreState) =>
+    getProductSizeGuidesError(state, productId),
+  );
+  const isLoading = useSelector((state: StoreState) =>
+    areProductSizeGuidesLoading(state, productId),
+  );
+  const isFetched = useSelector((state: StoreState) =>
+    areProductSizeGuidesFetched(state, productId),
+  );
+  const productSizeGuides = useSelector((state: StoreState) =>
+    getProductSizeGuides(state, productId),
+  );
+
+  const shouldLoadSizeGuides =
+    enableAutoFetch && !isLoading && !error && !productSizeGuides;
+
+  const fetch = useCallback(
+    () => fetchAction(productId, fetchConfig),
+    [fetchAction, fetchConfig, productId],
+  );
+
+  useEffect(() => {
+    shouldLoadSizeGuides && fetch();
+  }, [fetch, shouldLoadSizeGuides]);
+
+  return {
+    error,
+    isFetched,
+    isLoading,
+    data: productSizeGuides,
+    actions: {
+      refetch: fetch,
+    },
+  };
+};
+
+export default useProductSizeGuides;

--- a/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
@@ -796,6 +796,7 @@ Object {
   "getProductQuantityInBag": [Function],
   "getProductRelatedSetsIdsByType": [Function],
   "getProductSizeGuide": [Function],
+  "getProductSizeGuides": [Function],
   "getProductSizeGuidesError": [Function],
   "getProductSizeRemainingQuantity": [Function],
   "getProductSizes": [Function],

--- a/packages/redux/src/products/selectors/__tests__/sizeGuides.test.ts
+++ b/packages/redux/src/products/selectors/__tests__/sizeGuides.test.ts
@@ -12,6 +12,12 @@ describe('SizeGuides', () => {
         selectors.getProductSizeGuide(mockProductsState, mockProductId),
       ).toEqual(mockProductSizeGuides[0]);
     });
+
+    it('should get all the product size guides', () => {
+      expect(
+        selectors.getProductSizeGuides(mockProductsState, mockProductId),
+      ).toEqual(mockProductSizeGuides);
+    });
   });
 
   describe('areProductSizeGuidesLoading()', () => {

--- a/packages/redux/src/products/selectors/sizeGuides.ts
+++ b/packages/redux/src/products/selectors/sizeGuides.ts
@@ -47,6 +47,23 @@ export const getProductSizeGuidesError = (
 ) => getError((state.products as ProductsState).sizeGuides)[id];
 
 /**
+ * Returns the size guides for a given product id.
+ *
+ * @param state - Application state.
+ * @param id    - Product id.
+ *
+ * @returns The most specific size guide for a given product id.
+ */
+export const getProductSizeGuides = (
+  state: StoreState,
+  id: ProductEntity['id'],
+) => {
+  const product = getProduct(state, id);
+
+  return product?.sizeGuides;
+};
+
+/**
  * Returns the most specific size guide for a given product id.
  *
  * @param state - Application state.
@@ -58,7 +75,7 @@ export const getProductSizeGuide = (
   state: StoreState,
   id: ProductEntity['id'],
 ) => {
-  const product = getProduct(state, id);
+  const sizeGuides = getProductSizeGuides(state, id);
 
-  return product?.sizeGuides?.[0];
+  return sizeGuides?.[0];
 };

--- a/tests/__fixtures__/products/state.fixtures.ts
+++ b/tests/__fixtures__/products/state.fixtures.ts
@@ -100,7 +100,7 @@ export const mockSizeGuidesState = {
       456: false,
     },
     error: {
-      [mockProductId]: { message: 'Error' },
+      [mockProductId]: null,
     },
   },
 };


### PR DESCRIPTION
## Description

This PR adds the `useProductSizeGuides` react hook :

- Params
    - productId
    - enableAutoFetch (optional)
- Return
    - isLoading
    - error
    - isFetched
    - data
        - brand
            - id
            - name
        - maps
        - …
    - actions
        - refetch()

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
