### PR TITLE
feat(react): add useProductAttributes hook

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
@@ -182,6 +182,7 @@ Object {
   "useCountryStates": [Function],
   "useLocale": [Function],
   "usePrevious": [Function],
+  "useProductAttributes": [Function],
   "useProductDetails": [Function],
   "useProductSizeGuides": [Function],
   "useProductsList": [Function],

--- a/packages/react/src/products/hooks/__tests__/useProductAttributes.test.tsx
+++ b/packages/react/src/products/hooks/__tests__/useProductAttributes.test.tsx
@@ -1,0 +1,151 @@
+import { fetchProductAttributes } from '@farfetch/blackout-redux';
+import {
+  mockProductAttributes,
+  mockProductId,
+  mockProductsState,
+} from 'tests/__fixtures__/products';
+import { renderHook } from '@testing-library/react';
+import { withStore } from '../../../../tests/helpers';
+import useProductAttributes from '../useProductAttributes';
+
+jest.mock('@farfetch/blackout-redux', () => ({
+  ...jest.requireActual('@farfetch/blackout-redux'),
+  fetchProductAttributes: jest.fn(() => () => Promise.resolve()),
+}));
+
+describe('useProductAttributes', () => {
+  beforeEach(jest.clearAllMocks);
+
+  it('should return data correctly with initial state', () => {
+    const { result } = renderHook(() => useProductAttributes(mockProductId), {
+      wrapper: withStore(mockProductsState),
+    });
+
+    expect(result.current).toStrictEqual({
+      error: null,
+      isFetched: true,
+      isLoading: false,
+      data: mockProductAttributes,
+      actions: {
+        refetch: expect.any(Function),
+      },
+    });
+  });
+
+  it('should return error state', () => {
+    const errorMockProductsState = {
+      entities: {},
+      products: {
+        attributes: {
+          error: {
+            [mockProductId]: 'Error - Not loaded.',
+          },
+          isLoading: {
+            [mockProductId]: false,
+          },
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useProductAttributes(mockProductId), {
+      wrapper: withStore(errorMockProductsState),
+    });
+
+    expect(result.current).toStrictEqual({
+      error: 'Error - Not loaded.',
+      isFetched: true,
+      isLoading: false,
+      data: undefined,
+      actions: {
+        refetch: expect.any(Function),
+      },
+    });
+  });
+
+  it('should return loading state', () => {
+    const loadingMockProductsState = {
+      entities: {},
+      products: {
+        attributes: {
+          error: {},
+          isLoading: {
+            [mockProductId]: true,
+          },
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useProductAttributes(mockProductId), {
+      wrapper: withStore(loadingMockProductsState),
+    });
+
+    expect(result.current).toStrictEqual({
+      error: undefined,
+      isFetched: false,
+      isLoading: true,
+      data: undefined,
+      actions: {
+        refetch: expect.any(Function),
+      },
+    });
+  });
+
+  describe('options', () => {
+    it('should fetch data if `enableAutoFetch` option is true', () => {
+      const initialMockProductsState = {
+        entities: {},
+        products: {
+          attributes: {
+            error: {},
+            isLoading: {},
+          },
+        },
+      };
+
+      const options = {
+        fetchConfig: { headers: { 'X-Test-Header': 'test' } },
+      };
+
+      renderHook(() => useProductAttributes(mockProductId, options), {
+        wrapper: withStore(initialMockProductsState),
+      });
+
+      expect(fetchProductAttributes).toHaveBeenCalledWith(
+        mockProductId,
+        options.fetchConfig,
+      );
+    });
+
+    it('should not fetch data if `enableAutoFetch` option is false', () => {
+      renderHook(
+        () => useProductAttributes(mockProductId, { enableAutoFetch: false }),
+        {
+          wrapper: withStore(mockProductsState),
+        },
+      );
+
+      expect(fetchProductAttributes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('actions', () => {
+    it('should call `refetch` action successfully', () => {
+      const {
+        result: {
+          current: {
+            actions: { refetch },
+          },
+        },
+      } = renderHook(() => useProductAttributes(mockProductId), {
+        wrapper: withStore(mockProductsState),
+      });
+
+      refetch();
+
+      expect(fetchProductAttributes).toHaveBeenCalledWith(
+        mockProductId,
+        undefined,
+      );
+    });
+  });
+});

--- a/packages/react/src/products/hooks/index.ts
+++ b/packages/react/src/products/hooks/index.ts
@@ -5,3 +5,4 @@
 export { default as useProductDetails } from './useProductDetails';
 export { default as useProductsList } from './useProductsList';
 export { default as useProductSizeGuides } from './useProductSizeGuides';
+export { default as useProductAttributes } from './useProductAttributes';

--- a/packages/react/src/products/hooks/types/index.ts
+++ b/packages/react/src/products/hooks/types/index.ts
@@ -1,3 +1,4 @@
 export * from './useProductDetails';
 export * from './useProductsList';
 export * from './useProductSizeGuides';
+export * from './useProductAttributes';

--- a/packages/react/src/products/hooks/types/useProductAttributes.ts
+++ b/packages/react/src/products/hooks/types/useProductAttributes.ts
@@ -1,0 +1,6 @@
+import type { Config } from '@farfetch/blackout-client';
+
+export type UseProductAttributesOptions = {
+  fetchConfig?: Config;
+  enableAutoFetch?: boolean;
+};

--- a/packages/react/src/products/hooks/useProductAttributes.ts
+++ b/packages/react/src/products/hooks/useProductAttributes.ts
@@ -1,0 +1,58 @@
+import {
+  areProductAttributesFetched,
+  areProductAttributesLoading,
+  fetchProductAttributes,
+  getProductAttributes,
+  getProductAttributesError,
+  ProductEntity,
+  StoreState,
+} from '@farfetch/blackout-redux';
+import { useAction } from '../../helpers';
+import { useCallback, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import type { UseProductAttributesOptions } from './types';
+
+const useProductAttributes = (
+  productId: ProductEntity['id'],
+  options: UseProductAttributesOptions = {},
+) => {
+  const { fetchConfig, enableAutoFetch = true } = options;
+  const fetchAction = useAction(fetchProductAttributes);
+
+  const error = useSelector((state: StoreState) =>
+    getProductAttributesError(state, productId),
+  );
+  const isLoading = useSelector((state: StoreState) =>
+    areProductAttributesLoading(state, productId),
+  );
+  const isFetched = useSelector((state: StoreState) =>
+    areProductAttributesFetched(state, productId),
+  );
+  const productAttributes = useSelector((state: StoreState) =>
+    getProductAttributes(state, productId),
+  );
+
+  const shouldLoadAttributes =
+    enableAutoFetch && !isLoading && !error && !productAttributes;
+
+  const fetch = useCallback(
+    () => fetchAction(productId, fetchConfig),
+    [fetchAction, fetchConfig, productId],
+  );
+
+  useEffect(() => {
+    shouldLoadAttributes && fetch();
+  }, [fetch, shouldLoadAttributes]);
+
+  return {
+    error,
+    isFetched,
+    isLoading,
+    data: productAttributes,
+    actions: {
+      refetch: fetch,
+    },
+  };
+};
+
+export default useProductAttributes;

--- a/tests/__fixtures__/products/state.fixtures.ts
+++ b/tests/__fixtures__/products/state.fixtures.ts
@@ -14,7 +14,7 @@ export const mockAttributesState = {
       456: false,
     },
     error: {
-      [mockProductId]: { message: 'Error' },
+      [mockProductId]: null,
     },
   },
 };


### PR DESCRIPTION
## Description

This PR adds the `useProductAttributes` react hook :

- Params
    - productId
    - enableAutoFetch (optional)
- Return
    - isLoading
    - error
    - isFetched
    - data
        - Array of
            - id
            - name
            - values (Array)
                - id
                - value
    - actions
        - refetch()

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
