### PR TITLE
Feat add omnitracking order completed event

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -60,6 +60,9 @@ export const customTrackMockData = {
     orderId: 'ABC12',
     coupon: 'promo',
   },
+  [eventTypes.ORDER_COMPLETED]: {
+    orderId: 'ABC12',
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -510,6 +510,10 @@ export const trackEventsMapper = {
     hasError: !!data.properties?.errorMessage,
     errorMessage: data.properties?.errorMessage,
   }),
+  [eventTypes.ORDER_COMPLETED]: data => ({
+    tid: 2831,
+    ...getCheckoutEventGenericProperties(data),
+  }),
 };
 
 /**

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -35,6 +35,13 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Order Completed\` return should match the snapshot 1`] = `
+Object {
+  "orderCode": "ABC12",
+  "tid": 2831,
+}
+`;
+
 exports[`Omnitracking definitions \`Place Order Started\` return should match the snapshot 1`] = `
 Array [
   Object {


### PR DESCRIPTION
## Description

- Added order completed event mapping.

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

#476 

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
