### PR TITLE
fix(analytics|react): fix omnitracking's clientLanguage and clientCountry parameters

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
+++ b/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
@@ -16,7 +16,6 @@
 import {
   formatPageEvent,
   formatTrackEvent,
-  getCLientCountryFromCulture,
   getClientLanguageFromCulture,
   getSearchQuery,
   getUniqueViewIdParameter,
@@ -233,14 +232,8 @@ class Omnitracking extends Integration<OmnitrackingOptions> {
         userTraits.hasOwnProperty('isGuest') && !userTraits.isGuest;
       precalculatedPageViewParameters.basketId = userTraits.bagId;
 
-      let clientLanguage: string | undefined = '';
-      let clientCountry: string | undefined = '';
-
-      clientLanguage = getClientLanguageFromCulture(culture as string);
-      clientCountry = getCLientCountryFromCulture(culture as string);
-
-      precalculatedPageViewParameters.clientLanguage = clientLanguage;
-      precalculatedPageViewParameters.clientCountry = clientCountry;
+      precalculatedParameters.clientLanguage =
+        getClientLanguageFromCulture(culture);
       precalculatedPageViewParameters.clientCulture = culture;
     }
 

--- a/packages/analytics/src/integrations/Omnitracking/__fixtures__/expectedPagePayloadMobile.fixtures.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__fixtures__/expectedPagePayloadMobile.fixtures.ts
@@ -21,7 +21,6 @@ const fixtures = {
     isLogged: true,
     clientCulture: pageMockData.context.culture,
     clientLanguage: pageMockData.context.culture?.split('-')[0],
-    clientCountry: pageMockData.context.culture?.split('-')[1],
     basketId: pageMockData.user.traits?.bagId,
     userGender:
       userGenderValuesMapper[

--- a/packages/analytics/src/integrations/Omnitracking/__fixtures__/expectedPagePayloadUnknown.fixtures.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__fixtures__/expectedPagePayloadUnknown.fixtures.ts
@@ -19,7 +19,6 @@ const fixtures = {
     isLogged: true,
     clientCulture: pageMockData.context.culture,
     clientLanguage: pageMockData.context.culture?.split('-')[0],
-    clientCountry: pageMockData.context.culture?.split('-')[1],
     basketId: pageMockData.user.traits?.bagId,
     userGender:
       userGenderValuesMapper[

--- a/packages/analytics/src/integrations/Omnitracking/__fixtures__/expectedPagePayloadWeb.fixtures.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__fixtures__/expectedPagePayloadWeb.fixtures.ts
@@ -39,7 +39,6 @@ const fixtures = {
     isLogged: true,
     clientCulture: pageMockData.context.culture,
     clientLanguage: pageMockData.context.culture?.split('-')[0],
-    clientCountry: pageMockData.context.culture?.split('-')[1],
     basketId: pageMockData.user.traits?.bagId,
     userGender:
       userGenderValuesMapper[

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -153,35 +153,6 @@ describe('Omnitracking', () => {
           }),
         );
       });
-
-      it('Should send the clientCountry when a culture is passed', async () => {
-        const data = generateMockData();
-
-        await omnitracking.track(data);
-
-        expect(postTrackingSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            parameters: expect.objectContaining({
-              clientCountry: 'US',
-            }),
-          }),
-        );
-      });
-
-      it('Should not send the clientCountry when no culture is passed', async () => {
-        const data = generateMockData();
-        data.context.culture = undefined;
-
-        await omnitracking.track(data);
-
-        expect(postTrackingSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            parameters: expect.objectContaining({
-              clientCountry: undefined,
-            }),
-          }),
-        );
-      });
     });
 
     describe('searchQuery', () => {

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -537,27 +537,13 @@ export const getSearchQuery = (
  *
  * @returns The clientLanguage to be sent on the event.
  */
-export const getClientLanguageFromCulture = (culture: string) => {
-  const cultureSplit = (culture || '').split('-');
+export const getClientLanguageFromCulture = (culture = '') => {
+  const cultureSplit = culture.split('-');
   const clientLanguage = cultureSplit[0];
 
   return CLIENT_LANGUAGES_LIST.includes(clientLanguage as string)
     ? clientLanguage
     : DEFAULT_CLIENT_LANGUAGE;
-};
-
-/**
- * Returns the client country from the culture code.
- *
- * @param culture - The current culture code.
- *
- * @returns The clientCountry to be sent on the event.
- */
-export const getCLientCountryFromCulture = (culture: string) => {
-  const cultureSplit = (culture || '').split('-');
-  const clientCountry = cultureSplit[1];
-
-  return clientCountry;
 };
 
 /**

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -98,8 +98,8 @@ Array [
     "GA-123456-12",
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
-      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
-      "path_clean": "/pt/",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -120,8 +120,8 @@ Array [
     "GA-123456-12",
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
-      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
-      "path_clean": "/pt/",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -142,8 +142,8 @@ Array [
     "GA-123456-12",
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
-      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
-      "path_clean": "/pt/",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -155,8 +155,8 @@ Array [
   "GA-123456-12",
   Object {
     "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
-    "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
-    "path_clean": "/pt/",
+    "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+    "path_clean": "/en-pt/",
   },
 ]
 `;

--- a/packages/react/src/analytics/integrations/Omnitracking/Omnitracking.ts
+++ b/packages/react/src/analytics/integrations/Omnitracking/Omnitracking.ts
@@ -22,9 +22,12 @@ import {
   LoadIntegrationEventData,
   OmnitrackingOptions,
   StrippedDownAnalytics,
+  trackTypes,
   TrackTypesValues,
   utils,
 } from '@farfetch/blackout-analytics';
+import { getCLientCountryFromSubfolder } from './omnitracking-web-helper';
+import get from 'lodash/get';
 import UniqueViewIdStorage from './storage/UniqueViewIdStorage';
 import UniqueViewIdStorageOptions from './storage/UniqueViewIdStorageOptions';
 
@@ -60,6 +63,35 @@ class Omnitracking extends integrations.Omnitracking {
     this.uniqueViewIdStorage.removeExpired();
 
     this.currentUniqueViewId = this.uniqueViewIdStorage.get(document.referrer);
+  }
+
+  /**
+   * Adds a specific web behaviour for the pre-calculated parameters.
+   *
+   * @param data - Event data provided by analytics.
+   *
+   * @returns Object containing the pre-calculated parameters for the event.
+   */
+  override getPrecalculatedParametersForEvent(
+    data: EventData<TrackTypesValues>,
+  ) {
+    const basePreCalculatedParameters =
+      super.getPrecalculatedParametersForEvent(data);
+
+    if (data.type === trackTypes.PAGE) {
+      if (basePreCalculatedParameters) {
+        const subfolder = get(
+          data,
+          'context.web.window.location.pathname',
+          '',
+        ).split('/')[1];
+
+        basePreCalculatedParameters['clientCountry'] =
+          getCLientCountryFromSubfolder(subfolder);
+      }
+    }
+
+    return basePreCalculatedParameters;
   }
 
   /**

--- a/packages/react/src/analytics/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/react/src/analytics/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -10,9 +10,9 @@ import {
   StrippedDownAnalytics,
 } from '@farfetch/blackout-analytics';
 import { postTracking } from '@farfetch/blackout-client';
-import Omnitracking from '../Omnitracking';
-import UniqueViewIdStorage from '../Omnitracking/storage/UniqueViewIdStorage';
-import UniqueViewIdStorageOptions from '../Omnitracking/storage/UniqueViewIdStorageOptions';
+import Omnitracking from '..';
+import UniqueViewIdStorage from '../storage/UniqueViewIdStorage';
+import UniqueViewIdStorageOptions from '../storage/UniqueViewIdStorageOptions';
 
 jest.mock('@farfetch/blackout-client', () => ({
   ...jest.requireActual('@farfetch/blackout-client'),
@@ -168,6 +168,50 @@ describe('Omnitracking', () => {
           expect.objectContaining({
             parameters: expect.objectContaining({
               previousUniqueViewId: mockUniqueViewId,
+            }),
+          }),
+        );
+      });
+
+      it('Should send the correct clientCountry when a subfolder has the {country-language} format', async () => {
+        const omnitrackingInstance = Omnitracking.createInstance(
+          {},
+          loadIntegrationData,
+          strippedDownAnalytics,
+        );
+        const data = analyticsPageData[pageTypes.HOMEPAGE];
+
+        // @ts-ignore
+        data.context.web.window.location.pathname = '/en-pt';
+
+        await omnitrackingInstance.track(data);
+
+        expect(postTracking).toHaveBeenCalledWith(
+          expect.objectContaining({
+            parameters: expect.objectContaining({
+              clientCountry: 'PT',
+            }),
+          }),
+        );
+      });
+
+      it('Should send the correct clientCountry when a subfolder has the {language} format', async () => {
+        const omnitrackingInstance = Omnitracking.createInstance(
+          {},
+          loadIntegrationData,
+          strippedDownAnalytics,
+        );
+        const data = analyticsPageData[pageTypes.HOMEPAGE];
+
+        // @ts-ignore
+        data.context.web.window.location.pathname = '/pt';
+
+        await omnitrackingInstance.track(data);
+
+        expect(postTracking).toHaveBeenCalledWith(
+          expect.objectContaining({
+            parameters: expect.objectContaining({
+              clientCountry: undefined,
             }),
           }),
         );

--- a/packages/react/src/analytics/integrations/Omnitracking/omnitracking-web-helper.ts
+++ b/packages/react/src/analytics/integrations/Omnitracking/omnitracking-web-helper.ts
@@ -1,0 +1,20 @@
+/**
+ * Returns the client country from the subfolder code.
+ *
+ * @param subfolder - The current subfolder code.
+ *
+ * @returns The clientCountry to be sent on the event.
+ */
+export const getCLientCountryFromSubfolder = (subfolder = '') => {
+  const subfolderHasLanguage = subfolder.includes('-');
+
+  // If the subfolder is only composed by country, return undefined.
+  if (!subfolderHasLanguage) {
+    return undefined;
+  }
+
+  const subfolderSplit = subfolder.split('-');
+  const clientCountry = subfolderSplit[1];
+
+  return clientCountry ? clientCountry.toUpperCase() : undefined;
+};

--- a/tests/__fixtures__/analytics/baseAnalyticsEventData.fixtures.ts
+++ b/tests/__fixtures__/analytics/baseAnalyticsEventData.fixtures.ts
@@ -45,7 +45,7 @@ const fixtures = {
             utm_content: 'utm_content',
             utm_campaign: 'utm_campaign',
           },
-          pathname: '/pt/',
+          pathname: '/en-pt/',
           auth: '',
           host: '127.0.0.1:3000',
           port: '3000',
@@ -53,7 +53,7 @@ const fixtures = {
           password: '',
           username: '',
           origin: 'http://127.0.0.1:3000',
-          href: 'http://127.0.0.1:3000/pt/',
+          href: 'http://127.0.0.1:3000/en-pt/',
         },
         navigator: {
           language: 'en-US',


### PR DESCRIPTION
## Description
- Moved the two parameters logic to the react facade as it should only be applied on the web.
- Also fixed the calculation itself. Instead of looking at the culture passed via analytics.useContext(), it will now look at the subfolder.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
