### PR TITLE
Feat add omnitracking interact content event

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -157,6 +157,12 @@ export const customTrackMockData = {
   [eventTypes.SIGNUP_FORM_COMPLETED]: {
     method: 'Tenant',
   },
+  [eventTypes.INTERACT_CONTENT]: {
+    contentType: 'Navbar',
+    interactionType: 'click',
+    id: '123',
+    state: 'expanded',
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -553,6 +553,26 @@ export const trackEventsMapper = {
     tid: 2927,
     loginType: data.properties?.method,
   }),
+  [eventTypes.INTERACT_CONTENT]: data => {
+    const properties = data.properties;
+
+    if (!properties?.contentType || !properties?.interactionType) {
+      logger.warn(
+        `[Omnitracking] - Event ${data.event} properties "contentType" and "interactionType" should be sent 
+                        on the payload when triggering a "interact content" event. If you want to track this event, make 
+                        sure to pass these two properties.`,
+      );
+      return;
+    }
+
+    return {
+      tid: 2882,
+      contentType: properties?.contentType,
+      interactionType: properties?.interactionType,
+      val: properties?.id,
+      actionArea: properties?.state,
+    };
+  },
   [eventTypes.PRODUCT_UPDATED]: data => {
     const eventList = [];
     const properties = data.properties;
@@ -584,6 +604,7 @@ export const trackEventsMapper = {
       // size changed event
 
       const additionalParameters = {};
+
       if (properties?.oldSizeScaleId && properties?.sizeScaleId) {
         additionalParameters[
           'scaleList'

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -342,6 +342,21 @@ describe('Omnitracking', () => {
 
           expect(mockLoggerWarn).not.toHaveBeenCalled();
         });
+        it('should warn if an interact content does not have required parameters', async () => {
+          const data = generateTrackMockData({
+            event: eventTypes.INTERACT_CONTENT,
+            properties: {
+              contentType: undefined,
+            },
+          });
+          await omnitracking.track(data);
+
+          expect(mockLoggerWarn).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'properties "contentType" and "interactionType" should be sent',
+            ),
+          );
+        });
       });
     });
     describe('Should send track events when', () => {

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -54,6 +54,16 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Interact Content\` return should match the snapshot 1`] = `
+Object {
+  "actionArea": "expanded",
+  "contentType": "Navbar",
+  "interactionType": "click",
+  "tid": 2882,
+  "val": "123",
+}
+`;
+
 exports[`Omnitracking definitions \`Login\` return should match the snapshot 1`] = `
 Object {
   "loginType": "Tenant",


### PR DESCRIPTION
## Description

- Added interact content event mapping to omnitracking;

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

#501.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
