### PR TITLE
feat(analytics): add omnitracking's share event mappings

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -81,6 +81,14 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Share\` return should match the snapshot 1`] = `
+Object {
+  "actionArea": "PDP",
+  "productId": "123456",
+  "tid": 1205,
+}
+`;
+
 exports[`Omnitracking track events definitions \`Sign-up Form Viewed\` return should match the snapshot 1`] = `
 Object {
   "tid": 10097,

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -1,6 +1,7 @@
 import {
   generatePaymentAttemptReferenceId,
   getCheckoutEventGenericProperties,
+  getOmnitrackingProductId,
   getParameterValueFromEvent,
   getProductLineItems,
   getValParameterForEvent,
@@ -526,6 +527,11 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     promoCode: data.properties?.coupon,
     hasError: !!data.properties?.errorMessage,
     errorMessage: data.properties?.errorMessage,
+  }),
+  [eventTypes.SHARE]: (data: EventData<TrackTypesValues>) => ({
+    tid: 1205,
+    actionArea: data.properties?.from,
+    productId: getOmnitrackingProductId(data),
   }),
 } as const;
 

--- a/tests/__fixtures__/analytics/track/shareTrackData.fixtures.ts
+++ b/tests/__fixtures__/analytics/track/shareTrackData.fixtures.ts
@@ -8,6 +8,7 @@ const fixtures = {
     method: 'Facebook',
     contentType: 'image',
     id: '123456',
+    from: 'PDP',
   },
 };
 


### PR DESCRIPTION


## Description

- Added share event to omnitracking;

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
