### PR TITLE
chore(client): make query param optional on configuration clients

### DIFF
--- a/packages/client/src/settings/__tests__/getConfiguration.test.ts
+++ b/packages/client/src/settings/__tests__/getConfiguration.test.ts
@@ -51,7 +51,6 @@ describe('getConfiguration', () => {
       expectedConfig,
     );
   });
-
   it('should receive a client request error', async () => {
     mswServer.use(fixtures.failure());
 

--- a/packages/client/src/settings/types/getConfiguration.ts
+++ b/packages/client/src/settings/types/getConfiguration.ts
@@ -4,6 +4,6 @@ import type { ConfigurationQuery } from './configurationQuery';
 
 export type GetConfiguration = (
   code: Configuration['code'],
-  query: ConfigurationQuery,
+  query?: ConfigurationQuery,
   config?: Config,
 ) => Promise<Configuration>;

--- a/packages/client/src/settings/types/getConfigurations.ts
+++ b/packages/client/src/settings/types/getConfigurations.ts
@@ -3,6 +3,6 @@ import type { Configurations } from './configurations';
 import type { ConfigurationsQuery } from './configurationsQuery';
 
 export type GetConfigurations = (
-  query: ConfigurationsQuery,
+  query?: ConfigurationsQuery,
   config?: Config,
 ) => Promise<Configurations>;


### PR DESCRIPTION
## Description

- Add a default parameter and make the query parameter on `getConfiguration` and `getConfigurations` clients

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
