### PR TITLE
feat(core): add new option to pass an http client to omnitracking integration

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
@@ -23,6 +23,7 @@ import {
   validateOutgoingOmnitrackingPayload,
 } from './omnitracking-helper';
 import {
+  OPTION_HTTP_CLIENT,
   OPTION_SEARCH_QUERY_PARAMETERS,
   OPTION_TRANSFORM_PAYLOAD,
 } from './constants';
@@ -60,6 +61,7 @@ class Omnitracking extends Integration {
     const {
       [OPTION_TRANSFORM_PAYLOAD]: transformPayload,
       [OPTION_SEARCH_QUERY_PARAMETERS]: searchQueryParameters,
+      [OPTION_HTTP_CLIENT]: httpClient,
     } = options;
 
     this.transformPayload = transformPayload;
@@ -89,6 +91,12 @@ class Omnitracking extends Integration {
           `[Omnitracking] - Invalid value provided for ${OPTION_SEARCH_QUERY_PARAMETERS} option. All parameters should be typed as string`,
         );
       }
+    }
+
+    if (httpClient && typeof httpClient !== 'function') {
+      logger.error(
+        '[Omnitracking] - Invalid `httpClient` option. Please make to pass a valid function to perform the http requests to the omnitracking service.',
+      );
     }
 
     // These will be used to track the uniqueViewId and
@@ -336,8 +344,23 @@ class Omnitracking extends Integration {
     }
 
     if (validateOutgoingOmnitrackingPayload(finalPayload)) {
-      postTrackings(finalPayload);
+      await this.sendEvent(finalPayload);
     }
+  }
+
+  /**
+   * Sends the final payload to the httpClient, if passed. Will call the postTrackings client otherwise.
+   *
+   * @param {object} finalPayload - The very final payload to be sent to the omnitracking service endpoint.
+   *
+   * @returns {Promise} - Promise that will resolve when the method finishes.
+   */
+  async sendEvent(finalPayload) {
+    if (this.options.httpClient) {
+      return await this.options.httpClient(finalPayload);
+    }
+
+    postTrackings(finalPayload);
   }
 }
 

--- a/packages/core/src/analytics/integrations/Omnitracking/constants.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/constants.js
@@ -1,4 +1,5 @@
 export const OPTION_SEARCH_QUERY_PARAMETERS = 'searchQueryParameters';
+export const OPTION_HTTP_CLIENT = 'httpClient';
 export const OPTION_TRANSFORM_PAYLOAD = 'transformPayload';
 export const DEFAULT_SEARCH_QUERY_PARAMETERS = ['query', 'searchQuery', 'q'];
 export const DEFAULT_CLIENT_LANGUAGE = 'en';

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -672,6 +672,40 @@ describe('Omnitracking', () => {
         );
       });
     });
+
+    describe('httpClient', () => {
+      it('Should output an error on the console if the httpClient type is not a function', () => {
+        omnitracking = new Omnitracking({
+          httpClient: 'foo',
+        });
+
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          '[Omnitracking] - Invalid `httpClient` option. Please make to pass a valid function to perform the http requests to the omnitracking service.',
+        );
+      });
+
+      it('Should allow to pass a custom httpClient and call it when tracking an event', async () => {
+        const mockHttpClient = jest.fn();
+
+        omnitracking = new Omnitracking({
+          httpClient: mockHttpClient,
+        });
+
+        await omnitracking.track(generateMockData());
+
+        expect(mockHttpClient).toHaveBeenCalledWith({
+          ...expectedPagePayloadWeb,
+          parameters: {
+            ...expectedPagePayloadWeb.parameters,
+            uniqueViewId: expect.any(String),
+            previousUniqueViewId: null,
+            viewType: 'Others',
+            viewSubType: 'Others',
+          },
+        });
+        expect(postTrackingsSpy).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('parameters', () => {


### PR DESCRIPTION
## Description
This PR adds a new option to the omnitracking integration so we can pass a custom http client to handle the requests, allowing to override the default behaviour of calling the internal `postTrackings` core client.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
