### PR TITLE
Feat add omnitracking shipping event

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -77,6 +77,18 @@ export const customTrackMockData = {
     interactionType: 'click',
     paymentType: 'credit',
   },
+  [eventTypes.SHIPPING_METHOD_ADDED]: {
+    step: '2',
+    deliveryType: 'Standard/Standard',
+    interactionType: 'click',
+    paymentType: 'credit',
+  },
+  [eventTypes.SHIPPING_INFO_ADDED]: {
+    step: '2',
+    deliveryType: 'Standard/Standard',
+    interactionType: 'click',
+    paymentType: 'credit',
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
@@ -1,6 +1,7 @@
 import {
   generatePaymentAttemptReferenceId,
   getCheckoutEventGenericProperties,
+  getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
   getGenderValueFromProperties,
   getPageEventFromLocation,
@@ -160,5 +161,23 @@ describe('getDeliveryInformationDetails', () => {
         },
       }),
     ).toEqual('{"courierType":"sample"}');
+  });
+});
+
+describe('getCommonCheckoutStepTrackingData', () => {
+  it('should obtain common checkout parameters', () => {
+    expect(
+      getCommonCheckoutStepTrackingData({
+        properties: {
+          step: 2,
+          deliveryType: 'sample',
+          interactionType: 'click',
+        },
+      }),
+    ).toEqual({
+      checkoutStep: 2,
+      deliveryInformationDetails: '{"courierType":"sample"}',
+      interactionType: 'click',
+    });
   });
 });

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -6,7 +6,7 @@
 import {
   generatePaymentAttemptReferenceId,
   getCheckoutEventGenericProperties,
-  getDeliveryInformationDetails,
+  getCommonCheckoutStepTrackingData,
   getGenderValueFromProperties,
   getParameterValueFromEvent,
   getProductLineItems,
@@ -537,16 +537,22 @@ export const trackEventsMapper = {
     gender: getGenderValueFromProperties(data),
   }),
   [eventTypes.ADDRESS_INFO_ADDED]: data => ({
+    ...getCommonCheckoutStepTrackingData(data),
     tid: 2911,
-    checkoutStep: data.properties?.step,
-    deliveryInformationDetails: getDeliveryInformationDetails(data),
-    interactionType: data.properties?.interactionType,
   }),
   [eventTypes.PAYMENT_INFO_ADDED]: data => ({
+    ...getCommonCheckoutStepTrackingData(data),
     tid: 2912,
-    checkoutStep: data.properties?.step,
-    deliveryInformationDetails: getDeliveryInformationDetails(data),
-    interactionType: data.properties?.interactionType,
+    selectedPaymentMethod: data.properties?.paymentType,
+  }),
+  [eventTypes.SHIPPING_INFO_ADDED]: data => ({
+    ...getCommonCheckoutStepTrackingData(data),
+    tid: 2914,
+    selectedPaymentMethod: data.properties?.paymentType,
+  }),
+  [eventTypes.SHIPPING_METHOD_ADDED]: data => ({
+    ...getCommonCheckoutStepTrackingData(data),
+    tid: 2913,
     selectedPaymentMethod: data.properties?.paymentType,
   }),
 };

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -610,3 +610,16 @@ export const getDeliveryInformationDetails = data => {
     Object.keys(deliveryInfo).length ? deliveryInfo : undefined,
   );
 };
+
+/**
+ * Obtain Common Checkout Details.
+ *
+ * @param {object} data - The event's data.
+ *
+ * @returns {object} - Omnitracking's common checkout parameters.
+ */
+export const getCommonCheckoutStepTrackingData = data => ({
+  checkoutStep: data.properties?.step,
+  deliveryInformationDetails: getDeliveryInformationDetails(data),
+  interactionType: data.properties?.interactionType,
+});

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -115,6 +115,26 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Shipping Info Added\` return should match the snapshot 1`] = `
+Object {
+  "checkoutStep": "2",
+  "deliveryInformationDetails": "{\\"courierType\\":\\"Standard/Standard\\"}",
+  "interactionType": "click",
+  "selectedPaymentMethod": "credit",
+  "tid": 2914,
+}
+`;
+
+exports[`Omnitracking definitions \`Shipping Method Added\` return should match the snapshot 1`] = `
+Object {
+  "checkoutStep": "2",
+  "deliveryInformationDetails": "{\\"courierType\\":\\"Standard/Standard\\"}",
+  "interactionType": "click",
+  "selectedPaymentMethod": "credit",
+  "tid": 2913,
+}
+`;
+
 exports[`Omnitracking definitions \`Sign-up Form Viewed\` return should match the snapshot 1`] = `
 Object {
   "tid": 10097,


### PR DESCRIPTION
## Description

- Added shipping method event mapping.
- Added shipping info event mapping.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

#487 
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
