### PR TITLE
fix(core): split by merchant validation

### DIFF
--- a/packages/core/src/orders/client/helpers/adaptOrderDetails.js
+++ b/packages/core/src/orders/client/helpers/adaptOrderDetails.js
@@ -64,6 +64,8 @@ export const adaptOrderItemStatus = orderItemStatus => {
 
 export const adaptOrderStatus = orderStatus => {
   switch (orderStatus) {
+    case 'Created':
+      return 0;
     case 'CheckingStock':
       return 1;
     case 'ProcessingPayment':

--- a/packages/core/src/orders/client/postOrderItemActivities.js
+++ b/packages/core/src/orders/client/postOrderItemActivities.js
@@ -1,5 +1,4 @@
 import client, { adaptError } from '../../helpers/client';
-import join from 'proper-url-join';
 
 /**
  * @typedef {object} PostOrderItemActivityData
@@ -27,16 +26,11 @@ import join from 'proper-url-join';
 export default ({ orderId, itemId }, data, config) =>
   client
     .post(
-      join(
-        '/account/v1/orders',
-        orderId,
-        'items',
-        itemId,
-        'availableActivities',
-      ),
+      `/account/v1/orders/${orderId}/items/${itemId}/activities`,
       data,
       config,
     )
+
     .then(response => response.data)
     .catch(error => {
       throw adaptError(error);

--- a/packages/core/src/orders/redux/actions/__tests__/__snapshots__/doGetOrderDetails.test.js.snap
+++ b/packages/core/src/orders/redux/actions/__tests__/__snapshots__/doGetOrderDetails.test.js.snap
@@ -4,8 +4,8 @@ exports[`doGetOrderDetails() action creator should create the correct actions fo
 Object {
   "guest": false,
   "meta": Object {
-    "isSplitByMerchantOrderCode": true,
     "orderId": "3558DS",
+    "splitByMerchantOrderCode": false,
   },
   "payload": Object {
     "entities": Object {
@@ -675,8 +675,8 @@ exports[`doGetOrderDetails() action creator should create the correct actions fo
 Object {
   "guest": false,
   "meta": Object {
-    "isSplitByMerchantOrderCode": true,
     "orderId": "3558DS",
+    "splitByMerchantOrderCode": false,
   },
   "payload": Object {
     "entities": Object {

--- a/packages/core/src/orders/redux/actions/doPostOrderItemActivities.js
+++ b/packages/core/src/orders/redux/actions/doPostOrderItemActivities.js
@@ -36,11 +36,17 @@ export default postOrderItemActivities =>
     });
 
     try {
-      await postOrderItemActivities({ orderId, itemId }, data, config);
+      const result = await postOrderItemActivities(
+        { orderId, itemId },
+        data,
+        config,
+      );
 
       dispatch({
         type: POST_ORDER_ITEM_ACTIVITIES_SUCCESS,
       });
+
+      return result;
     } catch (error) {
       dispatch({
         payload: { error },


### PR DESCRIPTION
## Description

- Fixed split by merchant validation in getOrderDetails
- Added missing order status to adaptOrderStatus
- Fixed postOrderItemActivities action and client
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->
None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
