### PR TITLE
feat(analytics): add omnitracking's checkout abandoned event mappings

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -732,12 +732,18 @@ describe('Omnitracking', () => {
           const eventMapperKeyTemp =
             eventMapperKey as keyof typeof definitions.trackEventsMapper;
 
+          const mockedData = merge(
+            { event: eventMapperKeyTemp },
+            mockedTrackData,
+            trackEventsData[eventMapperKeyTemp],
+          );
+
           expect(
             (
               definitions.trackEventsMapper[
                 eventMapperKeyTemp
               ] as OmnitrackingTrackEventMapper
-            )(trackEventsData[eventMapperKeyTemp]),
+            )(mockedData),
           ).toMatchSnapshot();
           expect(typeof definitions.trackEventsMapper[eventMapperKeyTemp]).toBe(
             'function',

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Omnitracking track events definitions \`Checkout Abandoned\` return should match the snapshot 1`] = `
+Object {
+  "tid": 2084,
+}
+`;
+
 exports[`Omnitracking track events definitions \`Checkout Step Viewed\` return should match the snapshot 1`] = `
 Object {
   "tid": 10097,

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -500,12 +500,13 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
         };
     }
   },
-  [eventTypes.PRODUCT_LIST_VIEWED]: (data: EventData<TrackTypesValues>) => {
-    return {
-      tid: 2832,
-      lineItems: getProductLineItems(data),
-    };
-  },
+  [eventTypes.PRODUCT_LIST_VIEWED]: (data: EventData<TrackTypesValues>) => ({
+    tid: 2832,
+    lineItems: getProductLineItems(data),
+  }),
+  [eventTypes.CHECKOUT_ABANDONED]: () => ({
+    tid: 2084,
+  }),
 } as const;
 
 /**


### PR DESCRIPTION
## Description

 - Added omnitracking checkout abandoned event.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
