### PR TITLE
fix(react): fix GA4 page and event tracking

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/GA4.js
+++ b/packages/react/src/analytics/integrations/GA4/GA4.js
@@ -215,9 +215,13 @@ class GA4 extends integrations.Integration {
       case analyticsPageTypes.BAG:
       case analyticsPageTypes.SEARCH:
       case analyticsPageTypes.WISHLIST:
-        return await Promise.all([this.trackEvent(data), this.trackPage(data)]);
+        // Make sure the page view fires first, so the event being triggered after uses the correct page path (otherwise the event fires with the previous one).
+        await this.trackPage(data);
+        await this.trackEvent(data);
+
+        break;
       default:
-        return await this.trackPage(data);
+        await this.trackPage(data);
     }
   }
 

--- a/packages/react/src/analytics/integrations/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/__tests__/GA4.test.js
@@ -1095,14 +1095,14 @@ describe('GA4 Integration', () => {
             await ga4Instance.track(clonedEvent);
 
             // expect obtain fixed value
-            expect(ga4Spy.mock.calls[0][2].value).toEqual(10);
+            expect(ga4Spy.mock.calls[1][2].value).toEqual(10);
 
             delete clonedEvent.properties.value;
 
             await ga4Instance.track(clonedEvent);
 
             // expect obtain calculated value
-            expect(ga4Spy.mock.calls[2][2].value).toEqual(19);
+            expect(ga4Spy.mock.calls[3][2].value).toEqual(19);
           });
         });
 
@@ -1211,7 +1211,7 @@ describe('GA4 Integration', () => {
 
             await ga4Instance.track(data);
 
-            expect(ga4Spy.mock.calls[0]).toMatchSnapshot();
+            expect(ga4Spy.mock.calls).toMatchSnapshot();
           });
 
           it('should track search event search term instead of search query.', async () => {
@@ -1232,7 +1232,7 @@ describe('GA4 Integration', () => {
 
             await ga4Instance.track(data);
 
-            expect(ga4Spy.mock.calls[0]).toMatchSnapshot();
+            expect(ga4Spy.mock.calls).toMatchSnapshot();
           });
 
           it('should track search event search without search term but with search query instead.', async () => {
@@ -1253,7 +1253,7 @@ describe('GA4 Integration', () => {
 
             await ga4Instance.track(data);
 
-            expect(ga4Spy.mock.calls[0]).toMatchSnapshot();
+            expect(ga4Spy.mock.calls).toMatchSnapshot();
           });
         });
         describe('Navigation events', () => {

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
@@ -44,35 +44,59 @@ Array [
 
 exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Search events should not track search event with invalid search term or query, only page event. 1`] = `
 Array [
-  "config",
-  "GA-123456-12",
-  Object {
-    "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
-    "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
-    "path_clean": "/pt/",
-  },
+  Array [
+    "config",
+    "GA-123456-12",
+    Object {
+      "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
+    },
+  ],
 ]
 `;
 
 exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Search events should track search event search term instead of search query. 1`] = `
 Array [
-  "event",
-  "search",
-  Object {
-    "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
-    "search_term": "term",
-  },
+  Array [
+    "config",
+    "GA-123456-12",
+    Object {
+      "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
+    },
+  ],
+  Array [
+    "event",
+    "search",
+    Object {
+      "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "search_term": "term",
+    },
+  ],
 ]
 `;
 
 exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Search events should track search event search without search term but with search query instead. 1`] = `
 Array [
-  "event",
-  "search",
-  Object {
-    "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
-    "search_term": "query",
-  },
+  Array [
+    "config",
+    "GA-123456-12",
+    Object {
+      "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
+    },
+  ],
+  Array [
+    "event",
+    "search",
+    Object {
+      "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "search_term": "query",
+    },
+  ],
 ]
 `;
 
@@ -765,6 +789,15 @@ Array [
 exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Should map the bag event correctly 1`] = `
 Array [
   Array [
+    "config",
+    "GA-123456-12",
+    Object {
+      "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
+    },
+  ],
+  Array [
     "event",
     "view_cart",
     Object {
@@ -800,6 +833,11 @@ Array [
       "wishlist_name": undefined,
     },
   ],
+]
+`;
+
+exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Should map the search event correctly 1`] = `
+Array [
   Array [
     "config",
     "GA-123456-12",
@@ -809,11 +847,6 @@ Array [
       "path_clean": "/pt/",
     },
   ],
-]
-`;
-
-exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Should map the search event correctly 1`] = `
-Array [
   Array [
     "event",
     "search",
@@ -822,35 +855,26 @@ Array [
       "search_term": "shoes",
     },
   ],
-  Array [
-    "config",
-    "GA-123456-12",
-    Object {
-      "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
-      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
-      "path_clean": "/pt/",
-    },
-  ],
 ]
 `;
 
 exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Mappings Should map the wishlist event correctly 1`] = `
 Array [
   Array [
-    "event",
-    "view_wishlist",
-    Object {
-      "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
-      "wishlist_id": "d3618128-5aa9-4caa-a452-1dd1377a6190",
-    },
-  ],
-  Array [
     "config",
     "GA-123456-12",
     Object {
       "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
       "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
       "path_clean": "/pt/",
+    },
+  ],
+  Array [
+    "event",
+    "view_wishlist",
+    Object {
+      "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "wishlist_id": "d3618128-5aa9-4caa-a452-1dd1377a6190",
     },
   ],
 ]


### PR DESCRIPTION
## Description
This PR fixes a bug where a GA4 event was being triggered before a page view, which was causing an issue where the event was not being sent to GA with the correct page path. For this to happen, a page view must be registered on the dataLayer first, so the event being triggered after can be associated with the correct page_path.


<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
