### PR TITLE
feat(analytics): add omnitracking pre-calculated parameters

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
+++ b/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
@@ -48,6 +48,7 @@ import type {
 import type {
   OmnitrackingOptions,
   OmnitrackingPageEventParameters,
+  OmnitrackingPreCalculatedEventParameters,
   OmnitrackingRequestPayload,
   OmnitrackingTrackEventParameters,
   PageActionEvents,
@@ -158,13 +159,14 @@ class Omnitracking extends Integration<OmnitrackingOptions> {
    */
   getPrecalculatedParametersForEvent(
     data: EventData<TrackTypesValues>,
-  ): OmnitrackingTrackEventParameters | OmnitrackingPageEventParameters {
+  ): OmnitrackingPreCalculatedEventParameters {
     const isPageOrScreenEvent =
       isPageEventType(data) || isScreenEventType(data);
 
-    const precalculatedParameters:
-      | OmnitrackingTrackEventParameters
-      | OmnitrackingPageEventParameters = {};
+    const precalculatedParameters: OmnitrackingPreCalculatedEventParameters =
+      {};
+
+    const { culture, currencyCode } = data.context;
 
     // First we check if we need to change the values
     // of the uniqueViewId and previousUniqueViewId
@@ -214,7 +216,6 @@ class Omnitracking extends Integration<OmnitrackingOptions> {
         userTraits.hasOwnProperty('isGuest') && !userTraits.isGuest;
       precalculatedPageViewParameters.basketId = userTraits.bagId;
 
-      const { culture } = data.context;
       let clientLanguage: string | undefined = '';
       let clientCountry: string | undefined = '';
 
@@ -227,6 +228,7 @@ class Omnitracking extends Integration<OmnitrackingOptions> {
     }
 
     precalculatedParameters.uniqueViewId = this.currentUniqueViewId;
+    precalculatedParameters.viewCurrency = currencyCode;
 
     return precalculatedParameters;
   }

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -255,6 +255,24 @@ describe('Omnitracking', () => {
       });
     });
 
+    describe('currency', () => {
+      it('Should send the correct viewCurrency when a currency is passed', async () => {
+        const data = generateMockData();
+        // force a currencyCode context value
+        data.context.currencyCode = 'USD';
+
+        await omnitracking.track(data);
+
+        expect(postTrackingSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            parameters: expect.objectContaining({
+              viewCurrency: 'USD',
+            }),
+          }),
+        );
+      });
+    });
+
     it('Should return the formatted object for the `GenericPageVisited` event', async () => {
       const data = generateMockData();
 

--- a/packages/analytics/src/integrations/Omnitracking/types/Omnitracking.types.ts
+++ b/packages/analytics/src/integrations/Omnitracking/types/Omnitracking.types.ts
@@ -38,6 +38,10 @@ export type OmnitrackingTrackEventParameters = {
 export type OmnitrackingCommonEventParameters = {
   [K in typeof commonTrackAndPageParams[number]]?: unknown;
 };
+
+export type OmnitrackingPreCalculatedEventParameters =
+  OmnitrackingTrackEventParameters & OmnitrackingPageEventParameters;
+
 export interface OmnitrackingRequestPayload<
   T extends PageViewEvents | PageActionEvents,
 > {


### PR DESCRIPTION
## Description

- Added pre-calculated viewCurrency parameter to omnitracking.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
