### PR TITLE
chore(redux): migrate reducers action types to anyAction

### DIFF
--- a/packages/redux/src/addresses/reducer.ts
+++ b/packages/redux/src/addresses/reducer.ts
@@ -1,5 +1,5 @@
 import * as actionTypes from './actionTypes';
-import { combineReducers } from 'redux';
+import { AnyAction, combineReducers } from 'redux';
 import { LOGOUT_SUCCESS } from '../users/authentication/actionTypes';
 import type * as T from './types';
 import type { ReducerSwitch } from '../types';
@@ -19,9 +19,7 @@ export const INITIAL_STATE: T.AddressesState = {
 
 const predictions = (
   state = INITIAL_STATE.predictions,
-  action:
-    | T.FetchAddressPredictionsAction
-    | T.ResetAddressPredictionsSuccessAction,
+  action: AnyAction,
 ): T.AddressesState['predictions'] => {
   switch (action.type) {
     case actionTypes.FETCH_ADDRESS_PREDICTIONS_REQUEST:
@@ -49,9 +47,7 @@ const predictions = (
 
 const prediction = (
   state = INITIAL_STATE.prediction,
-  action:
-    | T.FetchAddressPredictionDetailsAction
-    | T.ResetAddressPredictionsSuccessAction,
+  action: AnyAction,
 ): T.AddressesState['prediction'] => {
   switch (action.type) {
     case actionTypes.FETCH_ADDRESS_PREDICTION_DETAILS_REQUEST:

--- a/packages/redux/src/bags/reducer.ts
+++ b/packages/redux/src/bags/reducer.ts
@@ -1,25 +1,8 @@
 import * as actionTypes from './actionTypes';
-import { combineReducers } from 'redux';
+import { AnyAction, combineReducers } from 'redux';
 import { LOGOUT_SUCCESS } from '../users/authentication/actionTypes';
-import type {
-  AddBagItemAction,
-  AddBagItemFailureAction,
-  AddBagItemRequestAction,
-  AddBagItemSuccessAction,
-  BagItemsState,
-  BagsState,
-  FetchBagAction,
-  FetchBagFailureAction,
-  FetchBagRequestAction,
-  FetchBagSuccessAction,
-  RemoveBagItemAction,
-  RemoveBagItemRequestAction,
-  RemoveBagItemSuccessAction,
-  UpdateBagItemAction,
-  UpdateBagItemRequestAction,
-  UpdateBagItemSuccessAction,
-} from './types';
 import type { BagItem } from '@farfetch/blackout-client';
+import type { BagItemsState, BagsState } from './types';
 import type { ReducerSwitch, StoreState } from '../types';
 
 export const INITIAL_STATE: BagsState = {
@@ -38,13 +21,7 @@ export const INITIAL_STATE: BagsState = {
 
 const error = (
   state = INITIAL_STATE.error,
-  action:
-    | AddBagItemFailureAction
-    | AddBagItemRequestAction
-    | FetchBagFailureAction
-    | FetchBagRequestAction
-    | RemoveBagItemRequestAction
-    | UpdateBagItemRequestAction,
+  action: AnyAction,
 ): BagsState['error'] => {
   switch (action.type) {
     case actionTypes.ADD_BAG_ITEM_FAILURE:
@@ -60,10 +37,7 @@ const error = (
   }
 };
 
-const id = (
-  state = INITIAL_STATE.id,
-  action: FetchBagSuccessAction,
-): BagsState['id'] => {
+const id = (state = INITIAL_STATE.id, action: AnyAction): BagsState['id'] => {
   switch (action.type) {
     case actionTypes.FETCH_BAG_SUCCESS:
       return action.payload.result.id;
@@ -74,11 +48,7 @@ const id = (
 
 const result = (
   state = INITIAL_STATE.result,
-  action:
-    | AddBagItemSuccessAction
-    | FetchBagSuccessAction
-    | RemoveBagItemSuccessAction
-    | UpdateBagItemSuccessAction,
+  action: AnyAction,
 ): BagsState['result'] => {
   switch (action.type) {
     case actionTypes.FETCH_BAG_SUCCESS:
@@ -91,10 +61,7 @@ const result = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: AddBagItemAction | FetchBagAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.ADD_BAG_ITEM_REQUEST:
     case actionTypes.FETCH_BAG_REQUEST:
@@ -111,11 +78,7 @@ const isLoading = (
 
 const items = (
   state = INITIAL_STATE.items,
-  action:
-    | AddBagItemSuccessAction
-    | FetchBagSuccessAction
-    | RemoveBagItemAction
-    | UpdateBagItemAction,
+  action: AnyAction,
 ): BagItemsState => {
   switch (action.type) {
     case actionTypes.FETCH_BAG_SUCCESS:

--- a/packages/redux/src/brands/reducer.ts
+++ b/packages/redux/src/brands/reducer.ts
@@ -1,17 +1,6 @@
 import * as actionTypes from './actionTypes';
 import { AnyAction, combineReducers } from 'redux';
-import type {
-  BrandsState,
-  FetchBrandAction,
-  FetchBrandFailureAction,
-  FetchBrandRequestAction,
-  FetchBrandsAction,
-  FetchBrandsFailureAction,
-  FetchBrandsRequestAction,
-  FetchBrandsSuccessAction,
-  ResetBrandsStateAction,
-  SetBrandsHashAction,
-} from './types';
+import type { BrandsState } from './types';
 import type { ReducerSwitch } from '../types';
 
 export const INITIAL_STATE: BrandsState = {
@@ -21,14 +10,7 @@ export const INITIAL_STATE: BrandsState = {
   result: {},
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action:
-    | FetchBrandRequestAction
-    | FetchBrandsRequestAction
-    | FetchBrandFailureAction
-    | FetchBrandsFailureAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_BRAND_REQUEST:
       return {
@@ -55,7 +37,7 @@ const error = (
   }
 };
 
-const hash = (state = INITIAL_STATE.hash, action: SetBrandsHashAction) => {
+const hash = (state = INITIAL_STATE.hash, action: AnyAction) => {
   if (action.type === actionTypes.SET_BRANDS_HASH) {
     return action.meta.hash;
   }
@@ -63,10 +45,7 @@ const hash = (state = INITIAL_STATE.hash, action: SetBrandsHashAction) => {
   return state;
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchBrandAction | FetchBrandsAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_BRAND_REQUEST:
       return {
@@ -95,10 +74,7 @@ const isLoading = (
   }
 };
 
-const result = (
-  state = INITIAL_STATE.result,
-  action: FetchBrandsSuccessAction | AnyAction,
-) => {
+const result = (state = INITIAL_STATE.result, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_BRANDS_SUCCESS:
       return {
@@ -134,13 +110,10 @@ const reducers = combineReducers({
  * @returns New state.
  */
 
-const brandsReducer: ReducerSwitch<
-  BrandsState,
-  | FetchBrandAction
-  | FetchBrandsAction
-  | ResetBrandsStateAction
-  | SetBrandsHashAction
-> = (state, action) => {
+const brandsReducer: ReducerSwitch<BrandsState, AnyAction> = (
+  state,
+  action,
+) => {
   if (action.type === actionTypes.RESET_BRANDS_STATE) {
     return reducers(INITIAL_STATE, action);
   }

--- a/packages/redux/src/categories/reducer/categories.ts
+++ b/packages/redux/src/categories/reducer/categories.ts
@@ -4,11 +4,7 @@ import topCategoryReducer, {
   INITIAL_STATE as TOP_CATEGORIES_INITIAL_STATE,
 } from './topCategories';
 import type { BlackoutError } from '@farfetch/blackout-client';
-import type {
-  CategoriesState,
-  FetchCategoriesAction,
-  ResetCategoriesStateAction,
-} from '../types';
+import type { CategoriesState } from '../types';
 
 export const INITIAL_STATE: CategoriesState = {
   error: null,
@@ -19,7 +15,7 @@ export const INITIAL_STATE: CategoriesState = {
 
 const error = (
   state: BlackoutError | null = INITIAL_STATE.error,
-  action: FetchCategoriesAction,
+  action: AnyAction,
 ): BlackoutError | null => {
   switch (action.type) {
     case actionTypes.FETCH_CATEGORIES_REQUEST:
@@ -31,10 +27,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchCategoriesAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_CATEGORIES_REQUEST:
       return true;
@@ -46,10 +39,7 @@ const isLoading = (
   }
 };
 
-const isFetched = (
-  state = INITIAL_STATE.isFetched,
-  action: FetchCategoriesAction,
-) => {
+const isFetched = (state = INITIAL_STATE.isFetched, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_CATEGORIES_SUCCESS:
     case actionTypes.FETCH_CATEGORIES_FAILURE:
@@ -87,7 +77,7 @@ const reducers = combineReducers({
  */
 const categoriesReducer = (
   state: CategoriesState,
-  action: FetchCategoriesAction | ResetCategoriesStateAction | AnyAction,
+  action: AnyAction,
 ): CategoriesState => {
   if (action.type === actionTypes.RESET_CATEGORIES_STATE) {
     return reducers(INITIAL_STATE, action);

--- a/packages/redux/src/categories/reducer/topCategories.ts
+++ b/packages/redux/src/categories/reducer/topCategories.ts
@@ -1,11 +1,6 @@
 import * as actionTypes from '../actionTypes';
 import { AnyAction, combineReducers, Reducer } from 'redux';
-import type {
-  CategoriesState,
-  FetchCategoriesAction,
-  FetchTopCategoriesAction,
-  TopCategoriesState,
-} from '../types';
+import type { CategoriesState, TopCategoriesState } from '../types';
 import type { Category } from '@farfetch/blackout-client';
 
 export const INITIAL_STATE: TopCategoriesState = {
@@ -14,10 +9,7 @@ export const INITIAL_STATE: TopCategoriesState = {
   result: null,
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action: FetchCategoriesAction | FetchTopCategoriesAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_TOP_CATEGORIES_REQUEST:
       return INITIAL_STATE.error;
@@ -28,10 +20,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchTopCategoriesAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_TOP_CATEGORIES_REQUEST:
       return true;
@@ -43,10 +32,7 @@ const isLoading = (
   }
 };
 
-const result = (
-  state = INITIAL_STATE.result,
-  action: FetchCategoriesAction | FetchTopCategoriesAction,
-) => {
+const result = (state = INITIAL_STATE.result, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_TOP_CATEGORIES_SUCCESS:
       return action.payload.result;
@@ -80,10 +66,7 @@ export const getResult = (
   state: CategoriesState,
 ): TopCategoriesState['result'] => state.top.result;
 
-const topReducer: Reducer<
-  TopCategoriesState,
-  FetchCategoriesAction | FetchTopCategoriesAction | AnyAction
-> = combineReducers({
+const topReducer: Reducer<TopCategoriesState, AnyAction> = combineReducers({
   error,
   isLoading,
   result,

--- a/packages/redux/src/checkout/reducer.ts
+++ b/packages/redux/src/checkout/reducer.ts
@@ -9,27 +9,7 @@ import produce from 'immer';
 import reducerFactory, {
   createReducerWithResult,
 } from '../helpers/reducerFactory';
-import type {
-  CheckoutState,
-  CreateCheckoutOrderChargeFailureAction,
-  CreateCheckoutOrderChargeRequestAction,
-  CreateCheckoutOrderChargeSuccessAction,
-  DeliveryBundleFailureAction,
-  DeliveryBundleRequestAction,
-  FetchCheckoutDetailsSuccessAction,
-  FetchCheckoutOrderChargeFailureAction,
-  FetchCheckoutOrderChargeRequestAction,
-  FetchCheckoutOrderChargeSuccessAction,
-  FetchDeliveryBundleSuccessAction,
-  GenericCheckoutAction,
-  GenericCheckoutFailureAction,
-  GenericCheckoutRequestAction,
-  GenericCheckoutSuccessAction,
-  ResetCheckoutOrderChargeStateAction,
-  ResetCheckoutStateAction,
-  UpdateDeliveryBundleSuccessAction,
-} from './types';
-import type { LogoutSuccessAction } from '../users/types';
+import type { CheckoutState } from './types';
 import type { StoreState } from '../types';
 
 export const INITIAL_STATE: CheckoutState = {
@@ -99,11 +79,7 @@ export const INITIAL_STATE: CheckoutState = {
 
 const error = (
   state = INITIAL_STATE.error,
-  action:
-    | GenericCheckoutFailureAction
-    | GenericCheckoutRequestAction
-    | ResetCheckoutStateAction
-    | LogoutSuccessAction,
+  action: AnyAction,
 ): CheckoutState['error'] => {
   switch (action?.type) {
     case actionTypes.CREATE_CHECKOUT_ORDER_FAILURE:
@@ -121,14 +97,7 @@ const error = (
   }
 };
 
-const id = (
-  state = INITIAL_STATE.id,
-  action:
-    | GenericCheckoutSuccessAction
-    | ResetCheckoutStateAction
-    | LogoutSuccessAction
-    | FetchCheckoutDetailsSuccessAction,
-) => {
+const id = (state = INITIAL_STATE.id, action: AnyAction) => {
   switch (action?.type) {
     case actionTypes.CREATE_CHECKOUT_ORDER_SUCCESS:
     case actionTypes.UPDATE_CHECKOUT_ORDER_SUCCESS:
@@ -146,13 +115,7 @@ const id = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action:
-    | GenericCheckoutAction
-    | ResetCheckoutStateAction
-    | LogoutSuccessAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action?.type) {
     case actionTypes.CREATE_CHECKOUT_ORDER_REQUEST:
     case actionTypes.FETCH_CHECKOUT_ORDER_REQUEST:
@@ -429,15 +392,7 @@ export const checkoutOrderItems = reducerFactory(
 
 export const checkoutOrderCharge = (
   state = INITIAL_STATE.checkoutOrderCharge,
-  action:
-    | LogoutSuccessAction
-    | FetchCheckoutOrderChargeSuccessAction
-    | FetchCheckoutOrderChargeFailureAction
-    | FetchCheckoutOrderChargeRequestAction
-    | CreateCheckoutOrderChargeSuccessAction
-    | CreateCheckoutOrderChargeFailureAction
-    | CreateCheckoutOrderChargeRequestAction
-    | ResetCheckoutOrderChargeStateAction,
+  action: AnyAction,
 ): CheckoutState['checkoutOrderCharge'] => {
   switch (action?.type) {
     case actionTypes.CREATE_CHECKOUT_ORDER_CHARGE_REQUEST:
@@ -471,12 +426,7 @@ export const checkoutOrderCharge = (
 
 export const checkoutOrderDeliveryBundleUpgrades = (
   state = INITIAL_STATE.checkoutOrderDeliveryBundleUpgrades,
-  action:
-    | LogoutSuccessAction
-    | DeliveryBundleRequestAction
-    | UpdateDeliveryBundleSuccessAction
-    | FetchDeliveryBundleSuccessAction
-    | DeliveryBundleFailureAction,
+  action: AnyAction,
 ): CheckoutState['checkoutOrderDeliveryBundleUpgrades'] => {
   switch (action?.type) {
     case actionTypes.UPDATE_DELIVERY_BUNDLE_UPGRADE_REQUEST:

--- a/packages/redux/src/contents/reducer.ts
+++ b/packages/redux/src/contents/reducer.ts
@@ -1,12 +1,6 @@
 import * as actionTypes from './actionTypes';
-import { combineReducers } from 'redux';
-import type {
-  ActionFetchCommercePages,
-  ActionFetchContents,
-  ActionFetchContentTypes,
-  ActionFetchSEO,
-  ContentsState,
-} from './types';
+import { AnyAction, combineReducers } from 'redux';
+import type { ContentsState } from './types';
 import type { ReducerSwitch } from '../types';
 
 export const INITIAL_STATE_CONTENT: ContentsState = {
@@ -25,7 +19,7 @@ export const INITIAL_STATE_CONTENT: ContentsState = {
 
 const searchResults = (
   state = INITIAL_STATE_CONTENT.searchResults,
-  action: ActionFetchContents | ActionFetchCommercePages,
+  action: AnyAction,
 ): ContentsState['searchResults'] => {
   switch (action.type) {
     case actionTypes.FETCH_CONTENTS_REQUEST:
@@ -62,7 +56,7 @@ const searchResults = (
 
 const contentTypes = (
   state = INITIAL_STATE_CONTENT.contentTypes,
-  action: ActionFetchContentTypes,
+  action: AnyAction,
 ): ContentsState['contentTypes'] => {
   switch (action.type) {
     case actionTypes.FETCH_CONTENT_TYPES_REQUEST:
@@ -87,7 +81,7 @@ const contentTypes = (
 
 const metadata = (
   state = INITIAL_STATE_CONTENT.metadata,
-  action: ActionFetchSEO,
+  action: AnyAction,
 ): ContentsState['metadata'] => {
   switch (action.type) {
     case actionTypes.FETCH_SEO_REQUEST:
@@ -158,10 +152,10 @@ const reducers = combineReducers({
  *
  * @returns New state.
  */
-const contentsReducer: ReducerSwitch<
-  ContentsState,
-  ActionFetchContents | ActionFetchContentTypes | ActionFetchSEO
-> = (state, action): ContentsState => {
+const contentsReducer: ReducerSwitch<ContentsState, AnyAction> = (
+  state,
+  action,
+): ContentsState => {
   if (action.type === actionTypes.RESET_CONTENTS) {
     return reducers(INITIAL_STATE_CONTENT, action);
   }

--- a/packages/redux/src/locale/reducer.ts
+++ b/packages/redux/src/locale/reducer.ts
@@ -3,15 +3,7 @@ import { AnyAction, combineReducers } from 'redux';
 import get from 'lodash/get';
 import produce from 'immer';
 import reducerFactory from '../helpers/reducerFactory';
-import type {
-  ActionFetchCountries,
-  ActionFetchCountry,
-  ActionFetchCountryCurrencies,
-  ActionFetchCountryStates,
-  ActionSetCountryCode,
-  FetchCountryAddressSchemaSuccessAction,
-  LocaleState,
-} from './types';
+import type { LocaleState } from './types';
 import type { StoreState } from '../types';
 
 export const INITIAL_STATE_LOCALE: LocaleState = {
@@ -41,7 +33,7 @@ export const INITIAL_STATE_LOCALE: LocaleState = {
 
 const countryCode = (
   state = INITIAL_STATE_LOCALE.countryCode,
-  action: ActionSetCountryCode,
+  action: AnyAction,
 ): LocaleState['countryCode'] => {
   switch (action.type) {
     case actionTypes.SET_COUNTRY_CODE:
@@ -82,7 +74,7 @@ const cities = (
 
 const countries = (
   state = INITIAL_STATE_LOCALE.countries,
-  action: ActionFetchCountries | ActionFetchCountry,
+  action: AnyAction,
 ): LocaleState['countries'] => {
   switch (action.type) {
     case actionTypes.FETCH_COUNTRY_REQUEST:
@@ -110,7 +102,7 @@ const countries = (
 
 const currencies = (
   state = INITIAL_STATE_LOCALE.currencies,
-  action: ActionFetchCountryCurrencies,
+  action: AnyAction,
 ): LocaleState['currencies'] => {
   switch (action.type) {
     case actionTypes.FETCH_COUNTRY_CURRENCIES_REQUEST:
@@ -135,7 +127,7 @@ const currencies = (
 
 const states = (
   state = INITIAL_STATE_LOCALE.states,
-  action: ActionFetchCountryStates,
+  action: AnyAction,
 ): LocaleState['states'] => {
   switch (action.type) {
     case actionTypes.FETCH_COUNTRY_STATES_REQUEST:
@@ -218,7 +210,7 @@ const reducers = combineReducers({
 export const entitiesMapper = {
   [actionTypes.FETCH_COUNTRY_ADDRESS_SCHEMA_SUCCESS]: (
     state: StoreState['entities'],
-    action: FetchCountryAddressSchemaSuccessAction,
+    action: AnyAction,
   ): StoreState['entities'] => {
     const countryId = action.payload.result;
     const countrySchema = get(

--- a/packages/redux/src/loyalty/reducer.ts
+++ b/packages/redux/src/loyalty/reducer.ts
@@ -1,5 +1,5 @@
 import * as actionTypes from './actionTypes';
-import { combineReducers } from 'redux';
+import { AnyAction, combineReducers } from 'redux';
 import { createReducerWithResult } from '../helpers/reducerFactory';
 import { LOGOUT_SUCCESS } from '../users/authentication/actionTypes';
 import type * as T from './types';
@@ -64,7 +64,7 @@ export const statements = createReducerWithResult(
 
 export const membership = (
   state = INITIAL_STATE.membership,
-  action: T.FetchProgramUsersMembershipAction | T.CreateProgramMembershipAction,
+  action: AnyAction,
 ): T.LoyaltyState['membership'] => {
   switch (action.type) {
     case actionTypes.FETCH_PROGRAM_USERS_MEMBERSHIP_REQUEST:

--- a/packages/redux/src/merchantsLocations/reducer.ts
+++ b/packages/redux/src/merchantsLocations/reducer.ts
@@ -1,12 +1,6 @@
 import * as actionTypes from './actionTypes';
-import { combineReducers } from 'redux';
-import type {
-  FetchMerchantsLocationsAction,
-  FetchMerchantsLocationsFailureAction,
-  FetchMerchantsLocationsRequestAction,
-  MerchantsLocationsState,
-  ResetMerchantsLocationsStateAction,
-} from './types';
+import { AnyAction, combineReducers } from 'redux';
+import type { MerchantsLocationsState } from './types';
 import type { StoreState } from '../types';
 
 export const INITIAL_STATE: MerchantsLocationsState = {
@@ -14,12 +8,7 @@ export const INITIAL_STATE: MerchantsLocationsState = {
   isLoading: false,
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action:
-    | FetchMerchantsLocationsFailureAction
-    | FetchMerchantsLocationsRequestAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_MERCHANTS_LOCATIONS_FAILURE:
       return action.payload.error;
@@ -30,10 +19,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchMerchantsLocationsAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_MERCHANTS_LOCATIONS_REQUEST:
       return true;
@@ -78,7 +64,7 @@ const reducers = combineReducers({
  */
 const merchantsLocationsReducer = (
   state: MerchantsLocationsState,
-  action: FetchMerchantsLocationsAction | ResetMerchantsLocationsStateAction,
+  action: AnyAction,
 ): MerchantsLocationsState => {
   if (action.type === actionTypes.RESET_MERCHANTS_LOCATIONS_STATE) {
     return INITIAL_STATE;

--- a/packages/redux/src/orders/reducer.ts
+++ b/packages/redux/src/orders/reducer.ts
@@ -11,7 +11,6 @@ import type {
   FetchOrdersSuccessAction,
   FetchOrderSuccessAction,
 } from './types';
-import type { LogoutSuccessAction } from '../users/types';
 import type {
   OrderItemEntity,
   OrderMerchantNormalized,
@@ -58,23 +57,7 @@ export const INITIAL_STATE: T.OrdersState = {
   },
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action:
-    | T.FetchOrderFailureAction
-    | T.FetchOrderRequestAction
-    | T.FetchOrderReturnsFailureAction
-    | T.FetchOrderReturnsRequestAction
-    | T.FetchOrderReturnOptionsFailureAction
-    | T.FetchOrderReturnOptionsRequestAction
-    | T.FetchOrdersFailureAction
-    | T.FetchOrdersRequestAction
-    | T.FetchTrackingsFailureAction
-    | T.FetchTrackingsRequestAction
-    | T.FetchOrderAvailableItemsActivitiesAction
-    | T.FetchOrderItemAvailableActivitiesAction
-    | T.ResetOrdersAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_ORDER_FAILURE:
     case actionTypes.FETCH_ORDER_RETURNS_FAILURE:
@@ -98,18 +81,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action:
-    | T.FetchOrdersAction
-    | T.FetchOrderAction
-    | T.FetchOrderReturnsAction
-    | T.FetchOrderReturnOptionsAction
-    | T.FetchTrackingsAction
-    | T.FetchOrderItemAvailableActivitiesAction
-    | T.FetchOrderAvailableItemsActivitiesAction
-    | T.ResetOrdersAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_ORDERS_REQUEST:
     case actionTypes.FETCH_ORDER_REQUEST:
@@ -392,7 +364,7 @@ export const ordersList = reducerFactory(
 
 export const orderDetails = (
   state = INITIAL_STATE.orderDetails,
-  action: T.FetchOrderAction,
+  action: AnyAction,
 ) => {
   switch (action.type) {
     case actionTypes.FETCH_ORDER_REQUEST:
@@ -433,7 +405,7 @@ export const orderDetails = (
 
 export const orderReturns = (
   state = INITIAL_STATE.orderReturns,
-  action: T.FetchOrderReturnsAction,
+  action: AnyAction,
 ) => {
   switch (action.type) {
     case actionTypes.FETCH_ORDER_RETURNS_REQUEST:
@@ -474,7 +446,7 @@ export const orderReturns = (
 
 export const orderReturnOptions = (
   state = INITIAL_STATE.orderReturnOptions,
-  action: T.FetchOrderReturnOptionsAction,
+  action: AnyAction,
 ) => {
   switch (action.type) {
     case actionTypes.FETCH_ORDER_RETURN_OPTIONS_REQUEST:
@@ -602,10 +574,7 @@ const reducer = combineReducers({
  *
  * @returns New state.
  */
-const ordersReducer = (
-  state: T.OrdersState,
-  action: LogoutSuccessAction | AnyAction,
-) => {
+const ordersReducer = (state: T.OrdersState, action: AnyAction) => {
   if (action.type === LOGOUT_SUCCESS) {
     return INITIAL_STATE;
   }

--- a/packages/redux/src/payments/reducer.ts
+++ b/packages/redux/src/payments/reducer.ts
@@ -5,7 +5,6 @@ import { LOGOUT_SUCCESS } from '../users/authentication/actionTypes';
 import get from 'lodash/get';
 import omit from 'lodash/omit';
 import type * as T from './types';
-import type { LogoutSuccessAction } from '../users';
 import type {
   PaymentInstrument,
   PaymentToken,
@@ -53,15 +52,7 @@ export const INITIAL_STATE: T.PaymentsState = {
 
 const paymentIntentCharge = (
   state = INITIAL_STATE.paymentIntentCharge,
-  action:
-    | T.CreatePaymentIntentChargeFailureAction
-    | T.CreatePaymentIntentChargeRequestAction
-    | T.CreatePaymentIntentChargeSuccessAction
-    | T.FetchPaymentIntentChargeFailureAction
-    | T.FetchPaymentIntentChargeRequestAction
-    | T.FetchPaymentIntentChargeSuccessAction
-    | T.ResetPaymentIntentChargeSuccessAction
-    | LogoutSuccessAction,
+  action: AnyAction,
 ): PaymentsState['paymentIntentCharge'] => {
   switch (action.type) {
     case actionTypes.CREATE_PAYMENT_INTENT_CHARGE_REQUEST:
@@ -110,24 +101,7 @@ const giftCardBalance = createReducerWithResult(
 
 const paymentInstruments = (
   state = INITIAL_STATE.paymentInstruments,
-  action:
-    | T.CreatePaymentIntentInstrumentFailureAction
-    | T.CreatePaymentIntentInstrumentRequestAction
-    | T.CreatePaymentIntentInstrumentSuccessAction
-    | T.FetchPaymentIntentInstrumentFailureAction
-    | T.FetchPaymentIntentInstrumentRequestAction
-    | T.FetchPaymentIntentInstrumentSuccessAction
-    | T.FetchPaymentIntentInstrumentsFailureAction
-    | T.FetchPaymentIntentInstrumentsRequestAction
-    | T.FetchPaymentIntentInstrumentsSuccessAction
-    | T.RemovePaymentIntentInstrumentFailureAction
-    | T.RemovePaymentIntentInstrumentRequestAction
-    | T.RemovePaymentIntentInstrumentSuccessAction
-    | T.UpdatePaymentIntentInstrumentFailureAction
-    | T.UpdatePaymentIntentInstrumentRequestAction
-    | T.UpdatePaymentIntentInstrumentSuccessAction
-    | T.ResetPaymentInstrumentsSuccessAction
-    | LogoutSuccessAction,
+  action: AnyAction,
 ): PaymentsState['paymentInstruments'] => {
   switch (action.type) {
     case actionTypes.FETCH_PAYMENT_INTENT_INSTRUMENT_REQUEST:
@@ -200,14 +174,7 @@ const paymentMethods = createReducerWithResult(
 
 const paymentTokens = (
   state = INITIAL_STATE.paymentTokens,
-  action:
-    | T.FetchPaymentTokensFailureAction
-    | T.FetchPaymentTokensRequestAction
-    | T.FetchPaymentTokensSuccessAction
-    | T.RemovePaymentTokensFailureAction
-    | T.RemovePaymentTokensRequestAction
-    | T.RemovePaymentTokensSuccessAction
-    | LogoutSuccessAction,
+  action: AnyAction,
 ): PaymentsState['paymentTokens'] => {
   switch (action.type) {
     case actionTypes.FETCH_PAYMENT_TOKENS_REQUEST:
@@ -340,25 +307,9 @@ const reducers = combineReducers({
  *
  * @returns New state.
  */
-const paymentsReducer: ReducerSwitch<
-  T.PaymentsState,
-  | T.CreatePaymentIntentChargeAction
-  | T.CreatePaymentIntentInstrumentAction
-  | T.FetchUserCreditBalanceAction
-  | T.FetchGiftCardBalanceAction
-  | T.FetchPaymentIntentChargeAction
-  | T.FetchPaymentIntentInstrumentAction
-  | T.FetchPaymentIntentInstrumentsAction
-  | T.FetchPaymentIntentAction
-  | T.FetchPaymentTokensAction
-  | T.FetchPaymentMethodsAction
-  | T.FetchPaymentMethodsByCountryAndCurrencyAction
-  | T.FetchPaymentMethodsByIntentAction
-  | T.RemovePaymentIntentInstrumentAction
-  | T.RemovePaymentTokensAction
-  | T.UpdatePaymentIntentInstrumentAction
-  | T.ResetPaymentIntentChargeAction
-  | T.ResetPaymentInstrumentsAction
-> = (state, action) => reducers(state, action);
+const paymentsReducer: ReducerSwitch<T.PaymentsState, AnyAction> = (
+  state,
+  action,
+) => reducers(state, action);
 
 export default paymentsReducer;

--- a/packages/redux/src/products/reducer/attributes.ts
+++ b/packages/redux/src/products/reducer/attributes.ts
@@ -1,23 +1,13 @@
 import * as actionTypes from '../actionTypes';
 import { AnyAction, combineReducers } from 'redux';
-import type {
-  FetchProductAttributesAction,
-  FetchProductAttributesFailureAction,
-  FetchProductAttributesRequestAction,
-  ProductsAttributesState,
-} from '../types';
+import type { ProductsAttributesState } from '../types';
 
 export const INITIAL_STATE: ProductsAttributesState = {
   error: {},
   isLoading: {},
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action:
-    | FetchProductAttributesRequestAction
-    | FetchProductAttributesFailureAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_ATTRIBUTES_REQUEST:
       return {
@@ -34,10 +24,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchProductAttributesAction | AnyAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_ATTRIBUTES_REQUEST:
       return {

--- a/packages/redux/src/products/reducer/details.ts
+++ b/packages/redux/src/products/reducer/details.ts
@@ -1,5 +1,5 @@
 import * as actionTypes from '../actionTypes';
-import { Action, combineReducers } from 'redux';
+import { AnyAction, combineReducers } from 'redux';
 import omit from 'lodash/omit';
 import type {
   DehydrateProductDetailsAction,
@@ -18,7 +18,7 @@ export const INITIAL_STATE: ProductsDetailsState = {
   isLoading: {},
 };
 
-const error = (state = INITIAL_STATE.error, action: Action) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_DETAILS_REQUEST:
       return {
@@ -47,7 +47,7 @@ const error = (state = INITIAL_STATE.error, action: Action) => {
   }
 };
 
-const isHydrated = (state = INITIAL_STATE.isHydrated, action: Action) => {
+const isHydrated = (state = INITIAL_STATE.isHydrated, action: AnyAction) => {
   if (action.type === actionTypes.DEHYDRATE_PRODUCT_DETAILS) {
     return {
       ...state,
@@ -66,7 +66,7 @@ const isHydrated = (state = INITIAL_STATE.isHydrated, action: Action) => {
   return state;
 };
 
-const isLoading = (state = INITIAL_STATE.isLoading, action: Action) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_DETAILS_REQUEST:
       return {
@@ -96,7 +96,7 @@ const isLoading = (state = INITIAL_STATE.isLoading, action: Action) => {
 export const entitiesMapper = {
   [actionTypes.RESET_PRODUCT_DETAILS_ENTITIES]: (
     state: NonNullable<StoreState['entities']>,
-    action: Action,
+    action: AnyAction,
   ): StoreState['entities'] => {
     if (!state) {
       return state;
@@ -144,7 +144,7 @@ const reducers = combineReducers({
  */
 const productsDetailsReducer = (
   state: ProductsDetailsState,
-  action: Action,
+  action: AnyAction,
 ): ProductsDetailsState => {
   if (
     action.type === actionTypes.RESET_PRODUCT_DETAILS_STATE &&

--- a/packages/redux/src/products/reducer/fittings.ts
+++ b/packages/redux/src/products/reducer/fittings.ts
@@ -1,21 +1,13 @@
 import * as actionTypes from '../actionTypes';
 import { AnyAction, combineReducers } from 'redux';
-import type {
-  FetchProductFittingsAction,
-  FetchProductFittingsFailureAction,
-  FetchProductFittingsRequestAction,
-  ProductsFittingsState,
-} from '../types';
+import type { ProductsFittingsState } from '../types';
 
 export const INITIAL_STATE: ProductsFittingsState = {
   error: {},
   isLoading: {},
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action: FetchProductFittingsRequestAction | FetchProductFittingsFailureAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_FITTINGS_REQUEST:
       return {
@@ -32,10 +24,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchProductFittingsAction | AnyAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_FITTINGS_REQUEST:
       return {

--- a/packages/redux/src/products/reducer/grouping.ts
+++ b/packages/redux/src/products/reducer/grouping.ts
@@ -1,21 +1,13 @@
 import * as actionTypes from '../actionTypes';
 import { AnyAction, combineReducers } from 'redux';
-import type {
-  FetchProductGroupingAction,
-  FetchProductGroupingFailureAction,
-  FetchProductGroupingRequestAction,
-  ProductsGroupingState,
-} from '../types';
+import type { ProductsGroupingState } from '../types';
 
 export const INITIAL_STATE: ProductsGroupingState = {
   error: {},
   isLoading: {},
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action: FetchProductGroupingRequestAction | FetchProductGroupingFailureAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_GROUPING_REQUEST:
       return {
@@ -32,10 +24,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchProductGroupingAction | AnyAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_GROUPING_REQUEST:
       return {

--- a/packages/redux/src/products/reducer/lists.ts
+++ b/packages/redux/src/products/reducer/lists.ts
@@ -1,14 +1,6 @@
 import * as actionTypes from '../actionTypes';
-import { combineReducers } from 'redux';
-import type {
-  DehydrateProductsListAction,
-  FetchProductsListAction,
-  FetchProductsListFailureAction,
-  FetchProductsListRequestAction,
-  ProductsListsState,
-  ResetProductsListsStateAction,
-  SetProductsListHashAction,
-} from '../types';
+import { AnyAction, combineReducers } from 'redux';
+import type { ProductsListsState } from '../types';
 import type { StoreState } from '../../types';
 
 export const INITIAL_STATE: ProductsListsState = {
@@ -18,10 +10,7 @@ export const INITIAL_STATE: ProductsListsState = {
   isLoading: {},
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action: FetchProductsListRequestAction | FetchProductsListFailureAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCTS_LIST_REQUEST:
       return {
@@ -38,20 +27,14 @@ const error = (
   }
 };
 
-const hash = (
-  state = INITIAL_STATE.hash,
-  action: SetProductsListHashAction,
-) => {
+const hash = (state = INITIAL_STATE.hash, action: AnyAction) => {
   if (action.type === actionTypes.SET_PRODUCTS_LIST_HASH) {
     return action.meta.hash;
   }
   return state;
 };
 
-const isHydrated = (
-  state = INITIAL_STATE.isHydrated,
-  action: DehydrateProductsListAction,
-) => {
+const isHydrated = (state = INITIAL_STATE.isHydrated, action: AnyAction) => {
   if (action.type === actionTypes.DEHYDRATE_PRODUCTS_LIST) {
     return {
       ...state,
@@ -61,10 +44,7 @@ const isHydrated = (
   return state;
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchProductsListAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCTS_LIST_REQUEST:
       return {
@@ -124,7 +104,7 @@ const reducers = combineReducers({
  */
 const productsListsReducer = (
   state: ProductsListsState,
-  action: FetchProductsListAction | ResetProductsListsStateAction,
+  action: AnyAction,
 ): ProductsListsState => {
   if (action.type === actionTypes.RESET_PRODUCTS_LISTS_STATE) {
     return INITIAL_STATE;

--- a/packages/redux/src/products/reducer/measurements.ts
+++ b/packages/redux/src/products/reducer/measurements.ts
@@ -1,12 +1,7 @@
 import * as actionTypes from '../actionTypes';
 import { AnyAction, combineReducers } from 'redux';
 import createMergedObject from '../../helpers/createMergedObject';
-import type {
-  FetchProductMeasurementsAction,
-  FetchProductMeasurementsFailureAction,
-  FetchProductMeasurementsRequestAction,
-  ProductsMeasurementsState,
-} from '../types';
+import type { ProductsMeasurementsState } from '../types';
 import type { StoreState } from '../../types';
 
 export const INITIAL_STATE: ProductsMeasurementsState = {
@@ -14,12 +9,7 @@ export const INITIAL_STATE: ProductsMeasurementsState = {
   isLoading: {},
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action:
-    | FetchProductMeasurementsRequestAction
-    | FetchProductMeasurementsFailureAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_MEASUREMENTS_REQUEST:
       return {
@@ -36,10 +26,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchProductMeasurementsAction | AnyAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_MEASUREMENTS_REQUEST:
       return {

--- a/packages/redux/src/products/reducer/recommendedSet.ts
+++ b/packages/redux/src/products/reducer/recommendedSet.ts
@@ -1,12 +1,6 @@
 import * as actionTypes from '../actionTypes';
 import { AnyAction, combineReducers } from 'redux';
-import type {
-  FetchRecommendedSetAction,
-  FetchRecommendedSetFailureAction,
-  FetchRecommendedSetRequestAction,
-  FetchRecommendedSetSuccessAction,
-  ProductsState,
-} from '../types';
+import type { ProductsState } from '../types';
 
 export const INITIAL_STATE: ProductsState['recommendedSets'] = {
   error: {},
@@ -14,10 +8,7 @@ export const INITIAL_STATE: ProductsState['recommendedSets'] = {
   result: {},
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action: FetchRecommendedSetAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_RECOMMENDED_SET_REQUEST:
       return {
@@ -34,10 +25,7 @@ const error = (
   }
 };
 
-const result = (
-  state = INITIAL_STATE.result,
-  action: FetchRecommendedSetAction,
-) => {
+const result = (state = INITIAL_STATE.result, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_RECOMMENDED_SET_SUCCESS:
       return {
@@ -49,14 +37,7 @@ const result = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action:
-    | FetchRecommendedSetRequestAction
-    | FetchRecommendedSetSuccessAction
-    | FetchRecommendedSetFailureAction
-    | AnyAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_RECOMMENDED_SET_REQUEST:
       return {

--- a/packages/redux/src/products/reducer/sizeGuides.ts
+++ b/packages/redux/src/products/reducer/sizeGuides.ts
@@ -1,23 +1,13 @@
 import * as actionTypes from '../actionTypes';
 import { AnyAction, combineReducers } from 'redux';
-import type {
-  FetchProductSizeGuidesAction,
-  FetchProductSizeGuidesFailureAction,
-  FetchProductSizeGuidesRequestAction,
-  ProductsSizeGuidesState,
-} from '../types';
+import type { ProductsSizeGuidesState } from '../types';
 
 export const INITIAL_STATE: ProductsSizeGuidesState = {
   error: {},
   isLoading: {},
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action:
-    | FetchProductSizeGuidesRequestAction
-    | FetchProductSizeGuidesFailureAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_SIZEGUIDES_REQUEST:
       return {
@@ -34,10 +24,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchProductSizeGuidesAction | AnyAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_SIZEGUIDES_REQUEST:
       return {

--- a/packages/redux/src/products/reducer/sizes.ts
+++ b/packages/redux/src/products/reducer/sizes.ts
@@ -1,21 +1,13 @@
 import * as actionTypes from '../actionTypes';
 import { AnyAction, combineReducers } from 'redux';
-import type {
-  FetchProductSizesAction,
-  FetchProductSizesFailureAction,
-  FetchProductSizesRequestAction,
-  ProductsSizesState,
-} from '../types';
+import type { ProductsSizesState } from '../types';
 
 export const INITIAL_STATE: ProductsSizesState = {
   error: {},
   isLoading: {},
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action: FetchProductSizesRequestAction | FetchProductSizesFailureAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_SIZES_REQUEST:
       return {
@@ -32,10 +24,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchProductSizesAction | AnyAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_SIZES_REQUEST:
       return {

--- a/packages/redux/src/products/reducer/variantsByMerchantsLocations.ts
+++ b/packages/redux/src/products/reducer/variantsByMerchantsLocations.ts
@@ -1,23 +1,13 @@
 import * as actionTypes from '../actionTypes';
 import { AnyAction, combineReducers } from 'redux';
-import type {
-  FetchProductMerchantsLocationsAction,
-  FetchProductMerchantsLocationsFailureAction,
-  FetchProductMerchantsLocationsRequestAction,
-  ProductsVariantsByMerchantsLocationsState,
-} from '../types';
+import type { ProductsVariantsByMerchantsLocationsState } from '../types';
 
 export const INITIAL_STATE: ProductsVariantsByMerchantsLocationsState = {
   error: {},
   isLoading: {},
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action:
-    | FetchProductMerchantsLocationsRequestAction
-    | FetchProductMerchantsLocationsFailureAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST:
       return {
@@ -34,10 +24,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchProductMerchantsLocationsAction | AnyAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_REQUEST:
       return {

--- a/packages/redux/src/promotionEvaluations/reducer.ts
+++ b/packages/redux/src/promotionEvaluations/reducer.ts
@@ -1,10 +1,6 @@
 import * as actionTypes from './actionTypes';
 import { AnyAction, combineReducers } from 'redux';
-import type {
-  FetchPromotionEvaluationItemsAction,
-  FetchPromotionEvaluationItemsSuccessAction,
-  PromotionEvaluationsState,
-} from './types';
+import type { PromotionEvaluationsState } from './types';
 
 export const INITIAL_STATE: PromotionEvaluationsState = {
   id: null,
@@ -13,10 +9,7 @@ export const INITIAL_STATE: PromotionEvaluationsState = {
   result: null,
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action: FetchPromotionEvaluationItemsAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST:
       return INITIAL_STATE.error;
@@ -27,10 +20,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchPromotionEvaluationItemsAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_REQUEST:
       return true;
@@ -42,10 +32,7 @@ const isLoading = (
   }
 };
 
-const result = (
-  state = INITIAL_STATE.result,
-  action: FetchPromotionEvaluationItemsSuccessAction | AnyAction,
-) => {
+const result = (state = INITIAL_STATE.result, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS:
       return action.payload.result;
@@ -54,10 +41,7 @@ const result = (
   }
 };
 
-const id = (
-  state = INITIAL_STATE.id,
-  action: FetchPromotionEvaluationItemsSuccessAction | AnyAction,
-) => {
+const id = (state = INITIAL_STATE.id, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_SUCCESS:
       return action.meta.promotionEvaluationId;

--- a/packages/redux/src/returns/reducer.ts
+++ b/packages/redux/src/returns/reducer.ts
@@ -2,25 +2,7 @@ import * as actionTypes from './actionTypes';
 import { AnyAction, combineReducers } from 'redux';
 import { LOGOUT_SUCCESS } from '../users/authentication/actionTypes';
 import reducerFactory from '../helpers/reducerFactory';
-import type {
-  CreateReturnAction,
-  CreateReturnFailureAction,
-  CreateReturnRequestAction,
-  CreateReturnSuccessAction,
-  GetReturnAction,
-  GetReturnFailureAction,
-  GetReturnPickupCapabilitiesAction,
-  GetReturnPickupCapabilitiesFailureAction,
-  GetReturnPickupCapabilitiesRequestAction,
-  GetReturnRequestAction,
-  GetReturnSuccessAction,
-  ResetReturnAction,
-  ReturnsState,
-  UpdateReturnAction,
-  UpdateReturnFailureAction,
-  UpdateReturnRequestAction,
-} from './types';
-import type { LogoutSuccessAction } from '../users/types';
+import type { ReturnsState } from './types';
 import type { StoreState } from '../types';
 
 export const INITIAL_STATE: ReturnsState = {
@@ -37,20 +19,7 @@ export const INITIAL_STATE: ReturnsState = {
   },
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action:
-    | CreateReturnFailureAction
-    | GetReturnPickupCapabilitiesFailureAction
-    | GetReturnFailureAction
-    | UpdateReturnFailureAction
-    | CreateReturnRequestAction
-    | GetReturnPickupCapabilitiesRequestAction
-    | GetReturnRequestAction
-    | UpdateReturnRequestAction
-    | ResetReturnAction
-    | LogoutSuccessAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.CREATE_RETURN_FAILURE:
     case actionTypes.FETCH_RETURN_PICKUP_CAPABILITIES_FAILURE:
@@ -69,14 +38,7 @@ const error = (
   }
 };
 
-const id = (
-  state = INITIAL_STATE.id,
-  action:
-    | CreateReturnSuccessAction
-    | GetReturnSuccessAction
-    | ResetReturnAction
-    | LogoutSuccessAction,
-) => {
+const id = (state = INITIAL_STATE.id, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.CREATE_RETURN_SUCCESS:
     case actionTypes.FETCH_RETURN_SUCCESS:
@@ -89,16 +51,7 @@ const id = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action:
-    | CreateReturnAction
-    | GetReturnPickupCapabilitiesAction
-    | GetReturnAction
-    | UpdateReturnAction
-    | ResetReturnAction
-    | LogoutSuccessAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.CREATE_RETURN_REQUEST:
     case actionTypes.FETCH_RETURN_PICKUP_CAPABILITIES_REQUEST:

--- a/packages/redux/src/search/reducer/searchDidYouMean.ts
+++ b/packages/redux/src/search/reducer/searchDidYouMean.ts
@@ -1,13 +1,6 @@
 import * as actionTypes from '../actionTypes';
-import { combineReducers } from 'redux';
-import type {
-  FetchSearchDidYouMeanAction,
-  FetchSearchDidYouMeanFailureAction,
-  FetchSearchDidYouMeanRequestAction,
-  FetchSearchDidYouMeanSuccessAction,
-  ResetSearchDidYouMeanAction,
-  SearchDidYouMeanState,
-} from '../types';
+import { AnyAction, combineReducers } from 'redux';
+import type { SearchDidYouMeanState } from '../types';
 
 export const INITIAL_STATE: SearchDidYouMeanState = {
   error: null,
@@ -16,12 +9,7 @@ export const INITIAL_STATE: SearchDidYouMeanState = {
   result: null,
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action:
-    | FetchSearchDidYouMeanRequestAction
-    | FetchSearchDidYouMeanFailureAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_SEARCH_DID_YOU_MEAN_REQUEST:
       return INITIAL_STATE.error;
@@ -32,10 +20,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchSearchDidYouMeanAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_SEARCH_DID_YOU_MEAN_REQUEST:
       return true;
@@ -47,10 +32,7 @@ const isLoading = (
   }
 };
 
-const query = (
-  state = INITIAL_STATE.query,
-  action: FetchSearchDidYouMeanRequestAction,
-) => {
+const query = (state = INITIAL_STATE.query, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_SEARCH_DID_YOU_MEAN_REQUEST:
       return action.meta.query;
@@ -59,10 +41,7 @@ const query = (
   }
 };
 
-const result = (
-  state = INITIAL_STATE.result,
-  action: FetchSearchDidYouMeanSuccessAction,
-) => {
+const result = (state = INITIAL_STATE.result, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_SEARCH_DID_YOU_MEAN_SUCCESS:
       return action.payload.result;
@@ -101,7 +80,7 @@ const reducer = combineReducers({
  */
 const searchDidYouMeanReducer = (
   state: SearchDidYouMeanState,
-  action: FetchSearchDidYouMeanAction | ResetSearchDidYouMeanAction,
+  action: AnyAction,
 ): SearchDidYouMeanState => {
   if (action.type === actionTypes.RESET_SEARCH_DID_YOU_MEAN) {
     return INITIAL_STATE;

--- a/packages/redux/src/search/reducer/searchIntents.ts
+++ b/packages/redux/src/search/reducer/searchIntents.ts
@@ -1,10 +1,6 @@
 import * as actionTypes from '../actionTypes';
-import { combineReducers } from 'redux';
-import type {
-  FetchSearchIntentsAction,
-  ResetSearchIntentsAction,
-  SearchIntentsState,
-} from '../types';
+import { AnyAction, combineReducers } from 'redux';
+import type { SearchIntentsState } from '../types';
 
 export const INITIAL_STATE: SearchIntentsState = {
   error: null,
@@ -12,10 +8,7 @@ export const INITIAL_STATE: SearchIntentsState = {
   result: null,
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action: FetchSearchIntentsAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_SEARCH_INTENTS_REQUEST:
       return INITIAL_STATE.error;
@@ -26,10 +19,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchSearchIntentsAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_SEARCH_INTENTS_REQUEST:
       return true;
@@ -42,10 +32,7 @@ const isLoading = (
   }
 };
 
-const result = (
-  state = INITIAL_STATE.result,
-  action: FetchSearchIntentsAction,
-) => {
+const result = (state = INITIAL_STATE.result, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_SEARCH_INTENTS_SUCCESS:
       return action.payload.result;
@@ -80,7 +67,7 @@ const reducer = combineReducers({
  */
 const searchIntentsReducer = (
   state: SearchIntentsState,
-  action: FetchSearchIntentsAction | ResetSearchIntentsAction,
+  action: AnyAction,
 ): SearchIntentsState => {
   if (action.type === actionTypes.RESET_SEARCH_INTENTS) {
     return INITIAL_STATE;

--- a/packages/redux/src/search/reducer/searchSuggestions.ts
+++ b/packages/redux/src/search/reducer/searchSuggestions.ts
@@ -1,10 +1,6 @@
 import * as actionTypes from '../actionTypes';
-import { combineReducers } from 'redux';
-import type {
-  FetchSearchSuggestionsAction,
-  ResetSearchSuggestionsAction,
-  SearchSuggestionsState,
-} from '../types';
+import { AnyAction, combineReducers } from 'redux';
+import type { SearchSuggestionsState } from '../types';
 
 export const INITIAL_STATE: SearchSuggestionsState = {
   error: null,
@@ -13,10 +9,7 @@ export const INITIAL_STATE: SearchSuggestionsState = {
   result: null,
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action: FetchSearchSuggestionsAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_SEARCH_SUGGESTIONS_REQUEST:
       return INITIAL_STATE.error;
@@ -27,10 +20,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchSearchSuggestionsAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_SEARCH_SUGGESTIONS_REQUEST:
       return true;
@@ -42,10 +32,7 @@ const isLoading = (
   }
 };
 
-const query = (
-  state = INITIAL_STATE.query,
-  action: FetchSearchSuggestionsAction,
-) => {
+const query = (state = INITIAL_STATE.query, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_SEARCH_SUGGESTIONS_REQUEST:
       return action.meta.query;
@@ -54,10 +41,7 @@ const query = (
   }
 };
 
-const result = (
-  state = INITIAL_STATE.result,
-  action: FetchSearchSuggestionsAction,
-) => {
+const result = (state = INITIAL_STATE.result, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_SEARCH_SUGGESTIONS_SUCCESS:
       return action.payload.result;
@@ -96,7 +80,7 @@ const reducer = combineReducers({
  */
 const searchSuggestionsReducer = (
   state: SearchSuggestionsState,
-  action: FetchSearchSuggestionsAction | ResetSearchSuggestionsAction,
+  action: AnyAction,
 ): SearchSuggestionsState => {
   if (action.type === actionTypes.RESET_SEARCH_SUGGESTIONS) {
     return INITIAL_STATE;

--- a/packages/redux/src/sizeGuides/reducer.ts
+++ b/packages/redux/src/sizeGuides/reducer.ts
@@ -1,12 +1,8 @@
 import * as actionTypes from './actionTypes';
 import { AnyAction, combineReducers } from 'redux';
 import type { BlackoutError, SizeGuide } from '@farfetch/blackout-client';
-import type {
-  FetchSizeGuidesAction,
-  ResetSizeGuidesStateAction,
-  SizeGuidesState,
-} from './types';
 import type { ReducerSwitch } from '../types';
+import type { SizeGuidesState } from './types';
 
 export const INITIAL_STATE: SizeGuidesState = {
   error: null,
@@ -16,7 +12,7 @@ export const INITIAL_STATE: SizeGuidesState = {
 
 const error = (
   state: BlackoutError | null = INITIAL_STATE.error,
-  action: FetchSizeGuidesAction,
+  action: AnyAction,
 ): BlackoutError | null => {
   switch (action.type) {
     case actionTypes.FETCH_SIZE_GUIDES_REQUEST:
@@ -30,7 +26,7 @@ const error = (
 
 const isLoading = (
   state: boolean = INITIAL_STATE.isLoading,
-  action: FetchSizeGuidesAction | AnyAction,
+  action: AnyAction,
 ): boolean => {
   switch (action.type) {
     case actionTypes.FETCH_SIZE_GUIDES_REQUEST:
@@ -45,7 +41,7 @@ const isLoading = (
 
 const result = (
   state: SizeGuide[] | null = INITIAL_STATE.result,
-  action: FetchSizeGuidesAction,
+  action: AnyAction,
 ): SizeGuide[] | null => {
   switch (action.type) {
     case actionTypes.FETCH_SIZE_GUIDES_SUCCESS:
@@ -77,10 +73,10 @@ const reducers = combineReducers({
  *
  * @returns New state.
  */
-const sizeGuidesReducer: ReducerSwitch<
-  SizeGuidesState,
-  FetchSizeGuidesAction | ResetSizeGuidesStateAction
-> = (state, action): SizeGuidesState => {
+const sizeGuidesReducer: ReducerSwitch<SizeGuidesState, AnyAction> = (
+  state,
+  action,
+): SizeGuidesState => {
   if (action.type === actionTypes.RESET_SIZE_GUIDES_STATE) {
     return reducers(INITIAL_STATE, action);
   }

--- a/packages/redux/src/sizeScales/reducer.ts
+++ b/packages/redux/src/sizeScales/reducer.ts
@@ -2,14 +2,8 @@ import * as actionTypes from './actionTypes';
 import { AnyAction, combineReducers } from 'redux';
 import isEmpty from 'lodash/isEmpty';
 import type { BlackoutError } from '@farfetch/blackout-client';
-import type {
-  FetchSizeScaleAction,
-  FetchSizeScaleMappingsAction,
-  FetchSizeScalesAction,
-  ResetSizeScalesStateAction,
-  SizeScalesState,
-} from './types';
 import type { ReducerSwitch } from '../types';
+import type { SizeScalesState } from './types';
 
 export const INITIAL_STATE: SizeScalesState = {
   error: null,
@@ -27,7 +21,7 @@ export const INITIAL_STATE: SizeScalesState = {
 
 const error = (
   state: BlackoutError | null = INITIAL_STATE.error,
-  action: FetchSizeScalesAction,
+  action: AnyAction,
 ) => {
   switch (action.type) {
     case actionTypes.FETCH_SIZE_SCALES_REQUEST:
@@ -49,7 +43,7 @@ const error = (
 
 const isLoading = (
   state: boolean = INITIAL_STATE.isLoading,
-  action: FetchSizeScalesAction | AnyAction,
+  action: AnyAction,
 ) => {
   switch (action.type) {
     case actionTypes.FETCH_SIZE_SCALES_REQUEST:
@@ -72,7 +66,7 @@ const isLoading = (
 
 const sizeScale = (
   state: SizeScalesState['sizeScale'] = INITIAL_STATE.sizeScale,
-  action: FetchSizeScalesAction | FetchSizeScaleAction,
+  action: AnyAction,
 ): SizeScalesState['sizeScale'] => {
   switch (action.type) {
     case actionTypes.FETCH_SIZE_SCALE_REQUEST:
@@ -154,7 +148,7 @@ const sizeScale = (
 
 const mappings = (
   state: SizeScalesState['mappings'] = INITIAL_STATE.mappings,
-  action: FetchSizeScaleMappingsAction,
+  action: AnyAction,
 ): SizeScalesState['mappings'] => {
   switch (action.type) {
     case actionTypes.FETCH_SIZESCALE_MAPPINGS_REQUEST:
@@ -234,13 +228,10 @@ const reducers = combineReducers({
  *
  * @returns New state.
  */
-const sizeScalesReducer: ReducerSwitch<
-  SizeScalesState,
-  | FetchSizeScaleAction
-  | FetchSizeScalesAction
-  | FetchSizeScaleMappingsAction
-  | ResetSizeScalesStateAction
-> = (state, action) => {
+const sizeScalesReducer: ReducerSwitch<SizeScalesState, AnyAction> = (
+  state,
+  action,
+) => {
   if (action.type === actionTypes.RESET_SIZE_SCALES_STATE) {
     return reducers(INITIAL_STATE, action);
   }

--- a/packages/redux/src/staffMembers/reducer.ts
+++ b/packages/redux/src/staffMembers/reducer.ts
@@ -1,12 +1,7 @@
 import * as actionTypes from './actionTypes';
 import { AnyAction, combineReducers } from 'redux';
-import type {
-  FetchStaffMemberAction,
-  FetchStaffMemberFailureAction,
-  FetchStaffMemberSuccessAction,
-  StaffMembersState,
-} from './types';
 import type { ReducerSwitch } from '../types';
+import type { StaffMembersState } from './types';
 
 export const INITIAL_STATE: StaffMembersState = {
   error: {},
@@ -14,10 +9,7 @@ export const INITIAL_STATE: StaffMembersState = {
   result: {},
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action: FetchStaffMemberSuccessAction | FetchStaffMemberFailureAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_STAFF_MEMBER_SUCCESS:
       return {
@@ -34,10 +26,7 @@ const error = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action: FetchStaffMemberAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_STAFF_MEMBER_REQUEST:
       return {
@@ -59,10 +48,7 @@ const isLoading = (
   }
 };
 
-const result = (
-  state = INITIAL_STATE.result,
-  action: FetchStaffMemberSuccessAction | AnyAction,
-) => {
+const result = (state = INITIAL_STATE.result, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_STAFF_MEMBER_SUCCESS:
       return {
@@ -92,13 +78,11 @@ export const getResult = (
  *
  * @returns New state.
  */
-const staffMembersReducer: ReducerSwitch<
-  StaffMembersState,
-  FetchStaffMemberAction
-> = combineReducers({
-  error,
-  isLoading,
-  result,
-});
+const staffMembersReducer: ReducerSwitch<StaffMembersState, AnyAction> =
+  combineReducers({
+    error,
+    isLoading,
+    result,
+  });
 
 export default staffMembersReducer;

--- a/packages/redux/src/wishlists/reducer/wishlists.ts
+++ b/packages/redux/src/wishlists/reducer/wishlists.ts
@@ -1,26 +1,11 @@
 import * as actionTypes from '../actionTypes';
-import { combineReducers, Reducer } from 'redux';
+import { AnyAction, combineReducers, Reducer } from 'redux';
 import { LOGOUT_SUCCESS } from '../../users/authentication/actionTypes';
 import wishlistsSetReducer, {
   INITIAL_STATE as SETS_INITIAL_STATE,
 } from './wishlistsSets';
-import type {
-  AddWishlistItemFailureAction,
-  AddWishlistItemRequestAction,
-  AddWishlistItemSuccessAction,
-  FetchWishlistFailureAction,
-  FetchWishlistRequestAction,
-  FetchWishlistSuccessAction,
-  RemoveWishlistItemFailureAction,
-  RemoveWishlistItemRequestAction,
-  RemoveWishlistItemSuccessAction,
-  UpdateWishlistItemFailureAction,
-  UpdateWishlistItemRequestAction,
-  UpdateWishlistItemSuccessAction,
-  WishlistSetsState,
-  WishlistsState,
-} from '../types';
 import type { ReducerSwitch, StoreState } from '../../types';
+import type { WishlistSetsState, WishlistsState } from '../types';
 
 export const INITIAL_STATE: WishlistsState = {
   error: null,
@@ -37,14 +22,7 @@ export const INITIAL_STATE: WishlistsState = {
   sets: SETS_INITIAL_STATE,
 };
 
-const result = (
-  state = INITIAL_STATE.result,
-  action:
-    | FetchWishlistSuccessAction
-    | AddWishlistItemSuccessAction
-    | RemoveWishlistItemSuccessAction
-    | UpdateWishlistItemSuccessAction,
-) => {
+const result = (state = INITIAL_STATE.result, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_WISHLIST_SUCCESS:
     case actionTypes.ADD_WISHLIST_ITEM_SUCCESS:
@@ -56,16 +34,7 @@ const result = (
   }
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action:
-    | FetchWishlistRequestAction
-    | FetchWishlistFailureAction
-    | AddWishlistItemRequestAction
-    | AddWishlistItemFailureAction
-    | RemoveWishlistItemRequestAction
-    | UpdateWishlistItemRequestAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.ADD_WISHLIST_ITEM_FAILURE:
     case actionTypes.FETCH_WISHLIST_FAILURE:
@@ -80,26 +49,14 @@ const error = (
   }
 };
 
-const idReducer = (
-  state = INITIAL_STATE.id,
-  action: FetchWishlistSuccessAction,
-) => {
+const idReducer = (state = INITIAL_STATE.id, action: AnyAction) => {
   if (action.type === actionTypes.FETCH_WISHLIST_SUCCESS) {
     return action.payload.result.id;
   }
   return state;
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action:
-    | AddWishlistItemRequestAction
-    | AddWishlistItemSuccessAction
-    | AddWishlistItemFailureAction
-    | FetchWishlistRequestAction
-    | FetchWishlistSuccessAction
-    | FetchWishlistFailureAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.ADD_WISHLIST_ITEM_REQUEST:
     case actionTypes.FETCH_WISHLIST_REQUEST:
@@ -114,18 +71,7 @@ const isLoading = (
   }
 };
 
-const itemsReducer = (
-  state = INITIAL_STATE.items,
-  action:
-    | AddWishlistItemSuccessAction
-    | FetchWishlistSuccessAction
-    | RemoveWishlistItemRequestAction
-    | UpdateWishlistItemRequestAction
-    | RemoveWishlistItemSuccessAction
-    | UpdateWishlistItemSuccessAction
-    | RemoveWishlistItemFailureAction
-    | UpdateWishlistItemFailureAction,
-) => {
+const itemsReducer = (state = INITIAL_STATE.items, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.ADD_WISHLIST_ITEM_SUCCESS:
     case actionTypes.FETCH_WISHLIST_SUCCESS:

--- a/packages/redux/src/wishlists/reducer/wishlistsSets.ts
+++ b/packages/redux/src/wishlists/reducer/wishlistsSets.ts
@@ -2,26 +2,8 @@ import * as actionTypes from '../actionTypes';
 import { AnyAction, combineReducers } from 'redux';
 import { LOGOUT_SUCCESS } from '../../users/authentication/actionTypes';
 import omit from 'lodash/omit';
-import type {
-  AddWishlistSetFailureAction,
-  AddWishlistSetRequestAction,
-  AddWishlistSetSuccessAction,
-  FetchWishlistSetFailureAction,
-  FetchWishlistSetRequestAction,
-  FetchWishlistSetsFailureAction,
-  FetchWishlistSetsRequestAction,
-  FetchWishlistSetsSuccessAction,
-  FetchWishlistSetSuccessAction,
-  FetchWishlistSuccessAction,
-  RemoveWishlistSetFailureAction,
-  RemoveWishlistSetRequestAction,
-  RemoveWishlistSetSuccessAction,
-  UpdateWishlistSetFailureAction,
-  UpdateWishlistSetRequestAction,
-  UpdateWishlistSetSuccessAction,
-  WishlistSetsState,
-} from '../types';
 import type { ReducerSwitch, StoreState } from '../../types';
+import type { WishlistSetsState } from '../types';
 
 export const INITIAL_STATE: WishlistSetsState = {
   error: null,
@@ -33,16 +15,7 @@ export const INITIAL_STATE: WishlistSetsState = {
   },
 };
 
-const error = (
-  state = INITIAL_STATE.error,
-  action:
-    | FetchWishlistSetsFailureAction
-    | AddWishlistSetFailureAction
-    | FetchWishlistSetsRequestAction
-    | AddWishlistSetRequestAction
-    | RemoveWishlistSetRequestAction
-    | UpdateWishlistSetRequestAction,
-) => {
+const error = (state = INITIAL_STATE.error, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_WISHLIST_SETS_FAILURE:
     case actionTypes.ADD_WISHLIST_SET_FAILURE:
@@ -57,14 +30,7 @@ const error = (
   }
 };
 
-const ids = (
-  state = INITIAL_STATE.ids,
-  action:
-    | FetchWishlistSetsSuccessAction
-    | AddWishlistSetSuccessAction
-    | RemoveWishlistSetSuccessAction
-    | FetchWishlistSuccessAction,
-) => {
+const ids = (state = INITIAL_STATE.ids, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_WISHLIST_SETS_SUCCESS:
       return action.payload.result;
@@ -81,16 +47,7 @@ const ids = (
   }
 };
 
-const isLoading = (
-  state = INITIAL_STATE.isLoading,
-  action:
-    | FetchWishlistSetsRequestAction
-    | AddWishlistSetRequestAction
-    | FetchWishlistSetsSuccessAction
-    | FetchWishlistSetsFailureAction
-    | AddWishlistSetSuccessAction
-    | AddWishlistSetFailureAction,
-) => {
+const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.FETCH_WISHLIST_SETS_REQUEST:
     case actionTypes.ADD_WISHLIST_SET_REQUEST:
@@ -105,19 +62,7 @@ const isLoading = (
   }
 };
 
-const set = (
-  state = INITIAL_STATE.set,
-  action:
-    | RemoveWishlistSetRequestAction
-    | FetchWishlistSetRequestAction
-    | UpdateWishlistSetRequestAction
-    | RemoveWishlistSetSuccessAction
-    | FetchWishlistSetSuccessAction
-    | UpdateWishlistSetSuccessAction
-    | RemoveWishlistSetFailureAction
-    | FetchWishlistSetFailureAction
-    | UpdateWishlistSetFailureAction,
-) => {
+const set = (state = INITIAL_STATE.set, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.REMOVE_WISHLIST_SET_REQUEST:
     case actionTypes.FETCH_WISHLIST_SET_REQUEST:


### PR DESCRIPTION
## Description
Migrated every reducer to use `AnyAction` strategy.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
