### PR TITLE
feat(core): add omnitracking's place order started event mappings

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -56,6 +56,10 @@ export const customTrackMockData = {
     coupon: 'PROMO_ABC',
     errorMessage: 'No promocode available.',
   },
+  [eventTypes.PLACE_ORDER_STARTED]: {
+    orderId: 'ABC12',
+    coupon: 'promo',
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
@@ -1,11 +1,16 @@
 import {
   generatePaymentAttemptReferenceId,
+  getCheckoutEventGenericProperties,
   getPageEventFromLocation,
   getPlatformSpecificParameters,
   getValParameterForEvent,
 } from '../omnitracking-helper';
+import { utils } from '../../..';
 import platformTypes from '../../../types/platformTypes';
 import trackTypes from '../../../types/trackTypes';
+
+utils.logger.warn = jest.fn();
+const mockLoggerWarn = utils.logger.warn;
 
 describe('getPageEventFromLocation', () => {
   it('should return null when location is not provided', () => {
@@ -47,5 +52,49 @@ describe('getPlatformSpecificParameters', () => {
     };
 
     expect(getPlatformSpecificParameters(eventData)).toStrictEqual({});
+  });
+});
+
+describe('getCheckoutEventGenericProperties', () => {
+  it('should display some warn', () => {
+    const eventData = {
+      properties: {
+        orderId: '123',
+      },
+    };
+
+    getCheckoutEventGenericProperties(eventData);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'property orderId should be an alphanumeric value',
+      ),
+    );
+  });
+
+  it('should get orderCode without warn and without property orderId', () => {
+    const eventData = {
+      properties: {
+        orderId: '5H5QYB',
+        checkoutOrderId: '123',
+      },
+    };
+
+    expect(getCheckoutEventGenericProperties(eventData)).toEqual({
+      orderCode: '5H5QYB',
+    });
+  });
+
+  it('should get orderCode without warn and with property orderId', () => {
+    const eventData = {
+      properties: {
+        orderId: '5H5QYB',
+        checkoutOrderId: '123',
+      },
+    };
+
+    expect(getCheckoutEventGenericProperties(eventData, true)).toEqual({
+      orderCode: '5H5QYB',
+      orderId: '123',
+    });
   });
 });

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -417,6 +417,9 @@ export const trackEventsMapper = {
       {
         tid: 188,
         val,
+        ...getCheckoutEventGenericProperties(data),
+        promocode: data.properties.coupon,
+        shippingTotalValue: data.properties?.shipping,
       },
     ];
   },
@@ -532,7 +535,7 @@ export const pageEventsMapper = {
     wishlistQuantity: getProductLineItemsQuantity(data.properties.products),
   }),
   [pageTypes.CHECKOUT]: data => ({
-    ...getCheckoutEventGenericProperties(data),
+    ...getCheckoutEventGenericProperties(data, true),
     viewType: 'Checkout SPA',
     viewSubType: 'Checkout SPA',
     orderValue: data.properties?.total,

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -538,7 +538,7 @@ export const getProductLineItemsQuantity = productList => {
   );
 };
 
-export const getCheckoutEventGenericProperties = data => {
+export const getCheckoutEventGenericProperties = (data, addOrderId = false) => {
   const validOrderCode = isNaN(data.properties?.orderId);
 
   if (!validOrderCode) {
@@ -549,10 +549,14 @@ export const getCheckoutEventGenericProperties = data => {
     );
   }
 
-  return {
-    orderCode: validOrderCode ? data.properties?.orderId : undefined,
-    orderId: !validOrderCode
-      ? parseInt(data.properties?.orderId)
-      : data.properties?.checkoutOrderId,
-  };
+  const orderCode = validOrderCode ? data.properties?.orderId : undefined;
+
+  return addOrderId
+    ? {
+        orderCode,
+        orderId: !validOrderCode
+          ? parseInt(data.properties?.orderId)
+          : data.properties?.checkoutOrderId,
+      }
+    : { orderCode };
 };

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -379,6 +379,11 @@ describe('Omnitracking', () => {
 
         let data = generateTrackMockData({
           event: eventTypes.PLACE_ORDER_STARTED,
+          properties: {
+            coupon: 'promo',
+            shipping: 12,
+            orderId: 'ABC12',
+          },
         });
 
         await omnitracking.track(data);
@@ -404,6 +409,9 @@ describe('Omnitracking', () => {
               parameters: {
                 ...expectedPayload.parameters,
                 tid: placeOrderTid2,
+                promocode: 'promo',
+                shippingTotalValue: 12,
+                orderCode: 'ABC12',
               },
             },
           ],

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -42,6 +42,9 @@ Array [
     "val": "{\\"type\\":\\"TRANSACTION\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
   },
   Object {
+    "orderCode": "ABC12",
+    "promocode": "promo",
+    "shippingTotalValue": 10,
     "tid": 188,
     "val": "{\\"type\\":\\"TRANSACTION\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
   },


### PR DESCRIPTION

## Description

- Added place order started event mapping;
- Fix omnitracking checkout event mapper helper to remove unwanted orderId;
- Fix tests;


<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
