### PR TITLE
fix(redux): fix buildBagItem

### DIFF
--- a/packages/client/src/bags/types/postBagItem.types.ts
+++ b/packages/client/src/bags/types/postBagItem.types.ts
@@ -19,7 +19,7 @@ export type PostBagItemData = {
   // For customizable products, string describing the product
   // customization, typically in JSON format. For example, users may be
   // able to customize the materials and colors of parts of the product.
-  customAttributes?: string;
+  customAttributes?: string | null;
   // For restriction product. This value is a code, received by the
   // user, used to unlock the AddToBag operation.
   authCode?: string;

--- a/packages/redux/src/bags/utils/buildBagItem.ts
+++ b/packages/redux/src/bags/utils/buildBagItem.ts
@@ -38,7 +38,7 @@ const buildBagItem = ({
   size,
 }: BuildBagItemParams) => {
   const parsedCustomAttributes =
-    typeof customAttributes === 'object'
+    !!customAttributes && typeof customAttributes === 'object'
       ? JSON.stringify(customAttributes)
       : customAttributes;
 


### PR DESCRIPTION
## Description

Fixed `buildBagItem` util that was returning an object with `customAttributes: "null"` (null as string) if the util function parameter `customAttributes` is `null`

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

none

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
