### PR TITLE
fix(react): add products brand data to useProductListing hook

### DIFF
--- a/packages/react/src/products/hooks/__tests__/useProductListing.test.tsx
+++ b/packages/react/src/products/hooks/__tests__/useProductListing.test.tsx
@@ -4,6 +4,7 @@ import {
   getSlug,
   resetProductsLists,
 } from '@farfetch/blackout-redux';
+import { mockBrandResponse } from 'tests/__fixtures__/brands';
 import {
   mockProductsListHash,
   mockProductsListHashWithoutParameters,
@@ -25,6 +26,10 @@ jest.mock('@farfetch/blackout-redux', () => ({
 }));
 
 const slug = getSlug(mockProductsListPathname);
+
+const expectedProductsWithBrand = Object.values(
+  mockProductsListNormalizedPayload.entities.products,
+).map(product => ({ ...product, brand: mockBrandResponse }));
 
 describe('useProductListing', () => {
   beforeEach(jest.clearAllMocks);
@@ -60,9 +65,8 @@ describe('useProductListing', () => {
       isLoading: false,
       data: {
         ...mockList,
-        items: Object.values(
-          mockProductsListNormalizedPayload.entities.products,
-        ),
+        items: expectedProductsWithBrand,
+        hash: mockProductsListHashWithoutParameters,
         pagination: {
           number: mockList.products.number,
           pageSize: mockList.config.pageSize,
@@ -198,9 +202,8 @@ describe('useProductListing', () => {
         isLoading: false,
         data: {
           ...mockList,
-          items: Object.values(
-            mockProductsListNormalizedPayload.entities.products,
-          ),
+          hash: mockProductsListHash,
+          items: expectedProductsWithBrand,
           pagination: {
             number: mockList.products.number,
             pageSize: mockList.config.pageSize,

--- a/packages/react/src/products/hooks/useProductListing.ts
+++ b/packages/react/src/products/hooks/useProductListing.ts
@@ -103,6 +103,7 @@ const useProductListing = (
       ? {
           ...listing,
           pagination,
+          hash: productListingHash,
           items: products,
         }
       : undefined,

--- a/packages/redux/src/brands/selectors.ts
+++ b/packages/redux/src/brands/selectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { getEntities, getEntityById } from '../entities';
+import { getEntities, getEntityById } from '../entities/selectors';
 import { getError, getHash, getIsLoading, getResult } from './reducer';
 import type { Brand, Brands } from '@farfetch/blackout-client';
 import type { BrandsState } from './types';

--- a/packages/redux/src/entities/types/product.types.ts
+++ b/packages/redux/src/entities/types/product.types.ts
@@ -15,6 +15,7 @@ import type {
   ProductVariantMerchantLocation,
   WishlistItem,
 } from '@farfetch/blackout-client';
+import type { BrandEntity } from './brand.types';
 import type {
   CustomAttributesAdapted,
   PriceAdapted,
@@ -153,4 +154,8 @@ export type ProductEntity = {
   // On the bag/wishlist the name comes from `name` instead of `shortDescription`
   // (see `bagItems` entity schema)
   name?: BagItem['productName'] | WishlistItem['productName'];
+};
+
+export type ProductEntityDenormalized = Omit<ProductEntity, 'brand'> & {
+  brand?: BrandEntity;
 };

--- a/packages/redux/src/products/selectors/__tests__/lists.test.ts
+++ b/packages/redux/src/products/selectors/__tests__/lists.test.ts
@@ -1,5 +1,6 @@
 import * as fromReducer from '../../reducer/lists';
 import * as selectors from '../lists';
+import { mockBrandResponse } from 'tests/__fixtures__/brands';
 import {
   mockBreadCrumbs,
   mockFacets,
@@ -170,10 +171,11 @@ describe('products list redux selectors', () => {
 
   describe('getProductsListProducts()', () => {
     const expectedResult = [
-      { id: 12913172, shortDescription: 'foo' },
+      { id: 12913172, shortDescription: 'foo', brand: mockBrandResponse },
       {
         id: 12913174,
         shortDescription: 'bar',
+        brand: mockBrandResponse,
         groupedEntries: mockGroupedEntries,
       },
     ];
@@ -196,10 +198,22 @@ describe('products list redux selectors', () => {
 
   describe('getProductsListProductsFromAllPages()', () => {
     const expectedResult = [
-      mockProductsListNormalizedPayload.entities.products[12913172],
-      mockProductsListNormalizedPayload.entities.products[12913174],
-      mockProductsListNormalizedPayload.entities.products[12913172],
-      mockProductsListNormalizedPayload.entities.products[12913174],
+      {
+        ...mockProductsListNormalizedPayload.entities.products[12913172],
+        brand: mockBrandResponse,
+      },
+      {
+        ...mockProductsListNormalizedPayload.entities.products[12913174],
+        brand: mockBrandResponse,
+      },
+      {
+        ...mockProductsListNormalizedPayload.entities.products[12913172],
+        brand: mockBrandResponse,
+      },
+      {
+        ...mockProductsListNormalizedPayload.entities.products[12913174],
+        brand: mockBrandResponse,
+      },
     ];
 
     it('should return an empty array if there are no `productsLists', () => {

--- a/packages/redux/src/products/serverInitialState/__tests__/lists.test.ts
+++ b/packages/redux/src/products/serverInitialState/__tests__/lists.test.ts
@@ -19,7 +19,7 @@ describe('products lists serverInitialState()', () => {
     const slug = '/en-pt/sets/woman?pageIndex=1&sort=price&sortDirection=asc';
     const model = {
       ...mockProductsListModel,
-      pageType: 'sets',
+      pageType: 'set',
       slug,
     };
 

--- a/packages/redux/src/products/serverInitialState/lists.ts
+++ b/packages/redux/src/products/serverInitialState/lists.ts
@@ -46,7 +46,7 @@ const serverInitialState: ListsServerInitialState = ({
   delete query.json;
 
   const builtSlug = getSlug(pathname);
-  const isSet = model?.pageType === 'sets';
+  const isSet = model?.pageType === 'set';
   const hash = generateProductsListHash(builtSlug, query, { isSet });
 
   // Normalize it

--- a/tests/__fixtures__/products/productsLists.fixtures.ts
+++ b/tests/__fixtures__/products/productsLists.fixtures.ts
@@ -1,3 +1,4 @@
+import { mockBrandId } from '../brands';
 import { mockBreadCrumbs } from './products.fixtures';
 import { mockPriceAdaptedEmpty, mockPricesResponse } from './price.fixtures';
 import { mockSetId } from './ids.fixtures';
@@ -867,11 +868,12 @@ export const mockProductsListNormalizedPayload = {
     merchants: { undefined: { id: undefined } },
     genders: { undefined: { id: undefined } },
     products: {
-      12913172: { id: 12913172, shortDescription: 'foo' },
+      12913172: { id: 12913172, shortDescription: 'foo', brand: mockBrandId },
       12913174: {
         id: 12913174,
         shortDescription: 'bar',
         groupedEntries: mockGroupedEntries,
+        brand: mockBrandId,
       },
     },
     facets: mockFacetsNormalized,

--- a/tests/__fixtures__/products/state.fixtures.ts
+++ b/tests/__fixtures__/products/state.fixtures.ts
@@ -1,3 +1,4 @@
+import { mockState as brandsMockState } from '../brands';
 import { mockMerchantId, mockProductId } from './ids.fixtures';
 import { mockProduct } from './products.fixtures';
 import {
@@ -135,6 +136,7 @@ export const mockProductsState = {
   },
   entities: {
     ...mockProductsListNormalizedPayload.entities,
+    ...brandsMockState.entities,
     bagItems: {
       101: {
         id: 101,


### PR DESCRIPTION
## Description

This PR:
- adds brand data to each product returned by the `useProductListing` hook;
- fixes listing `serverInitialState` to infer whether the page is of type `set` or not. This change fixes the fact that the listing hash was being miscalculated (it was always calculated as `listing/<something>` instead of `sets/<something>` when it was a set page).

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
