### PR TITLE
Feat add omnitracking filters events

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -127,6 +127,30 @@ export const customTrackMockData = {
     quantity: 2,
     oldQuantity: 1,
   },
+  [eventTypes.FILTERS_APPLIED]: {
+    from: 'PLP',
+    filters: {
+      brands: [2765, 4062],
+      categories: [135973],
+      colors: [1],
+      discount: [0],
+      gender: [0],
+      price: [0, 1950],
+      sizes: [16],
+    },
+  },
+  [eventTypes.FILTERS_CLEARED]: {
+    from: 'PLP',
+    filters: {
+      brands: [2765, 4062],
+      categories: [135973],
+      colors: [1],
+      discount: [0],
+      gender: [0],
+      price: [0, 1950],
+      sizes: [16],
+    },
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -531,6 +531,20 @@ export const trackEventsMapper = {
     productId: getOmnitrackingProductId(data),
     lineItems: getProductLineItems(data),
   }),
+  [eventTypes.FILTERS_APPLIED]: data => ({
+    tid: 2921,
+    actionArea: data.properties?.from,
+    filtersApplied: data.properties?.filters
+      ? JSON.stringify(data.properties?.filters)
+      : undefined,
+  }),
+  [eventTypes.FILTERS_CLEARED]: data => ({
+    tid: 2917,
+    actionArea: data.properties?.from,
+    filtersApplied: data.properties?.filters
+      ? JSON.stringify(data.properties?.filters)
+      : undefined,
+  }),
   [eventTypes.PRODUCT_UPDATED]: data => {
     const eventList = [];
     const properties = data.properties;

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -38,6 +38,22 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Filters Applied\` return should match the snapshot 1`] = `
+Object {
+  "actionArea": "PLP",
+  "filtersApplied": "{\\"brands\\":[2765,4062],\\"categories\\":[135973],\\"colors\\":[1],\\"discount\\":[0],\\"gender\\":[0],\\"price\\":[0,1950],\\"sizes\\":[16]}",
+  "tid": 2921,
+}
+`;
+
+exports[`Omnitracking definitions \`Filters Cleared\` return should match the snapshot 1`] = `
+Object {
+  "actionArea": "PLP",
+  "filtersApplied": "{\\"brands\\":[2765,4062],\\"categories\\":[135973],\\"colors\\":[1],\\"discount\\":[0],\\"gender\\":[0],\\"price\\":[0,1950],\\"sizes\\":[16]}",
+  "tid": 2917,
+}
+`;
+
 exports[`Omnitracking definitions \`Logout\` return should match the snapshot 1`] = `
 Object {
   "tid": 431,


### PR DESCRIPTION
## Description

- Added filters cleared and filters applied event mapping to omnitracking;

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

#498.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
