### PR TITLE
feat(react): add usePaymentTokens hook

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
@@ -181,6 +181,7 @@ Object {
   "useCountryStateCities": [Function],
   "useCountryStates": [Function],
   "useLocale": [Function],
+  "usePaymentTokens": [Function],
   "usePrevious": [Function],
   "useProductAttributes": [Function],
   "useProductDetails": [Function],

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,7 @@ export * from './checkout';
 export * from './helpers';
 export * from './products';
 export * from './locale';
+export * from './payments';
 export * from './search';
 export * from './users';
 export * from './wishlists';

--- a/packages/react/src/payments/hooks/__tests__/usePaymentTokens.test.tsx
+++ b/packages/react/src/payments/hooks/__tests__/usePaymentTokens.test.tsx
@@ -1,0 +1,174 @@
+import { cleanup, renderHook } from '@testing-library/react';
+import {
+  expectedPaymentTokensNormalizedPayload,
+  mockInitialState,
+  paymentTokenId,
+  paymentTokenId2,
+} from 'tests/__fixtures__/payments';
+import {
+  fetchPaymentTokens,
+  removePaymentToken,
+  StoreState,
+} from '@farfetch/blackout-redux';
+import { withStore } from '../../../../tests/helpers';
+import usePaymentTokens from '../usePaymentTokens';
+
+const paymentTokens =
+  expectedPaymentTokensNormalizedPayload.entities.paymentTokens;
+
+const stateMockData: StoreState = {
+  payments: {
+    ...mockInitialState.payments,
+    paymentTokens: {
+      ...mockInitialState.payments.paymentTokens,
+      result: [paymentTokenId, paymentTokenId2],
+    },
+  },
+  entities: {
+    ...expectedPaymentTokensNormalizedPayload.entities,
+  },
+};
+
+jest.mock('@farfetch/blackout-redux', () => ({
+  ...jest.requireActual('@farfetch/blackout-redux'),
+  fetchPaymentTokens: jest.fn(() => () => Promise.resolve()),
+  removePaymentToken: jest.fn(() => () => Promise.resolve()),
+}));
+
+describe('usePaymentTokens', () => {
+  beforeEach(jest.clearAllMocks);
+  afterEach(cleanup);
+
+  it('should return correctly with initial state', () => {
+    const {
+      result: { current },
+    } = renderHook(() => usePaymentTokens(), {
+      wrapper: withStore(stateMockData),
+    });
+
+    expect(current).toStrictEqual({
+      error: null,
+      isLoading: false,
+      isFetched: true,
+      data: {
+        items: [paymentTokens[paymentTokenId], paymentTokens[paymentTokenId2]],
+      },
+      actions: {
+        fetch: expect.any(Function),
+        remove: expect.any(Function),
+      },
+    });
+  });
+
+  it('should return error state', () => {
+    const mockError = { message: 'This is an error message' };
+
+    const {
+      result: {
+        current: { error },
+      },
+    } = renderHook(() => usePaymentTokens(), {
+      wrapper: withStore({
+        ...stateMockData,
+        payments: {
+          ...stateMockData.payments,
+          paymentTokens: {
+            ...stateMockData.payments?.paymentTokens,
+            error: mockError,
+          },
+        },
+      }),
+    });
+
+    expect(error).toEqual(mockError);
+  });
+
+  it('should return loading state', () => {
+    const {
+      result: {
+        current: { isLoading },
+      },
+    } = renderHook(() => usePaymentTokens(), {
+      wrapper: withStore({
+        ...stateMockData,
+        payments: {
+          ...stateMockData.payments,
+          paymentTokens: {
+            ...stateMockData.payments?.paymentTokens,
+            isLoading: true,
+          },
+        },
+      }),
+    });
+
+    expect(isLoading).toBe(true);
+  });
+
+  it('should return correctly if not fetched', () => {
+    const {
+      result: {
+        current: { isLoading, isFetched, error },
+      },
+    } = renderHook(() => usePaymentTokens(), {
+      wrapper: withStore(mockInitialState),
+    });
+
+    expect(error).toBeNull();
+    expect(isLoading).toBe(false);
+    expect(isFetched).toBe(false);
+  });
+
+  describe('options', () => {
+    it('should call fetch data if `enableAutoFetch` option is true', () => {
+      renderHook(() => usePaymentTokens(), {
+        wrapper: withStore(mockInitialState),
+      });
+
+      expect(fetchPaymentTokens).toHaveBeenCalled();
+    });
+
+    it('should not fetch data if `enableAutoFetch` option is false', () => {
+      renderHook(() => usePaymentTokens({ enableAutoFetch: false }), {
+        wrapper: withStore(mockInitialState),
+      });
+
+      expect(fetchPaymentTokens).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('actions', () => {
+    it('should call `fetch` action', async () => {
+      const {
+        result: {
+          current: {
+            actions: { fetch },
+          },
+        },
+      } = renderHook(() => usePaymentTokens({ enableAutoFetch: false }), {
+        wrapper: withStore(mockInitialState),
+      });
+
+      await fetch();
+
+      expect(fetchPaymentTokens).toHaveBeenCalled();
+    });
+
+    it('should call `remove` action', async () => {
+      const tokenId = '123';
+
+      const {
+        result: {
+          current: {
+            actions: { remove },
+          },
+        },
+      } = renderHook(() => usePaymentTokens(), {
+        wrapper: withStore(stateMockData),
+      });
+
+      await remove(tokenId);
+
+      expect(removePaymentToken).toHaveBeenCalledWith(tokenId);
+    });
+  });
+});

--- a/packages/react/src/payments/hooks/index.ts
+++ b/packages/react/src/payments/hooks/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Payment hooks.
+ */
+export { default as usePaymentTokens } from './usePaymentTokens';

--- a/packages/react/src/payments/hooks/types/index.ts
+++ b/packages/react/src/payments/hooks/types/index.ts
@@ -1,0 +1,1 @@
+export * from './usePaymentTokens.types';

--- a/packages/react/src/payments/hooks/types/usePaymentTokens.types.ts
+++ b/packages/react/src/payments/hooks/types/usePaymentTokens.types.ts
@@ -1,0 +1,7 @@
+import type { Config, GetPaymentTokensQuery } from '@farfetch/blackout-client';
+
+export type UsePaymentTokensOptions = {
+  enableAutoFetch?: boolean;
+  fetchQuery?: GetPaymentTokensQuery;
+  fetchConfig?: Config;
+};

--- a/packages/react/src/payments/hooks/usePaymentTokens.ts
+++ b/packages/react/src/payments/hooks/usePaymentTokens.ts
@@ -1,0 +1,53 @@
+import {
+  arePaymentTokensFetched,
+  arePaymentTokensLoading,
+  fetchPaymentTokens,
+  getPaymentTokens,
+  getPaymentTokensError,
+  removePaymentToken,
+} from '@farfetch/blackout-redux';
+import { useAction } from '../../helpers';
+import { useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import type { UsePaymentTokensOptions } from './types';
+
+function usePaymentTokens(options: UsePaymentTokensOptions = {}) {
+  const { enableAutoFetch = true, fetchQuery, fetchConfig } = options;
+  // Selectors
+  const paymentTokens = useSelector(getPaymentTokens);
+  const isLoading = useSelector(arePaymentTokensLoading);
+  const error = useSelector(getPaymentTokensError);
+  const isFetched = useSelector(arePaymentTokensFetched);
+  // Actions
+  const fetch = useAction(fetchPaymentTokens);
+  const remove = useAction(removePaymentToken);
+
+  useEffect(() => {
+    if (enableAutoFetch && !isLoading && !error && !isFetched) {
+      fetch(fetchQuery, fetchConfig);
+    }
+  }, [
+    enableAutoFetch,
+    error,
+    fetch,
+    fetchConfig,
+    fetchQuery,
+    isFetched,
+    isLoading,
+  ]);
+
+  const items = useMemo(
+    () => (paymentTokens ? Object.values(paymentTokens) : undefined),
+    [paymentTokens],
+  );
+
+  return {
+    isLoading,
+    error,
+    data: { items },
+    isFetched,
+    actions: { fetch, remove },
+  };
+}
+
+export default usePaymentTokens;

--- a/packages/react/src/payments/index.ts
+++ b/packages/react/src/payments/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks';

--- a/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
@@ -63,6 +63,7 @@ Object {
   "areOrdersLoading": [Function],
   "arePaymentInstrumentsLoading": [Function],
   "arePaymentMethodsLoading": [Function],
+  "arePaymentTokensFetched": [Function],
   "arePaymentTokensLoading": [Function],
   "areProductAttributesFetched": [Function],
   "areProductAttributesLoading": [Function],

--- a/packages/redux/src/payments/__tests__/reducer.test.ts
+++ b/packages/redux/src/payments/__tests__/reducer.test.ts
@@ -389,13 +389,7 @@ describe('payments reducer', () => {
           },
         };
 
-        const expectedResult = {
-          paymentInstruments: {},
-          paymentTokens: {},
-          checkoutOrders: {},
-        };
-
-        expect(entitiesMapper[LOGOUT_SUCCESS](state)).toEqual(expectedResult);
+        expect(entitiesMapper[LOGOUT_SUCCESS](state)).toEqual({});
       });
     });
   });

--- a/packages/redux/src/payments/__tests__/selectors.test.ts
+++ b/packages/redux/src/payments/__tests__/selectors.test.ts
@@ -84,6 +84,48 @@ describe('Payments redux selectors', () => {
         expect(spy).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe('arePaymentTokensFetched()', () => {
+      it('should return correctly if not fetched', () => {
+        expect(selectors.arePaymentTokensFetched(mockInitialState)).toBe(false);
+      });
+
+      it('should return correctly on error', () => {
+        const mockError = {
+          message: 'This is an error message',
+          name: 'error',
+          code: 500,
+        };
+
+        expect(
+          selectors.arePaymentTokensFetched({
+            ...mockState,
+            payments: {
+              ...mockState.payments,
+              paymentTokens: {
+                ...mockState.payments?.paymentTokens,
+                error: mockError,
+              },
+            },
+          }),
+        ).toBe(true);
+      });
+
+      it('should return correctly on load', () => {
+        expect(
+          selectors.arePaymentTokensFetched({
+            ...mockState,
+            payments: {
+              ...mockState.payments,
+              paymentTokens: {
+                ...mockState.payments?.paymentTokens,
+                isLoading: true,
+              },
+            },
+          }),
+        ).toBe(false);
+      });
+    });
   });
 
   describe('Instruments', () => {

--- a/packages/redux/src/payments/reducer.ts
+++ b/packages/redux/src/payments/reducer.ts
@@ -258,12 +258,10 @@ export const entitiesMapper = {
   [LOGOUT_SUCCESS]: (
     state: NonNullable<StoreState['entities']>,
   ): StoreState['entities'] => {
-    return {
-      ...state,
-      paymentInstruments: {},
-      paymentTokens: {},
-      checkoutOrders: {},
-    };
+    const { paymentInstruments, paymentTokens, checkoutOrders, ...rest } =
+      state;
+
+    return rest;
   },
 };
 

--- a/packages/redux/src/payments/selectors.ts
+++ b/packages/redux/src/payments/selectors.ts
@@ -69,6 +69,18 @@ export const arePaymentTokensLoading = (state: StoreState) =>
   getPaymentTokensReducer(state.payments as PaymentsState).isLoading;
 
 /**
+ * Returns the fetched status for the payment tokens.
+ *
+ * @param state - Application state.
+ *
+ * @returns - Fetched status.
+ */
+export const arePaymentTokensFetched = (state: StoreState) =>
+  (getPaymentTokensResult(state) !== null ||
+    getPaymentTokensError(state) !== null) &&
+  !arePaymentTokensLoading(state);
+
+/**
  * Returns the payment instruments entity.
  *
  * @param state - Application state.


### PR DESCRIPTION
## Description

This PR adds the `usePaymentTokens` react hook :

- Params
    - enableAutoFetch (optional)
- Return
    - isLoading
    - error
    - isFetched
    - data
        - items (Array of tokens)
    - actions
        - fetch
        - remove

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

Also, a redux selector `arePaymentTokensFetched` was added to `blackout-redux`

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
