### PR TITLE
Feat add checkout order placed omnitracking next

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -403,6 +403,11 @@ describe('Omnitracking', () => {
 
         const data = generateTrackMockData({
           event: eventTypes.PLACE_ORDER_STARTED,
+          properties: {
+            coupon: 'promo',
+            shipping: 12,
+            orderId: 'ABC12',
+          },
         });
 
         await omnitracking.track(data);
@@ -428,6 +433,9 @@ describe('Omnitracking', () => {
               parameters: {
                 ...expectedPayload.parameters,
                 tid: placeOrderTid2,
+                promocode: 'promo',
+                shippingTotalValue: 12,
+                orderCode: 'ABC12',
               },
             },
           ],

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -26,6 +26,9 @@ Array [
     "val": "{\\"type\\":\\"TRANSACTION\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
   },
   Object {
+    "orderCode": "50314b8e9bcf000000000000",
+    "promocode": "ACME2019",
+    "shippingTotalValue": 3.6,
     "tid": 188,
     "val": "{\\"type\\":\\"TRANSACTION\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
   },

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
@@ -1,15 +1,20 @@
 import {
   generatePaymentAttemptReferenceId,
+  getCheckoutEventGenericProperties,
   getPageEventFromLocation,
   getPlatformSpecificParameters,
   getValParameterForEvent,
 } from '../omnitracking-helper';
+import { logger } from '../../../utils';
 import platformTypes from '../../../types/platformTypes';
 import trackTypes from '../../../types/trackTypes';
 import type {
   EventData,
   TrackTypesValues,
 } from '../../../types/analytics.types';
+
+logger.warn = jest.fn();
+const mockLoggerWarn = logger.warn;
 
 describe('getPageEventFromLocation', () => {
   it('should return null when location is not provided', () => {
@@ -51,5 +56,48 @@ describe('getPlatformSpecificParameters', () => {
     } as EventData<TrackTypesValues>;
 
     expect(getPlatformSpecificParameters(eventData)).toStrictEqual({});
+  });
+});
+
+describe('getCheckoutEventGenericProperties', () => {
+  it('should display some warn', () => {
+    const eventData = {
+      type: trackTypes.TRACK,
+      properties: { orderId: '123' } as Record<string, unknown>,
+    } as EventData<TrackTypesValues>;
+
+    getCheckoutEventGenericProperties(eventData);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'property orderId should be an alphanumeric value',
+      ),
+    );
+  });
+
+  it('should get orderCode without warn and without property orderId', () => {
+    const eventData = {
+      properties: {
+        orderId: '5H5QYB',
+        checkoutOrderId: '123',
+      } as Record<string, unknown>,
+    } as EventData<TrackTypesValues>;
+
+    expect(getCheckoutEventGenericProperties(eventData)).toEqual({
+      orderCode: '5H5QYB',
+    });
+  });
+
+  it('should get orderCode without warn and with property orderId', () => {
+    const eventData = {
+      properties: {
+        orderId: '5H5QYB',
+        checkoutOrderId: '123',
+      } as Record<string, unknown>,
+    } as EventData<TrackTypesValues>;
+
+    expect(getCheckoutEventGenericProperties(eventData, true)).toEqual({
+      orderCode: '5H5QYB',
+      orderId: '123',
+    });
   });
 });

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -1,5 +1,6 @@
 import {
   generatePaymentAttemptReferenceId,
+  getCheckoutEventGenericProperties,
   getParameterValueFromEvent,
   getProductLineItems,
   getValParameterForEvent,
@@ -434,6 +435,9 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
       {
         tid: 188,
         val,
+        ...getCheckoutEventGenericProperties(data),
+        promocode: data.properties?.coupon,
+        shippingTotalValue: data.properties?.shipping,
       },
     ];
   },

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_CLIENT_LANGUAGE,
   DEFAULT_SEARCH_QUERY_PARAMETERS,
 } from './constants';
-import { getCustomerIdFromUser } from '../../utils';
+import { getCustomerIdFromUser, logger } from '../../utils';
 import { isPageEventType, isScreenEventType } from '../../utils/typePredicates';
 import {
   pageActionEventTypes,
@@ -602,4 +602,37 @@ export const getProductLineItems = (data: EventData<TrackTypesValues>) => {
   }
 
   return undefined;
+};
+
+/**
+ * Obtain checkout generic omnitracking's properties.
+ *
+ * @param data - The event's data.
+ * @param addOrderId - If this property is true then add orderId to return.
+ * @returns The checkout omnitracking order data.
+ */
+export const getCheckoutEventGenericProperties = (
+  data: EventData<TrackTypesValues>,
+  addOrderId = false,
+) => {
+  const validOrderCode = isNaN(Number(data.properties?.orderId));
+
+  if (!validOrderCode) {
+    logger.warn(
+      `[Omnitracking] - Event ${data.event} property orderId should be an alphanumeric value.
+                        If you send the internal orderId, please use 'orderId' (e.g.: 5H5QYB) 
+                        and 'checkoutOrderId' (e.g.:123123123)`,
+    );
+  }
+
+  const orderCode = validOrderCode ? data.properties?.orderId : undefined;
+
+  return addOrderId
+    ? {
+        orderCode,
+        orderId: !validOrderCode
+          ? Number(data.properties?.orderId)
+          : data.properties?.checkoutOrderId,
+      }
+    : { orderCode };
 };


### PR DESCRIPTION
## Description

- Added place order started event mapping;
- Add mapper helper to deal with checkout orderId and orderCode;
- Fix tests;

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

#528 
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
