### PR TITLE
feat(core): add new selector for order splitting

### DIFF
--- a/packages/core/src/orders/redux/__fixtures__/orders.fixtures.js
+++ b/packages/core/src/orders/redux/__fixtures__/orders.fixtures.js
@@ -18,6 +18,7 @@ export const orderItemId2 = 10070162;
 export const orderItemId3 = 10070163;
 export const returnOptionId = '10537_3';
 export const returnOptionId2 = '10538_3';
+export const status = 'Return Accepted and Refunded';
 export const trackingNumber = '4538009162';
 export const trackingNumber2 = '4538009163';
 export const userId = 29521154;


### PR DESCRIPTION
## Description

This adds a new selector for order splitting in the stable edition. This will provide a more optimised organization of the data in the store to be rendered in the tenant.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
