### PR TITLE
feat(analytics): add omnitracking's promocode mappings

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -56,6 +56,15 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Promocode Applied\` return should match the snapshot 1`] = `
+Object {
+  "errorMessage": "No promocode available.",
+  "hasError": true,
+  "promoCode": "ACME2019",
+  "tid": 311,
+}
+`;
+
 exports[`Omnitracking track events definitions \`Sign-up Form Viewed\` return should match the snapshot 1`] = `
 Object {
   "tid": 10097,

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -511,6 +511,12 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
   [eventTypes.CHECKOUT_ABANDONED]: () => ({
     tid: 2084,
   }),
+  [eventTypes.PROMOCODE_APPLIED]: (data: EventData<TrackTypesValues>) => ({
+    tid: 311,
+    promoCode: data.properties?.coupon,
+    hasError: !!data.properties?.errorMessage,
+    errorMessage: data.properties?.errorMessage,
+  }),
 } as const;
 
 /**

--- a/tests/__fixtures__/analytics/track/promocodeAppliedTrackData.fixtures.ts
+++ b/tests/__fixtures__/analytics/track/promocodeAppliedTrackData.fixtures.ts
@@ -10,6 +10,7 @@ const fixtures = {
     shipping: 3.6,
     tax: 2.04,
     coupon: 'ACME2019',
+    errorMessage: 'No promocode available.',
     shippingTier: 'Next Day',
     currency: 'USD',
   },


### PR DESCRIPTION
## Description

- Added promocode applied event mapping.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
