### PR TITLE
feat(analytics): add new option to pass an http client to omnitracking integration - next

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/constants.ts
+++ b/packages/analytics/src/integrations/Omnitracking/constants.ts
@@ -1,4 +1,5 @@
 export const OPTION_SEARCH_QUERY_PARAMETERS = 'searchQueryParameters';
+export const OPTION_HTTP_CLIENT = 'httpClient';
 export const OPTION_TRANSFORM_PAYLOAD = 'transformPayload';
 export const DEFAULT_SEARCH_QUERY_PARAMETERS = ['query', 'searchQuery', 'q'];
 export const DEFAULT_CLIENT_LANGUAGE = 'en';

--- a/packages/analytics/src/integrations/Omnitracking/types/Omnitracking.types.ts
+++ b/packages/analytics/src/integrations/Omnitracking/types/Omnitracking.types.ts
@@ -1,4 +1,5 @@
 import {
+  OPTION_HTTP_CLIENT,
   OPTION_SEARCH_QUERY_PARAMETERS,
   OPTION_TRANSFORM_PAYLOAD,
 } from '../constants';
@@ -63,6 +64,9 @@ export type OmnitrackingTrackEventsMapper = {
 };
 
 export type SearchQueryParameters = string[];
+export type HttpClient = (
+  payload: OmnitrackingRequestPayload<PageViewEvents | PageActionEvents>,
+) => Promise<void>;
 export type TransformPayloadFunction = (
   payload: OmnitrackingRequestPayload<PageViewEvents | PageActionEvents>,
   data: EventData<TrackTypesValues>,
@@ -71,6 +75,7 @@ export type TransformPayloadFunction = (
 export interface OmnitrackingOptions extends IntegrationOptions {
   [OPTION_TRANSFORM_PAYLOAD]?: TransformPayloadFunction;
   [OPTION_SEARCH_QUERY_PARAMETERS]?: SearchQueryParameters;
+  [OPTION_HTTP_CLIENT]?: HttpClient;
 }
 
 export type SpecificParametersForEventType<


### PR DESCRIPTION
## Description
This PR adds a new option to the omnitracking integration so we can pass a custom http client to handle the requests, allowing to override the default behaviour of calling the internal postTrackings core client.


<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
