### PR TITLE
fix(client): fix adaptError for errors with no response description

### DIFF
--- a/packages/client/src/helpers/client/__fixtures__/errors.fixtures.ts
+++ b/packages/client/src/helpers/client/__fixtures__/errors.fixtures.ts
@@ -1,13 +1,22 @@
 import type {
   MockAxiosApiErrorData,
+  MockAxiosRequest,
   MockAxiosResponse,
   Result,
 } from '../types';
+
+const mockRequest = {
+  status: 400,
+  response: {
+    description: 'i am error',
+  },
+};
 
 const mockAxiosApiError = (
   data: MockAxiosApiErrorData,
   returnResponse = true,
   returnRequest = true,
+  request: MockAxiosRequest = mockRequest,
 ) => {
   const config = {
     url: '/test',
@@ -41,12 +50,6 @@ const mockAxiosApiError = (
       xsrfCookieName: 'XSRF-TOKEN',
       xsrfHeaderName: 'X-XSRF-TOKEN',
       maxContentLength: -1,
-    },
-  };
-  const request = {
-    status: 400,
-    response: {
-      description: 'i am error',
     },
   };
 
@@ -116,6 +119,10 @@ export const APIListErrorData = mockAxiosApiError({
 });
 
 export const ApiErrorNoResponse = mockAxiosApiError({}, false);
+
+export const ApiErrorNoRequestDescription = mockAxiosApiError({}, false, true, {
+  status: 404,
+});
 
 export const errorAxios = {
   message: 'Oops, Axios failed somehow',

--- a/packages/client/src/helpers/client/__tests__/__snapshots__/formatError.test.ts.snap
+++ b/packages/client/src/helpers/client/__tests__/__snapshots__/formatError.test.ts.snap
@@ -33,6 +33,14 @@ Object {
 }
 `;
 
+exports[`formatError() should format the error properly when the request has no description 1`] = `
+Object {
+  "code": -1,
+  "message": "Request failed with status code 404",
+  "status": 404,
+}
+`;
+
 exports[`formatError() should format the error properly when the request has no response 1`] = `
 Object {
   "code": -1,

--- a/packages/client/src/helpers/client/__tests__/formatError.test.ts
+++ b/packages/client/src/helpers/client/__tests__/formatError.test.ts
@@ -3,6 +3,7 @@ import {
   ApiErrorData,
   ApiErrorDataNoMessage,
   ApiErrorDataNoMessageNorDeveloperMessage,
+  ApiErrorNoRequestDescription,
   ApiErrorNoResponse,
   ApiErrorString,
   APIListErrorData,
@@ -101,15 +102,12 @@ describe('formatError()', () => {
 
   it('should format the error properly when the request has no response', () => {
     const result = adaptError(ApiErrorNoResponse);
-    const {
-      response: { description },
-      status,
-    } = ApiErrorNoResponse.request as MockAxiosRequest;
+    const { response, status } = ApiErrorNoResponse.request as MockAxiosRequest;
 
     expect(result).toEqual(
       expect.objectContaining({
         code: defaultError.code,
-        message: description,
+        message: response?.description,
         status,
       }),
     );
@@ -126,6 +124,24 @@ describe('formatError()', () => {
         status: undefined,
       }),
     );
+  });
+
+  it('should format the error properly when the request has no description', () => {
+    const genericError = new Error('Request failed with status code 404');
+    const customError = Object.assign(genericError, {
+      ...ApiErrorNoRequestDescription,
+    });
+    const result = adaptError(customError);
+    const { status } = ApiErrorNoRequestDescription.request as MockAxiosRequest;
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        code: defaultError.code,
+        message: genericError.message,
+        status,
+      }),
+    );
+    expect(result).toMatchSnapshot();
   });
 
   it('should convert error to BlackoutError', () => {

--- a/packages/client/src/helpers/client/formatError.ts
+++ b/packages/client/src/helpers/client/formatError.ts
@@ -116,7 +116,7 @@ export const adaptError = (error: unknown): BlackoutError => {
     return Object.assign(error, {
       ...extraParameters,
       code: defaultError.code,
-      message: response.description || error.message,
+      message: response?.description || error.message,
       status,
       ...response,
     });

--- a/packages/client/src/helpers/client/types/formatError.types.ts
+++ b/packages/client/src/helpers/client/types/formatError.types.ts
@@ -55,7 +55,7 @@ export type MockAxiosResponse = {
 
 export type MockAxiosRequest = {
   status: number;
-  response: {
+  response?: {
     description: string;
   };
 };


### PR DESCRIPTION
## Description

- Add optional chaining on the adaptError function to work on the scenario when the error request doesn't have a valid description and the error message should be thrown (e.g. 404 Request Not Found)

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you agree that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
