### PR TITLE
Feat add omnitracking login signup events

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -151,6 +151,12 @@ export const customTrackMockData = {
       sizes: [16],
     },
   },
+  [eventTypes.LOGIN]: {
+    method: 'Tenant',
+  },
+  [eventTypes.SIGNUP_FORM_COMPLETED]: {
+    method: 'Tenant',
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -545,6 +545,14 @@ export const trackEventsMapper = {
       ? JSON.stringify(data.properties?.filters)
       : undefined,
   }),
+  [eventTypes.LOGIN]: data => ({
+    tid: 2924,
+    loginType: data.properties?.method,
+  }),
+  [eventTypes.SIGNUP_FORM_COMPLETED]: data => ({
+    tid: 2927,
+    loginType: data.properties?.method,
+  }),
   [eventTypes.PRODUCT_UPDATED]: data => {
     const eventList = [];
     const properties = data.properties;

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -54,6 +54,13 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Login\` return should match the snapshot 1`] = `
+Object {
+  "loginType": "Tenant",
+  "tid": 2924,
+}
+`;
+
 exports[`Omnitracking definitions \`Logout\` return should match the snapshot 1`] = `
 Object {
   "tid": 431,
@@ -205,6 +212,13 @@ Object {
   "interactionType": "click",
   "selectedPaymentMethod": "credit",
   "tid": 2913,
+}
+`;
+
+exports[`Omnitracking definitions \`Sign-up Form Completed\` return should match the snapshot 1`] = `
+Object {
+  "loginType": "Tenant",
+  "tid": 2927,
 }
 `;
 


### PR DESCRIPTION
## Description

- Added login event mapping to omnitracking;
- Added signup event mapping to omnitracking;
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

#499.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
