### PR TITLE
feat(analytics|react): add product details and listing pages to omnitracking

### DIFF
--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -18,6 +18,7 @@ import type {
   EventContextData,
   EventData,
   EventProperties,
+  ExtendedTrackTypes,
   IntegrationFactory,
   IntegrationOptions,
   IntegrationRuntimeData,
@@ -663,12 +664,7 @@ class Analytics {
    *
    * @returns Data for the event.
    */
-  protected async getEventData<
-    T extends
-      | TrackTypesValues
-      | typeof ON_SET_USER_TRACK_TYPE
-      | typeof LOAD_INTEGRATION_TRACK_TYPE,
-  >(
+  protected async getEventData<T extends ExtendedTrackTypes>(
     type: T,
     additionalData?: Partial<EventData<T>>,
     eventContext?: EventData<T>['context']['event'],

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -114,11 +114,11 @@ describe('Omnitracking', () => {
 
       expect(postTrackingSpy).toHaveBeenCalledWith({
         ...mockExpectedPagePayloadWeb,
-        parameters: {
+        parameters: expect.objectContaining({
           ...mockExpectedPagePayloadWeb.parameters,
           uniqueViewId: expect.any(String),
           previousUniqueViewId: null,
-        },
+        }),
       });
     });
 
@@ -719,9 +719,30 @@ describe('Omnitracking', () => {
               definitions.trackEventsMapper[
                 eventMapperKeyTemp
               ] as OmnitrackingTrackEventMapper
-            )(mockedTrackData),
+            )(trackEventsData[eventMapperKeyTemp]),
           ).toMatchSnapshot();
           expect(typeof definitions.trackEventsMapper[eventMapperKeyTemp]).toBe(
+            'function',
+          );
+        },
+      );
+
+      it.each(Object.keys(definitions.pageEventsMapper))(
+        '`%s` return should match the snapshot',
+        eventMapperKey => {
+          const eventMapperKeyTemp =
+            eventMapperKey as keyof typeof definitions.pageEventsMapper;
+
+          const mockedData = merge(
+            {},
+            mockedPageData,
+            pageEventsData[eventMapperKeyTemp],
+          );
+
+          expect(
+            definitions.pageEventsMapper[eventMapperKeyTemp](mockedData),
+          ).toMatchSnapshot();
+          expect(typeof definitions.pageEventsMapper[eventMapperKeyTemp]).toBe(
             'function',
           );
         },
@@ -765,12 +786,12 @@ describe('Omnitracking', () => {
         expect(postTrackingSpy).toHaveBeenCalledWith({
           ...mockExpectedPagePayloadWeb,
           event: mockEvent,
-          parameters: {
+          parameters: expect.objectContaining({
             ...mockExpectedPagePayloadWeb.parameters,
             promoCode: mockPromoCode,
             previousUniqueViewId: mocked_view_uid,
             uniqueViewId: expect.any(String),
-          },
+          }),
         });
       });
 
@@ -949,11 +970,11 @@ describe('Omnitracking', () => {
 
         expect(mockHttpClient).toHaveBeenCalledWith({
           ...mockExpectedPagePayloadWeb,
-          parameters: {
+          parameters: expect.objectContaining({
             ...mockExpectedPagePayloadWeb.parameters,
             uniqueViewId: expect.any(String),
             previousUniqueViewId: null,
-          },
+          }),
         });
         expect(postTrackingSpy).not.toHaveBeenCalled();
       });
@@ -1075,11 +1096,11 @@ describe('Omnitracking', () => {
 
       expect(postTrackingSpy).toHaveBeenCalledWith({
         ...mockExpectedPagePayloadMobile,
-        parameters: {
+        parameters: expect.objectContaining({
           ...mockExpectedPagePayloadMobile.parameters,
           previousUniqueViewId: null,
           uniqueViewId: expect.any(String),
-        },
+        }),
       });
     });
 
@@ -1092,11 +1113,11 @@ describe('Omnitracking', () => {
 
       expect(postTrackingSpy).toHaveBeenCalledWith({
         ...mockExpectedPagePayloadUnknown,
-        parameters: {
+        parameters: expect.objectContaining({
           ...mockExpectedPagePayloadUnknown.parameters,
           previousUniqueViewId: null,
           uniqueViewId: expect.any(String),
-        },
+        }),
       });
     });
   });

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -40,6 +40,13 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Product List Viewed\` return should match the snapshot 1`] = `
+Object {
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25},{\\"productId\\":\\"507f1f77bcf86cd799439012\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25}]",
+  "tid": 2832,
+}
+`;
+
 exports[`Omnitracking track events definitions \`Sign-up Form Viewed\` return should match the snapshot 1`] = `
 Object {
   "tid": 10097,
@@ -671,6 +678,22 @@ Object {
     "ProductDetail",
     "product",
   ],
+}
+`;
+
+exports[`Omnitracking track events definitions \`product-details\` return should match the snapshot 1`] = `
+Object {
+  "lineItems": "[{\\"productId\\":12122479,\\"itemPromotion\\":1,\\"designerName\\":\\"Saint Laurent\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":2,\\"sizeID\\":\\"20\\",\\"itemQuantity\\":13,\\"promoCode\\":\\"EASTER2022\\",\\"storeID\\":20000}]",
+  "viewSubType": "Product",
+  "viewType": "Product",
+}
+`;
+
+exports[`Omnitracking track events definitions \`product-listing\` return should match the snapshot 1`] = `
+Object {
+  "lineItems": "[{\\"productId\\":12345678,\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
+  "viewSubType": "Listing",
+  "viewType": "Listing",
 }
 `;
 

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -1,6 +1,7 @@
 import {
   generatePaymentAttemptReferenceId,
   getParameterValueFromEvent,
+  getProductLineItems,
   getValParameterForEvent,
 } from './omnitracking-helper';
 import eventTypes from '../../types/eventTypes';
@@ -483,7 +484,31 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
         };
     }
   },
+  [eventTypes.PRODUCT_LIST_VIEWED]: (data: EventData<TrackTypesValues>) => {
+    return {
+      tid: 2832,
+      lineItems: getProductLineItems(data),
+    };
+  },
 } as const;
+
+/**
+ * Interested events for page tracking.
+ * If there is a page event that can have specific rules or parameters,
+ * make sure to define it in this mapper.
+ */
+export const pageEventsMapper = {
+  [pageTypes.PRODUCT_DETAILS]: (data: EventData<TrackTypesValues>) => ({
+    viewType: 'Product',
+    viewSubType: 'Product',
+    lineItems: getProductLineItems(data),
+  }),
+  [pageTypes.PRODUCT_LISTING]: (data: EventData<TrackTypesValues>) => ({
+    viewType: 'Listing',
+    viewSubType: 'Listing',
+    lineItems: getProductLineItems(data),
+  }),
+};
 
 export const userGenderValuesMapper = {
   0: 'NotDefined',
@@ -493,4 +518,11 @@ export const userGenderValuesMapper = {
   NotDefined: 'NotDefined',
   Male: 'Male',
   Female: 'Female',
+} as const;
+
+export const viewGenderValuesMapper = {
+  Kids: 'Kids',
+  Men: 'Men',
+  Women: 'Women',
+  Undefined: 'Undefined',
 } as const;

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -157,7 +157,7 @@ function getSpecificWebParameters<T extends EventData<TrackTypesValues>>(
     {} as SpecificParametersForEventType<T>;
 
   if (isPageEventType(data)) {
-    const referrer = get(data, 'context.web.document.referrer', '');
+    const referrer = get(data, 'context.web.pageLocationReferrer', '');
     const location = get(data, 'context.web.window.location', {});
     const query = get(location, 'query', {});
     const internalRequest =
@@ -555,4 +555,62 @@ export const getCLientCountryFromCulture = (culture: string) => {
   const clientCountry = cultureSplit[1];
 
   return clientCountry;
+};
+
+/**
+ * Obtain product Id omnitracking parameter.
+ *
+ * @param data - The event tracking data.
+ *
+ * @returns The product id.
+ */
+export const getOmnitrackingProductId = (data: EventData<TrackTypesValues>) => {
+  return data?.properties?.productId || data?.properties?.id;
+};
+
+/**
+ * Transforms the products list payload into `lineItems` omnitracking parameter.
+ *
+ * @param data - The event tracking data.
+ *
+ * @returns The mapped `lineItems` in json format.
+ */
+export const getProductLineItems = (data: EventData<TrackTypesValues>) => {
+  const properties = data?.properties || {};
+  const productsList = properties.products;
+  const productId = getOmnitrackingProductId(data);
+
+  if (productsList && productsList.length) {
+    const mappedProductList = productsList.map(product => ({
+      productId: product.id,
+      itemPromotion: product.discountValue,
+      designerName: product.brand,
+      category: (product.category || '').split('/')[0],
+      itemFullPrice: product.priceWithoutDiscount,
+      sizeID: product.sizeId,
+      itemQuantity: product.quantity,
+      promoCode: product.coupon,
+      storeID: product.locationId,
+    }));
+
+    return JSON.stringify(mappedProductList);
+  }
+
+  if (productId) {
+    return JSON.stringify([
+      {
+        productId,
+        itemPromotion: properties.discountValue,
+        designerName: properties.brand,
+        category: ((properties?.category || '') as string).split('/')[0],
+        itemFullPrice: properties.priceWithoutDiscount,
+        sizeID: properties.sizeId,
+        itemQuantity: properties.quantity,
+        promoCode: properties.coupon,
+        storeID: properties.locationId,
+      },
+    ]);
+  }
+
+  return undefined;
 };

--- a/packages/analytics/src/types/analytics.types.ts
+++ b/packages/analytics/src/types/analytics.types.ts
@@ -84,6 +84,11 @@ export interface IntegrationFactory<T extends IntegrationOptions> {
   shouldLoad(consent: ConsentData | null | undefined): boolean;
 }
 
+export type ExtendedTrackTypes =
+  | TrackTypesValues
+  | typeof ON_SET_USER_TRACK_TYPE
+  | typeof LOAD_INTEGRATION_TRACK_TYPE;
+
 export type UserTraits = Omit<User, 'id'>;
 
 export type UserData = {

--- a/packages/react/src/analytics/__tests__/context.test.ts
+++ b/packages/react/src/analytics/__tests__/context.test.ts
@@ -15,6 +15,7 @@ describe('context', () => {
           title: document.title,
           referrer: document.referrer,
         },
+        pageLocationReferrer: window.location.href,
       },
     };
 

--- a/packages/react/src/analytics/context.ts
+++ b/packages/react/src/analytics/context.ts
@@ -12,19 +12,29 @@ export type WebContextType = {
       title: string;
       referrer: string;
     };
+    pageLocationReferrer: string | undefined;
   };
 };
 
+let lastLocation =
+  typeof document !== 'undefined' ? document.referrer : undefined;
+
 /**
- * Adds web environment information to the context.
+ * Returns the web context for the analytics package.
  *
  * @returns Context object for web applications.
  */
 export const context = (): WebContextType => {
+  const locationHref = window.location.href;
+
+  if (lastLocation !== locationHref) {
+    lastLocation = locationHref;
+  }
+
   return {
     web: {
       window: {
-        location: parse(window.location.href, true),
+        location: parse(locationHref, true),
         navigator: merge({}, window.navigator),
         screen: merge({}, window.screen),
       },
@@ -32,6 +42,10 @@ export const context = (): WebContextType => {
         title: document.title,
         referrer: document.referrer,
       },
+      // Since document.referrer stays the same on single page applications,
+      // we have this alternative that will hold the previous page location
+      // based on page track calls with `analyticsWeb.page()`.
+      pageLocationReferrer: lastLocation,
     },
   };
 };

--- a/tests/__fixtures__/analytics/baseAnalyticsEventData.fixtures.ts
+++ b/tests/__fixtures__/analytics/baseAnalyticsEventData.fixtures.ts
@@ -69,6 +69,7 @@ const fixtures = {
         title: 'Acme',
         referrer: 'https://example.com',
       },
+      pageLocationReferrer: 'https://example.com',
     },
   },
   timestamp: 1567010265879,

--- a/tests/__fixtures__/analytics/page/index.ts
+++ b/tests/__fixtures__/analytics/page/index.ts
@@ -1,6 +1,8 @@
 import { pageTypes, PageviewEventData } from '@farfetch/blackout-analytics';
 import bagPageData from './bagPageData.fixtures';
 import homepagePageData from './homepagePageData.fixtures';
+import listingPageData from './listingPageData.fixtures';
+import productPageData from './productPageData.fixtures';
 import searchPageData from './searchPageData.fixtures';
 import wishlistPageData from './wishlistPageData.fixtures';
 
@@ -8,11 +10,10 @@ export type DefaultPageFixturesResult = PageviewEventData & {
   event: string;
 };
 
+type pageEvents = keyof typeof pageTypes;
+
 export type PageFixtures = {
-  [pageTypes.HOMEPAGE]: DefaultPageFixturesResult;
-  [pageTypes.SEARCH]: DefaultPageFixturesResult;
-  [pageTypes.BAG]: DefaultPageFixturesResult;
-  [pageTypes.WISHLIST]: DefaultPageFixturesResult;
+  [event in typeof pageTypes[pageEvents]]?: DefaultPageFixturesResult;
 };
 
 const pageFixtures: PageFixtures = {
@@ -20,6 +21,8 @@ const pageFixtures: PageFixtures = {
   [pageTypes.SEARCH]: searchPageData,
   [pageTypes.BAG]: bagPageData,
   [pageTypes.WISHLIST]: wishlistPageData,
+  [pageTypes.PRODUCT_LISTING]: listingPageData,
+  [pageTypes.PRODUCT_DETAILS]: productPageData,
 };
 
 export default pageFixtures;

--- a/tests/__fixtures__/analytics/page/listingPageData.fixtures.ts
+++ b/tests/__fixtures__/analytics/page/listingPageData.fixtures.ts
@@ -1,0 +1,21 @@
+import { pageTypes } from '@farfetch/blackout-analytics';
+import basePageData from './basePageData.fixtures';
+
+const fixtures = {
+  ...basePageData,
+  event: pageTypes.PRODUCT_LISTING,
+  properties: {
+    products: [
+      {
+        id: 12345678,
+        discountValue: 1,
+        brand: 'designer name',
+        category: 'shoes',
+        priceWithoutDiscount: 1,
+        sizeId: 1,
+      },
+    ],
+  },
+};
+
+export default fixtures;

--- a/tests/__fixtures__/analytics/page/productPageData.fixtures.ts
+++ b/tests/__fixtures__/analytics/page/productPageData.fixtures.ts
@@ -1,0 +1,22 @@
+import { pageTypes } from '@farfetch/blackout-analytics';
+import basePageData from './basePageData.fixtures';
+
+const fixtures = {
+  ...basePageData,
+  event: pageTypes.PRODUCT_DETAILS,
+  properties: {
+    gender: 0,
+    brand: 'Saint Laurent',
+    category: 'Clothing/Pants/Slacks',
+    currency: 'USD',
+    discountValue: 1,
+    id: 12122479,
+    priceWithoutDiscount: 2,
+    quantity: 13,
+    sizeId: '20',
+    locationId: 20000,
+    coupon: 'EASTER2022',
+  },
+};
+
+export default fixtures;


### PR DESCRIPTION
## Description

- Add persist of navigation from parameter, by using from parameter on page events;
- Add Product Listing Page Event to omnitracking;
- Add Product Page Event to omnitracking;
- Since document.referrer stays the same on single page applications,
this PR adds an alternative property called `pageLocationReferrer`
for page trackings that will hold the previous URL when navigating trough
pages.
- This PR also adds the type of event that is being tracked to each `useContext`
function and calls the webContext directly on the analyticsWeb constructor.
Mapped the Omnitracking's `referrer` to the new `pageLocationReferrer`,
since the document.referrer was causing issues when analyzing user behavior.
- Adjust test to cover the above points.

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
