### PR TITLE
Feat add omnitracking payment info event

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -71,6 +71,12 @@ export const customTrackMockData = {
     deliveryType: 'Standard/Standard',
     interactionType: 'click',
   },
+  [eventTypes.PAYMENT_INFO_ADDED]: {
+    step: '1',
+    deliveryType: 'Standard/Standard',
+    interactionType: 'click',
+    paymentType: 'credit',
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -542,6 +542,13 @@ export const trackEventsMapper = {
     deliveryInformationDetails: getDeliveryInformationDetails(data),
     interactionType: data.properties?.interactionType,
   }),
+  [eventTypes.PAYMENT_INFO_ADDED]: data => ({
+    tid: 2912,
+    checkoutStep: data.properties?.step,
+    deliveryInformationDetails: getDeliveryInformationDetails(data),
+    interactionType: data.properties?.interactionType,
+    selectedPaymentMethod: data.properties?.paymentType,
+  }),
 };
 
 /**

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -51,6 +51,16 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Payment Info Added\` return should match the snapshot 1`] = `
+Object {
+  "checkoutStep": "1",
+  "deliveryInformationDetails": "{\\"courierType\\":\\"Standard/Standard\\"}",
+  "interactionType": "click",
+  "selectedPaymentMethod": "credit",
+  "tid": 2912,
+}
+`;
+
 exports[`Omnitracking definitions \`Place Order Started\` return should match the snapshot 1`] = `
 Array [
   Object {


### PR DESCRIPTION
## Description

- Added payment_info_added event mapping.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

#486 
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
