### PR TITLE
Feat add omnitracking checkout started event

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -49,6 +49,9 @@ export const customTrackMockData = {
     actionArea: 'share_button_facebook',
     productId: 123,
   },
+  [eventTypes.CHECKOUT_STARTED]: {
+    currency: 'USD',
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -5,6 +5,7 @@
 
 import {
   generatePaymentAttemptReferenceId,
+  getCheckoutEventGenericProperties,
   getParameterValueFromEvent,
   getProductLineItems,
   getProductLineItemsQuantity,
@@ -12,7 +13,6 @@ import {
 } from './omnitracking-helper';
 import eventTypes from '../../types/eventTypes';
 import fromParameterTypes from '../../types/fromParameterTypes';
-import logger from '../../utils/logger';
 import pageTypes from '../../types/pageTypes';
 
 export const PRODUCT_ID_PARAMETER = 'productId';
@@ -490,6 +490,12 @@ export const trackEventsMapper = {
     tid: 2923,
     checkoutStep: data.properties.step,
   }),
+  [eventTypes.CHECKOUT_STARTED]: data => ({
+    tid: 2918,
+    basketValue: data.properties.total,
+    basketCurrency: data.properties.currency,
+    lineItems: getProductLineItems(data),
+  }),
   [eventTypes.SHARE]: data => ({
     tid: 1205,
     actionArea: data.properties.actionArea,
@@ -519,28 +525,13 @@ export const pageEventsMapper = {
     lineItems: getProductLineItems(data),
     wishlistQuantity: getProductLineItemsQuantity(data.properties.products),
   }),
-  [pageTypes.CHECKOUT]: data => {
-    const validOrderCode = isNaN(data.properties?.orderId);
-
-    if (!validOrderCode) {
-      logger.warn(
-        `[Omnitracking] - Event ${data.event} property orderId should be an alphanumeric value.
-                        If you send the internal orderId, please use 'orderId' (e.g.: 5H5QYB) 
-                        and 'checkoutOrderId' (e.g.:123123123)`,
-      );
-    }
-
-    return {
-      viewType: 'Checkout SPA',
-      viewSubType: 'Checkout SPA',
-      orderValue: data.properties?.total,
-      orderCode: validOrderCode ? data.properties?.orderId : undefined,
-      orderId: !validOrderCode
-        ? parseInt(data.properties?.orderId)
-        : data.properties?.checkoutOrderId,
-      shippingTotalValue: data.properties?.shipping,
-    };
-  },
+  [pageTypes.CHECKOUT]: data => ({
+    ...getCheckoutEventGenericProperties(data),
+    viewType: 'Checkout SPA',
+    viewSubType: 'Checkout SPA',
+    orderValue: data.properties?.total,
+    shippingTotalValue: data.properties?.shipping,
+  }),
   [pageTypes.BAG]: data => ({
     viewType: 'Shopping Bag',
     viewSubType: 'Bag',

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -19,6 +19,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import analyticsTrackTypes from '../../types/trackTypes';
 import get from 'lodash/get';
+import logger from '../../utils/logger';
 import pick from 'lodash/pick';
 import platformTypes from '../../types/platformTypes';
 
@@ -535,4 +536,23 @@ export const getProductLineItemsQuantity = productList => {
     (acc, curr) => acc + (curr.quantity || 0),
     0,
   );
+};
+
+export const getCheckoutEventGenericProperties = data => {
+  const validOrderCode = isNaN(data.properties?.orderId);
+
+  if (!validOrderCode) {
+    logger.warn(
+      `[Omnitracking] - Event ${data.event} property orderId should be an alphanumeric value.
+                        If you send the internal orderId, please use 'orderId' (e.g.: 5H5QYB) 
+                        and 'checkoutOrderId' (e.g.:123123123)`,
+    );
+  }
+
+  return {
+    orderCode: validOrderCode ? data.properties?.orderId : undefined,
+    orderId: !validOrderCode
+      ? parseInt(data.properties?.orderId)
+      : data.properties?.checkoutOrderId,
+  };
 };

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -6,6 +6,15 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Checkout Started\` return should match the snapshot 1`] = `
+Object {
+  "basketCurrency": "USD",
+  "basketValue": 100,
+  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
+  "tid": 2918,
+}
+`;
+
 exports[`Omnitracking definitions \`Checkout Step Editing\` return should match the snapshot 1`] = `
 Object {
   "checkoutStep": 2,


### PR DESCRIPTION
## Description

- Added checkout started omnitracking event mapping.

### Dependencies

https://github.com/Farfetch/blackout/pull/458

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
