### PR TITLE
feat(redux): add result return on doGetProfile

### DIFF
--- a/packages/core/src/profile/client/getProfile.js
+++ b/packages/core/src/profile/client/getProfile.js
@@ -60,7 +60,8 @@ export const adaptStatus = value => {
 export default (userExtraInfo, config) => {
   const containsExtraInfo =
     (userExtraInfo instanceof Array && !!userExtraInfo.length) ||
-    userExtraInfo instanceof String;
+    userExtraInfo instanceof String ||
+    typeof userExtraInfo === 'string';
 
   // When the tenant doesn't provide userExtraInfo the config object will be
   // the first argument.

--- a/packages/core/src/profile/redux/actions/doGetProfile.js
+++ b/packages/core/src/profile/redux/actions/doGetProfile.js
@@ -41,6 +41,8 @@ export default getProfile => (data, config) => async dispatch => {
       type: GET_PROFILE_SUCCESS,
       meta: config,
     });
+
+    return result;
   } catch (error) {
     dispatch({
       payload: { error },


### PR DESCRIPTION
## Description

This pr adds the return of the client method response on doGetProfile action. It also adds a string literal validation on getProfile.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
