### PR TITLE
feat(core): add omnitracking's share event mappings

### DIFF
--- a/packages/core/src/analytics/__fixtures__/pageData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/pageData.fixtures.js
@@ -122,6 +122,7 @@ export const customPageMockData = {
   [pageTypes.CHECKOUT]: {
     total: 100,
     shipping: 10,
+    orderId: 'ASH12',
   },
 };
 

--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -45,6 +45,10 @@ export const customTrackMockData = {
   [eventTypes.CHECKOUT_STEP_EDITING]: {
     step: 2,
   },
+  [eventTypes.SHARE]: {
+    actionArea: 'share_button_facebook',
+    productId: 123,
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -678,7 +678,7 @@ describe('Omnitracking', () => {
     it.each(Object.keys(definitions.trackEventsMapper))(
       '`%s` return should match the snapshot',
       eventMapperKey => {
-        const mockedData = merge(mockedTrackData, {
+        const mockedData = merge({}, mockedTrackData, {
           properties: customTrackMockData[eventMapperKey],
         });
 
@@ -695,7 +695,7 @@ describe('Omnitracking', () => {
     it.each(Object.keys(definitions.pageEventsMapper))(
       '`%s` return should match the snapshot',
       eventMapperKey => {
-        const mockedData = merge(mockedPageData, {
+        const mockedData = merge({}, mockedPageData, {
           properties: customPageMockData[eventMapperKey],
         });
 

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -60,6 +60,14 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Share\` return should match the snapshot 1`] = `
+Object {
+  "actionArea": "share_button_facebook",
+  "productId": undefined,
+  "tid": 1205,
+}
+`;
+
 exports[`Omnitracking definitions \`Sign-up Form Viewed\` return should match the snapshot 1`] = `
 Object {
   "tid": 10097,
@@ -70,6 +78,7 @@ Object {
 exports[`Omnitracking definitions \`bag\` return should match the snapshot 1`] = `
 Object {
   "basketQuantity": 8,
+  "basketValue": 100,
   "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"itemQuantity\\":5},{\\"productId\\":98765,\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"itemQuantity\\":3}]",
   "viewSubType": "Bag",
   "viewType": "Shopping Bag",
@@ -78,6 +87,8 @@ Object {
 
 exports[`Omnitracking definitions \`checkout\` return should match the snapshot 1`] = `
 Object {
+  "orderCode": "ASH12",
+  "orderId": undefined,
   "orderValue": 100,
   "shippingTotalValue": 10,
   "viewSubType": "Checkout SPA",
@@ -223,7 +234,6 @@ Object {
     "isShippingAddressClickAndCollect",
     "orderCode",
     "orderCurrency",
-    "orderId",
     "orderValue",
     "orderVAT",
     "productCount",


### PR DESCRIPTION
## Description

- Fixed some missing mappings in checkout and bag events;
- Added share event to omnitracking;
- Adjust tests to cover this changes.

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
