### PR TITLE
feat(core): add omnitracking's address info mappings

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -66,6 +66,11 @@ export const customTrackMockData = {
   [eventTypes.SIGNUP_NEWSLETTER]: {
     gender: ['0', '1'],
   },
+  [eventTypes.ADDRESS_INFO_ADDED]: {
+    step: '1',
+    deliveryType: 'Standard/Standard',
+    interactionType: 'click',
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
@@ -1,6 +1,7 @@
 import {
   generatePaymentAttemptReferenceId,
   getCheckoutEventGenericProperties,
+  getDeliveryInformationDetails,
   getGenderValueFromProperties,
   getPageEventFromLocation,
   getPlatformSpecificParameters,
@@ -144,5 +145,20 @@ describe('getGenderValueFromProperties', () => {
         },
       }),
     ).toEqual(`customGenderName,${SignupNewsletterGenderMappings[0]}`);
+  });
+});
+
+describe('getDeliveryInformationDetails', () => {
+  it('should deal with empty information', () => {
+    expect(getDeliveryInformationDetails({})).toEqual(undefined);
+  });
+  it('should deal with delivery type', () => {
+    expect(
+      getDeliveryInformationDetails({
+        properties: {
+          deliveryType: 'sample',
+        },
+      }),
+    ).toEqual('{"courierType":"sample"}');
   });
 });

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -6,6 +6,7 @@
 import {
   generatePaymentAttemptReferenceId,
   getCheckoutEventGenericProperties,
+  getDeliveryInformationDetails,
   getGenderValueFromProperties,
   getParameterValueFromEvent,
   getProductLineItems,
@@ -518,6 +519,12 @@ export const trackEventsMapper = {
   [eventTypes.SIGNUP_NEWSLETTER]: data => ({
     tid: 2831,
     gender: getGenderValueFromProperties(data),
+  }),
+  [eventTypes.ADDRESS_INFO_ADDED]: data => ({
+    tid: 2911,
+    checkoutStep: data.properties?.step,
+    deliveryInformationDetails: getDeliveryInformationDetails(data),
+    interactionType: data.properties?.interactionType,
   }),
 };
 

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -591,3 +591,22 @@ export const getGenderValueFromProperties = data => {
 
   return genderArray.reduce((acc, item) => `${acc},${item}`);
 };
+
+/**
+ * Obtain Delivery Information Details using event properties data in JSON Format.
+ *
+ * @param {object} data - The event's data.
+ *
+ * @returns {string} - Delivery Information Details in Json Format.
+ */
+export const getDeliveryInformationDetails = data => {
+  const deliveryInfo = {};
+
+  if (data.properties?.deliveryType) {
+    deliveryInfo['courierType'] = data.properties?.deliveryType;
+  }
+
+  return JSON.stringify(
+    Object.keys(deliveryInfo).length ? deliveryInfo : undefined,
+  );
+};

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Omnitracking definitions \`Address Info Added\` return should match the snapshot 1`] = `
+Object {
+  "checkoutStep": "1",
+  "deliveryInformationDetails": "{\\"courierType\\":\\"Standard/Standard\\"}",
+  "interactionType": "click",
+  "tid": 2911,
+}
+`;
+
 exports[`Omnitracking definitions \`Checkout Abandoned\` return should match the snapshot 1`] = `
 Object {
   "tid": 2084,


### PR DESCRIPTION


## Description

- Added address_info_added event mapping.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
