### PR TITLE
Feat add omnitracking scroll track event

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -14,6 +14,7 @@ import {
   getValParameterForEvent,
 } from './omnitracking-helper';
 import eventTypes from '../../types/eventTypes';
+import interactionTypes from '../../types/interactionTypes';
 import logger from '../../utils/logger';
 import pageTypes from '../../types/pageTypes';
 
@@ -555,6 +556,16 @@ export const trackEventsMapper = {
   }),
   [eventTypes.INTERACT_CONTENT]: data => {
     const properties = data.properties;
+
+    if (properties?.interactionType === interactionTypes.SCROLL) {
+      if (properties.target === document.body)
+        return {
+          tid: 668,
+          scrollDepth: properties.percentageScrolled,
+        };
+
+      return;
+    }
 
     if (!properties?.contentType || !properties?.interactionType) {
       logger.warn(


### PR DESCRIPTION
## Description

- Added interact content's scroll track support on omnitracking;
- Tests improvement of omnitracking interact content;

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

#504
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
