### PR TITLE
feat(core): add omnitracking's promocode mappings

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -52,6 +52,10 @@ export const customTrackMockData = {
   [eventTypes.CHECKOUT_STARTED]: {
     currency: 'USD',
   },
+  [eventTypes.PROMOCODE_APPLIED]: {
+    coupon: 'PROMO_ABC',
+    errorMessage: 'No promocode available.',
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -501,6 +501,12 @@ export const trackEventsMapper = {
     actionArea: data.properties.actionArea,
     productId: data.properties.id,
   }),
+  [eventTypes.PROMOCODE_APPLIED]: data => ({
+    tid: 311,
+    promoCode: data.properties.coupon,
+    hasError: !!data.properties?.errorMessage,
+    errorMessage: data.properties?.errorMessage,
+  }),
 };
 
 /**

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -69,6 +69,15 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Promocode Applied\` return should match the snapshot 1`] = `
+Object {
+  "errorMessage": "No promocode available.",
+  "hasError": true,
+  "promoCode": "PROMO_ABC",
+  "tid": 311,
+}
+`;
+
 exports[`Omnitracking definitions \`Share\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "share_button_facebook",


### PR DESCRIPTION
## Description

- Added promocode applied event mapping.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
