### PR TITLE
feat(analytics): remove percentage in scroll event

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/eventMapping.js
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.js
@@ -619,7 +619,7 @@ const getSignupNewsletterParametersFromEvent = eventProperties => {
  */
 const getScrollParametersFromEvent = eventProperties => {
   return {
-    percent_scrolled: `${eventProperties.percentageScrolled}%`,
+    percent_scrolled: eventProperties.percentageScrolled,
   };
 };
 

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
@@ -887,7 +887,7 @@ Array [
     "scroll",
     Object {
       "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
-      "percent_scrolled": "25%",
+      "percent_scrolled": 25,
     },
   ],
 ]


### PR DESCRIPTION
This PR remove percentage string in scroll event, sending only the numeric value of percentageScrolled.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
