### PR TITLE
Feat add omnitracking select content event

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -163,6 +163,12 @@ export const customTrackMockData = {
     id: '123',
     state: 'expanded',
   },
+  [eventTypes.SELECT_CONTENT]: {
+    contentType: 'Navbar',
+    interactionType: 'click',
+    id: '123',
+    productId: '12345',
+  },
 };
 
 export const expectedTrackPayload = {

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -573,6 +573,26 @@ export const trackEventsMapper = {
       actionArea: properties?.state,
     };
   },
+  [eventTypes.SELECT_CONTENT]: data => {
+    const properties = data.properties;
+
+    if (!properties?.contentType || !properties?.id) {
+      logger.warn(
+        `[Omnitracking] - Event ${data.event} properties "contentType" and "id" should be sent 
+                        on the payload when triggering a "select content" event. If you want to track this 
+                        event, make sure to pass these two properties.`,
+      );
+      return;
+    }
+
+    return {
+      tid: 2885,
+      contentType: properties?.contentType,
+      interactionType: properties?.interactionType,
+      val: properties?.id,
+      productId: properties?.productId,
+    };
+  },
   [eventTypes.PRODUCT_UPDATED]: data => {
     const eventList = [];
     const properties = data.properties;
@@ -580,6 +600,7 @@ export const trackEventsMapper = {
     if (properties.colour && properties.oldColour !== properties.colour) {
       // color changed event
       const additionalParameters = {};
+
       if (properties?.oldColourId && properties?.colourId) {
         additionalParameters[
           'colourList'
@@ -602,7 +623,6 @@ export const trackEventsMapper = {
 
     if (properties.size && properties.oldSize !== properties.size) {
       // size changed event
-
       const additionalParameters = {};
 
       if (properties?.oldSizeScaleId && properties?.sizeScaleId) {

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -342,6 +342,9 @@ describe('Omnitracking', () => {
 
           expect(mockLoggerWarn).not.toHaveBeenCalled();
         });
+      });
+
+      describe('Event Tracking', () => {
         it('should warn if an interact content does not have required parameters', async () => {
           const data = generateTrackMockData({
             event: eventTypes.INTERACT_CONTENT,
@@ -354,6 +357,21 @@ describe('Omnitracking', () => {
           expect(mockLoggerWarn).toHaveBeenCalledWith(
             expect.stringContaining(
               'properties "contentType" and "interactionType" should be sent',
+            ),
+          );
+        });
+        it('should warn if an select content does not have required parameters', async () => {
+          const data = generateTrackMockData({
+            event: eventTypes.SELECT_CONTENT,
+            properties: {
+              contentType: undefined,
+            },
+          });
+          await omnitracking.track(data);
+
+          expect(mockLoggerWarn).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'properties "contentType" and "id" should be sent',
             ),
           );
         });

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -197,6 +197,16 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Select Content\` return should match the snapshot 1`] = `
+Object {
+  "contentType": "Navbar",
+  "interactionType": "click",
+  "productId": "12345",
+  "tid": 2885,
+  "val": "123",
+}
+`;
+
 exports[`Omnitracking definitions \`Share\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "share_button_facebook",


### PR DESCRIPTION
## Description

- Added select content event mapping to omnitracking;
- Reafactoring of interact content tests.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

#503
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
