### PR TITLE
feat(analytics): add omnitracking's checkout started and checkout page view event mappings

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -6,6 +6,15 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Checkout Started\` return should match the snapshot 1`] = `
+Object {
+  "basketCurrency": "USD",
+  "basketValue": 24.64,
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1}]",
+  "tid": 2918,
+}
+`;
+
 exports[`Omnitracking track events definitions \`Checkout Step Viewed\` return should match the snapshot 1`] = `
 Object {
   "tid": 10097,
@@ -60,6 +69,16 @@ exports[`Omnitracking track events definitions \`Sign-up Form Viewed\` return sh
 Object {
   "tid": 10097,
   "val": "{\\"type\\":\\"REGISTER\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
+}
+`;
+
+exports[`Omnitracking track events definitions \`checkout\` return should match the snapshot 1`] = `
+Object {
+  "orderCode": "ASH12",
+  "orderValue": 100,
+  "shippingTotalValue": 10,
+  "viewSubType": "Checkout SPA",
+  "viewType": "Checkout SPA",
 }
 `;
 

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -441,6 +441,12 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
       },
     ];
   },
+  [eventTypes.CHECKOUT_STARTED]: data => ({
+    tid: 2918,
+    basketValue: data.properties.total,
+    basketCurrency: data.properties.currency,
+    lineItems: getProductLineItems(data),
+  }),
   [eventTypes.LOGOUT]: () => ({
     tid: 431,
   }),
@@ -528,6 +534,13 @@ export const pageEventsMapper = {
     viewType: 'Listing',
     viewSubType: 'Listing',
     lineItems: getProductLineItems(data),
+  }),
+  [pageTypes.CHECKOUT]: (data: EventData<TrackTypesValues>) => ({
+    ...getCheckoutEventGenericProperties(data),
+    viewType: 'Checkout SPA',
+    viewSubType: 'Checkout SPA',
+    orderValue: data.properties?.total,
+    shippingTotalValue: data.properties?.shipping,
   }),
 };
 

--- a/tests/__fixtures__/analytics/page/checkoutPageData.fixtures.ts
+++ b/tests/__fixtures__/analytics/page/checkoutPageData.fixtures.ts
@@ -1,0 +1,15 @@
+import { pageTypes } from '@farfetch/blackout-analytics';
+import basePageData from './basePageData.fixtures';
+
+const fixtures = {
+  ...basePageData,
+  event: pageTypes.CHECKOUT,
+  properties: {
+    total: 100,
+    shipping: 10,
+    checkoutOrderId: 12345678,
+    orderId: 'ASH12',
+  },
+};
+
+export default fixtures;

--- a/tests/__fixtures__/analytics/page/index.ts
+++ b/tests/__fixtures__/analytics/page/index.ts
@@ -1,5 +1,6 @@
 import { pageTypes, PageviewEventData } from '@farfetch/blackout-analytics';
 import bagPageData from './bagPageData.fixtures';
+import checkoutPageData from './checkoutPageData.fixtures';
 import homepagePageData from './homepagePageData.fixtures';
 import listingPageData from './listingPageData.fixtures';
 import productPageData from './productPageData.fixtures';
@@ -23,6 +24,7 @@ const pageFixtures: PageFixtures = {
   [pageTypes.WISHLIST]: wishlistPageData,
   [pageTypes.PRODUCT_LISTING]: listingPageData,
   [pageTypes.PRODUCT_DETAILS]: productPageData,
+  [pageTypes.CHECKOUT]: checkoutPageData,
 };
 
 export default pageFixtures;


### PR DESCRIPTION
## Description
This PR adds mappings for the checkout started event and the checkout page view event.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
