### PR TITLE
feat(analytics): add omnitracking's edit checkout step tracking mappings

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -15,6 +15,13 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Checkout Step Editing\` return should match the snapshot 1`] = `
+Object {
+  "checkoutStep": 1,
+  "tid": 2923,
+}
+`;
+
 exports[`Omnitracking track events definitions \`Checkout Step Viewed\` return should match the snapshot 1`] = `
 Object {
   "tid": 10097,

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -447,6 +447,10 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     basketCurrency: data.properties.currency,
     lineItems: getProductLineItems(data),
   }),
+  [eventTypes.CHECKOUT_STEP_EDITING]: data => ({
+    tid: 2923,
+    checkoutStep: data.properties.step,
+  }),
   [eventTypes.LOGOUT]: () => ({
     tid: 431,
   }),


### PR DESCRIPTION
## Description
Added edit checkout step event to omnitracking mapppers.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
