### PR TITLE
Feat add omnitracking product clicked event

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -107,6 +107,10 @@ export const customTrackMockData = {
     wishlistId: '4c040892-cc27-4294-99e3-524b14eddf33',
     currency: 'EUR',
   },
+  [eventTypes.PRODUCT_CLICKED]: {
+    from: 'PDP',
+    id: 123,
+  },
   [eventTypes.PRODUCT_UPDATED]: {
     from: 'PDP',
     id: 12345,

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -8,6 +8,7 @@ import {
   getCheckoutEventGenericProperties,
   getCommonCheckoutStepTrackingData,
   getGenderValueFromProperties,
+  getOmnitrackingProductId,
   getProductLineItems,
   getProductLineItemsQuantity,
   getValParameterForEvent,
@@ -463,7 +464,7 @@ export const trackEventsMapper = {
   [eventTypes.SHARE]: data => ({
     tid: 1205,
     actionArea: data.properties?.method,
-    productId: data.properties.id,
+    productId: getOmnitrackingProductId(data),
   }),
   [eventTypes.PROMOCODE_APPLIED]: data => ({
     tid: 311,
@@ -524,6 +525,12 @@ export const trackEventsMapper = {
     wishlistId: data.properties?.wishlistId,
     lineItems: getProductLineItems(data),
   }),
+  [eventTypes.PRODUCT_CLICKED]: data => ({
+    tid: 2926,
+    actionArea: data.properties?.from,
+    productId: getOmnitrackingProductId(data),
+    lineItems: getProductLineItems(data),
+  }),
   [eventTypes.PRODUCT_UPDATED]: data => {
     const eventList = [];
     const properties = data.properties;
@@ -546,7 +553,7 @@ export const trackEventsMapper = {
       eventList.push({
         ...additionalParameters,
         tid: 2098,
-        productId: properties?.id,
+        productId: getOmnitrackingProductId(data),
         actionArea: properties?.from,
       });
     }
@@ -582,7 +589,7 @@ export const trackEventsMapper = {
       eventList.push({
         ...additionalParameters,
         tid: 2920,
-        productId: properties?.id,
+        productId: getOmnitrackingProductId(data),
         actionArea: properties?.from,
       });
     }
@@ -595,7 +602,7 @@ export const trackEventsMapper = {
 
       eventList.push({
         tid: 2919,
-        productId: properties?.id,
+        productId: getOmnitrackingProductId(data),
         actionArea: properties?.from,
         itemQuantity: properties?.quantity,
       });

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -467,6 +467,17 @@ export const getClientLanguageFromCulture = (culture = '') => {
 };
 
 /**
+ * Obtain product Id omnitracking parameter.
+ *
+ * @param {object} data - The event tracking data.
+ *
+ * @returns {string} - The product id.
+ */
+export const getOmnitrackingProductId = data => {
+  return data?.properties?.productId || data?.properties?.id;
+};
+
+/**
  * Transforms the products list payload into `lineItems` omnitracking parameter.
  *
  * @param {object} data - The event tracking data.
@@ -476,7 +487,7 @@ export const getClientLanguageFromCulture = (culture = '') => {
 export const getProductLineItems = data => {
   const properties = data?.properties || {};
   const productsList = properties.products;
-  const productId = properties.productId || properties.id;
+  const productId = getOmnitrackingProductId(data);
 
   if (productsList && productsList.length) {
     const mappedProductList = productsList.map(product => ({

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -96,6 +96,15 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Product Clicked\` return should match the snapshot 1`] = `
+Object {
+  "actionArea": "PDP",
+  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
+  "productId": 123,
+  "tid": 2926,
+}
+`;
+
 exports[`Omnitracking definitions \`Product List Viewed\` return should match the snapshot 1`] = `
 Object {
   "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
@@ -158,7 +167,7 @@ Object {
 exports[`Omnitracking definitions \`Share\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "share_button_facebook",
-  "productId": undefined,
+  "productId": 123,
   "tid": 1205,
 }
 `;


### PR DESCRIPTION
## Description

Added product clicked event mapping to omnitracking;

### Dependencies

#497.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
