### PR TITLE
fix(redux): fix resetProductsLists action

### DIFF
--- a/packages/react/src/products/hooks/__tests__/useProductListing.test.tsx
+++ b/packages/react/src/products/hooks/__tests__/useProductListing.test.tsx
@@ -224,6 +224,7 @@ describe('useProductListing', () => {
       const {
         result: {
           current: {
+            data,
             actions: { reset },
           },
         },
@@ -233,7 +234,7 @@ describe('useProductListing', () => {
 
       reset();
 
-      expect(resetProductsLists).toHaveBeenCalled();
+      expect(resetProductsLists).toHaveBeenCalledWith([data?.hash]);
     });
 
     it('should call `fetchListing` successfully when `refetch` action is called and type is `listing`', () => {

--- a/packages/react/src/products/hooks/useProductListing.ts
+++ b/packages/react/src/products/hooks/useProductListing.ts
@@ -41,7 +41,9 @@ const useProductListing = (
   const fetchListingAction = useAction(fetchProductListing);
   const fetchSetAction = useAction(fetchProductSet);
   const resetAction = useAction(resetProductsLists);
-  const reset = useCallback(resetAction, [resetAction]);
+  const reset = useCallback(() => {
+    resetAction([productListingHash]);
+  }, [resetAction, productListingHash]);
 
   const isLoading = useSelector((state: StoreState) =>
     isProductsListLoading(state, productListingHash),

--- a/packages/redux/src/entities/types/productsList.types.ts
+++ b/packages/redux/src/entities/types/productsList.types.ts
@@ -1,8 +1,9 @@
 import type { FacetEntity } from './facet.types';
 import type {
   FacetGroup,
-  ProductListing as OriginalListing,
-  ProductSet as OriginalSet,
+  FilterSegment,
+  ProductListing,
+  ProductSet,
 } from '@farfetch/blackout-client';
 import type { ProductEntity } from './product.types';
 
@@ -12,19 +13,25 @@ export type FacetGroupsNormalized = Array<
   }
 >;
 
-type ProductsNormalized = Omit<OriginalListing['products'], 'entries'> &
-  Omit<OriginalSet['products'], 'entries'> & {
+export type FilterSegmentNormalized = FilterSegment & {
+  facetId: FacetEntity['id'];
+};
+
+type ProductsNormalized = Omit<ProductListing['products'], 'entries'> &
+  Omit<ProductSet['products'], 'entries'> & {
     entries: ProductEntity['id'][];
   };
 
 export type ProductsListEntity = Omit<
-  OriginalListing,
-  'products' | 'facetGroups'
+  ProductListing,
+  'products' | 'facetGroups' | 'filterSegments'
 > &
-  Omit<OriginalSet, 'products' | 'facetGroups'> & {
+  Omit<ProductSet, 'products' | 'facetGroups' | 'filterSegments' | 'id'> & {
     // Entities
     products: ProductsNormalized;
     facetGroups: FacetGroupsNormalized;
     // Properties
     hash: string;
+    filterSegments: FilterSegmentNormalized[];
+    id?: ProductSet['id'];
   };

--- a/packages/redux/src/products/actions/resetProductDetails.ts
+++ b/packages/redux/src/products/actions/resetProductDetails.ts
@@ -38,7 +38,7 @@ const resetProductEntities =
   ): void => {
     dispatch({
       type: actionTypes.RESET_PRODUCT_DETAILS_ENTITIES,
-      productIds,
+      payload: productIds,
     });
   };
 

--- a/packages/redux/src/products/actions/resetProductDetailsState.ts
+++ b/packages/redux/src/products/actions/resetProductDetailsState.ts
@@ -28,7 +28,7 @@ const resetProductDetailsState =
   (dispatch: Dispatch<ResetProductDetailsStateAction>): void => {
     dispatch({
       type: actionTypes.RESET_PRODUCT_DETAILS_STATE,
-      productIds,
+      payload: productIds,
     });
   };
 

--- a/packages/redux/src/products/actions/resetProductsLists.ts
+++ b/packages/redux/src/products/actions/resetProductsLists.ts
@@ -28,7 +28,7 @@ import type { ThunkDispatch } from 'redux-thunk';
  * @returns Dispatch reset productsLists entities action.
  */
 const resetProductsListsEntities =
-  () =>
+  (productsListsHashes?: Array<string>) =>
   (
     dispatch: ThunkDispatch<
       StoreState,
@@ -38,6 +38,7 @@ const resetProductsListsEntities =
   ): void => {
     dispatch({
       type: actionTypes.RESET_PRODUCTS_LISTS_ENTITIES,
+      payload: productsListsHashes,
     });
   };
 
@@ -74,7 +75,7 @@ const resetProductsListsEntities =
  * @returns Dispatch reset products lists state and entities action.
  */
 const resetProductsLists =
-  () =>
+  (productsListsHashes?: Array<string>) =>
   (
     dispatch: ThunkDispatch<
       StoreState,
@@ -82,8 +83,8 @@ const resetProductsLists =
       ResetProductsListsStateAction | ResetProductsListsEntitiesAction
     >,
   ): void => {
-    dispatch(resetProductsListsState());
-    dispatch(resetProductsListsEntities());
+    dispatch(resetProductsListsState(productsListsHashes));
+    dispatch(resetProductsListsEntities(productsListsHashes));
   };
 
 export default resetProductsLists;

--- a/packages/redux/src/products/actions/resetProductsListsState.ts
+++ b/packages/redux/src/products/actions/resetProductsListsState.ts
@@ -28,10 +28,11 @@ import type { ResetProductsListsStateAction } from '../types';
  * @returns Dispatch reset products list state action.
  */
 const resetProductsListsState =
-  () =>
+  (productsListsHashes?: Array<string>) =>
   (dispatch: Dispatch<ResetProductsListsStateAction>): void => {
     dispatch({
       type: actionTypes.RESET_PRODUCTS_LISTS_STATE,
+      payload: productsListsHashes,
     });
   };
 

--- a/packages/redux/src/products/reducer/__tests__/details.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/details.test.ts
@@ -19,12 +19,36 @@ describe('details redux reducer', () => {
   });
 
   describe('reset handling', () => {
-    it('should return the initial state', () => {
+    it('should return the initial state if no payload is provided', () => {
       expect(
         reducer(undefined, {
           type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
         }),
       ).toEqual(initialState);
+
+      expect(
+        reducer(undefined, {
+          type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
+          payload: [],
+        }),
+      ).toEqual(initialState);
+    });
+
+    it('should return the same state if a payload with at least one product id is provided and it is not in state', () => {
+      const anotherProductId = mockProductId + 1;
+
+      const state = {
+        error: { [anotherProductId]: new Error('dummy error') },
+        isLoading: { [anotherProductId]: false },
+        isHydrated: { [anotherProductId]: true },
+      };
+
+      expect(
+        reducer(state, {
+          type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
+          payload: [mockProductId],
+        }),
+      ).toEqual(state);
     });
   });
 
@@ -74,7 +98,7 @@ describe('details redux reducer', () => {
         // @ts-expect-error
         const state = reducer(defaultErrorState, {
           type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
-          productIds: [10000, 20000, 30000],
+          payload: [10000, 20000, 30000],
         });
 
         // Full reset product details state requests are handled by the outer reducer
@@ -126,7 +150,7 @@ describe('details redux reducer', () => {
         // @ts-expect-error
         const state = reducer(defaultIsHydratedState, {
           type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
-          productIds: [10000, 20000, 30000],
+          payload: [10000, 20000, 30000],
         });
 
         // Full reset product details state requests are handled by the outer reducer
@@ -207,7 +231,7 @@ describe('details redux reducer', () => {
         // @ts-expect-error
         const state = reducer(defaultIsLoadingState, {
           type: productsActionTypes.RESET_PRODUCT_DETAILS_STATE,
-          productIds: [10000, 20000, 30000],
+          payload: [10000, 20000, 30000],
         });
 
         // Full reset product details state requests are handled by the outer reducer
@@ -257,6 +281,16 @@ describe('details redux reducer', () => {
             { type: productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES },
           ),
         ).toStrictEqual(expectedResult);
+
+        expect(
+          entitiesMapper[productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES](
+            state,
+            {
+              type: productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES,
+              payload: [],
+            },
+          ),
+        ).toStrictEqual(expectedResult);
       });
 
       it('should handle partial reset', () => {
@@ -277,7 +311,7 @@ describe('details redux reducer', () => {
             state,
             {
               type: productsActionTypes.RESET_PRODUCT_DETAILS_ENTITIES,
-              productIds: [10000, 20000, 30000],
+              payload: [10000, 20000, 30000],
             },
           ),
         ).toStrictEqual(expectedResult);

--- a/packages/redux/src/products/reducer/details.ts
+++ b/packages/redux/src/products/reducer/details.ts
@@ -33,34 +33,28 @@ const error = (state = INITIAL_STATE.error, action: AnyAction) => {
           action as FetchProductDetailsFailureAction
         ).payload.error,
       };
-    case actionTypes.RESET_PRODUCT_DETAILS_STATE: {
-      const productIds = (action as ResetProductDetailsStateAction).productIds;
-
-      if (!productIds?.length) {
-        return state;
-      }
-
-      return omit(state, productIds);
-    }
+    case actionTypes.RESET_PRODUCT_DETAILS_STATE:
+      return partialResetStateReducer(
+        state,
+        action as ResetProductDetailsStateAction,
+      );
     default:
       return state;
   }
 };
 
 const isHydrated = (state = INITIAL_STATE.isHydrated, action: AnyAction) => {
-  if (action.type === actionTypes.DEHYDRATE_PRODUCT_DETAILS) {
-    return {
-      ...state,
-      [(action as DehydrateProductDetailsAction).meta.productId]: false,
-    };
-  } else if (action.type === actionTypes.RESET_PRODUCT_DETAILS_STATE) {
-    const productIds = (action as ResetProductDetailsStateAction).productIds;
-
-    if (!productIds?.length) {
-      return state;
-    }
-
-    return omit(state, productIds);
+  switch (action.type) {
+    case actionTypes.DEHYDRATE_PRODUCT_DETAILS:
+      return {
+        ...state,
+        [(action as DehydrateProductDetailsAction).meta.productId]: false,
+      };
+    case actionTypes.RESET_PRODUCT_DETAILS_STATE:
+      return partialResetStateReducer(
+        state,
+        action as ResetProductDetailsStateAction,
+      );
   }
 
   return state;
@@ -80,13 +74,10 @@ const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
         [(action as FetchProductDetailsSuccessAction).meta.productId]: false,
       };
     case actionTypes.RESET_PRODUCT_DETAILS_STATE: {
-      const productIds = (action as ResetProductDetailsStateAction).productIds;
-
-      if (!productIds?.length) {
-        return state;
-      }
-
-      return omit(state, productIds);
+      return partialResetStateReducer(
+        state,
+        action as ResetProductDetailsStateAction,
+      );
     }
     default:
       return state;
@@ -102,10 +93,10 @@ export const entitiesMapper = {
       return state;
     }
 
-    const productIds = (action as ResetProductDetailsEntitiesAction).productIds;
+    const productIds = (action as ResetProductDetailsEntitiesAction).payload;
     const { products, ...rest } = state;
 
-    if (!productIds) {
+    if (!productIds?.length) {
       return rest;
     }
 
@@ -117,6 +108,19 @@ export const entitiesMapper = {
     };
   },
 };
+
+function partialResetStateReducer<T extends object | null | undefined>(
+  state: T,
+  action: ResetProductDetailsStateAction,
+): T {
+  const productIds = action.payload;
+
+  if (!productIds?.length) {
+    return state;
+  }
+
+  return omit(state, productIds) as T;
+}
 
 export const getError = (
   state: ProductsDetailsState,
@@ -148,7 +152,7 @@ const productsDetailsReducer: Reducer<ProductsDetailsState> = (
 ) => {
   if (
     action.type === actionTypes.RESET_PRODUCT_DETAILS_STATE &&
-    !(action as ResetProductDetailsStateAction).productIds?.length
+    !(action as ResetProductDetailsStateAction).payload?.length
   ) {
     return INITIAL_STATE;
   }

--- a/packages/redux/src/products/types/actions/productDetails.types.ts
+++ b/packages/redux/src/products/types/actions/productDetails.types.ts
@@ -44,7 +44,7 @@ export interface DehydrateProductDetailsAction extends Action {
  */
 export interface ResetProductDetailsStateAction extends Action {
   type: typeof actionTypes.RESET_PRODUCT_DETAILS_STATE;
-  productIds?: Array<ProductEntity['id']>;
+  payload: Array<ProductEntity['id']> | undefined;
 }
 
 /**
@@ -52,7 +52,7 @@ export interface ResetProductDetailsStateAction extends Action {
  */
 export interface ResetProductDetailsEntitiesAction extends Action {
   type: typeof actionTypes.RESET_PRODUCT_DETAILS_ENTITIES;
-  productIds?: Array<ProductEntity['id']>;
+  payload: Array<ProductEntity['id']> | undefined;
 }
 
 export type ResetProductDetailsAction =

--- a/packages/redux/src/products/types/actions/productsLists.types.ts
+++ b/packages/redux/src/products/types/actions/productsLists.types.ts
@@ -59,6 +59,7 @@ export interface SetProductsListHashAction extends Action {
  */
 export interface ResetProductsListsStateAction extends Action {
   type: typeof actionTypes.RESET_PRODUCTS_LISTS_STATE;
+  payload: Array<string> | undefined;
 }
 
 /**
@@ -66,6 +67,7 @@ export interface ResetProductsListsStateAction extends Action {
  */
 export interface ResetProductsListsEntitiesAction extends Action {
   type: typeof actionTypes.RESET_PRODUCTS_LISTS_ENTITIES;
+  payload: Array<string> | undefined;
 }
 
 export type ResetProductsListsAction =

--- a/tests/__fixtures__/products/productsLists.fixtures.ts
+++ b/tests/__fixtures__/products/productsLists.fixtures.ts
@@ -499,12 +499,16 @@ export const mockFacetGroups = [
   },
 ];
 
-export const mockFacetGroupsNormalized = mockFacetGroups.map(
-  (facet, index) => ({
+export const mockFacetGroupsNormalized = mockFacetGroups.map((facet, index) => {
+  const facets = mockFacets[index];
+  const values = facets ? [[facets.id]] : [[]];
+
+  return {
     ...facet,
-    values: [[mockFacets[index]?.id]],
-  }),
-);
+    values,
+  };
+});
+
 export const mockProductsList = {
   breadCrumbs: mockBreadCrumbs,
   name: null,
@@ -1070,6 +1074,7 @@ export const mockProductsListNormalizedPayload = {
     },
   },
 };
+
 export const mockProductsListModel = {
   slug: mockProductsListSlug,
   subfolder: 'us',
@@ -1110,51 +1115,53 @@ export const mockProductsListModel = {
 };
 
 export const mockProductsListEntity = {
-  [mockProductsListHash]: {
-    id: 123,
-    products: {
-      entries: [12913172, 12913174],
-      number: 1,
-      totalItems: 40,
-      totalPages: 2,
+  id: 123,
+  products: {
+    entries: [12913172, 12913174],
+    number: 1,
+    totalItems: 40,
+    totalPages: 2,
+  },
+  hash: mockProductsListHash,
+  breadCrumbs: [
+    {
+      text: 'Woman',
+      slug: 'woman',
+      link: 'shopping/woman',
+      parent: true,
     },
-    hash: mockProductsListHash,
-    breadCrumbs: [
-      {
-        text: 'Woman',
-        slug: 'woman',
-        link: 'shopping/woman',
-        parent: true,
-      },
-    ],
-    name: 'New arrivals',
-    facetGroups: mockFacetGroupsNormalized,
-    filterSegments: [
-      {
-        order: 0,
-        type: 6,
-        key: 'categories',
-        gender: 0,
-        value: 144307,
-        valueUpperBound: 0,
-        slug: 'women',
-        description: 'Women',
-        deep: 1,
-        parentId: 0,
-        fromQueryString: false,
-        negativeFilter: false,
-        facetId: 'categories_144307',
-      },
-    ],
-    config: mockProductsListResponse.config,
-    didYouMean: ['dress'],
-    searchTerm: null,
-    facetsBaseUrl: '/shopping',
-    _sorts: null,
-    _clearUrl: null,
-    _isClearHidden: false,
-    gender: GenderCode.Woman,
-    redirectInformation: null,
-    genderName: 'women',
-  } as ProductsListEntity,
+  ],
+  name: 'New arrivals',
+  facetGroups: mockFacetGroupsNormalized,
+  filterSegments: [
+    {
+      order: 0,
+      type: 6,
+      key: 'categories',
+      gender: 0,
+      value: 144307,
+      valueUpperBound: 0,
+      slug: 'women',
+      description: 'Women',
+      deep: 1,
+      parentId: 0,
+      fromQueryString: false,
+      negativeFilter: false,
+      facetId: 'categories_144307',
+    },
+  ],
+  config: mockProductsListResponse.config,
+  didYouMean: ['dress'],
+  searchTerm: null,
+  facetsBaseUrl: '/shopping',
+  _sorts: null,
+  _clearUrl: null,
+  _isClearHidden: false,
+  gender: GenderCode.Woman,
+  redirectInformation: null,
+  genderName: 'women',
+};
+
+export const mockProductsListsEntity: Record<string, ProductsListEntity> = {
+  [mockProductsListHash]: mockProductsListEntity,
 };


### PR DESCRIPTION
## Description

- This fixes the resetProductsLists action to include support for resetting only specific products lists instead of resetting all list states. This will fix the `useProductListing` hook reset action which will now only reset the state of the listing passed as its parameter.
- Small refactoring of the `details` reducer to reuse reset code between slices.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
