### PR TITLE
feat(analytics): add omnitracking's address info mappings

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Omnitracking track events definitions \`Address Info Added\` return should match the snapshot 1`] = `
+Object {
+  "checkoutStep": "1",
+  "deliveryInformationDetails": "{\\"courierType\\":\\"Standard/Standard\\"}",
+  "interactionType": "click",
+  "tid": 2911,
+}
+`;
+
 exports[`Omnitracking track events definitions \`Checkout Abandoned\` return should match the snapshot 1`] = `
 Object {
   "tid": 2084,

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
@@ -1,6 +1,7 @@
 import {
   generatePaymentAttemptReferenceId,
   getCheckoutEventGenericProperties,
+  getDeliveryInformationDetails,
   getPageEventFromLocation,
   getPlatformSpecificParameters,
   getProductLineItemsQuantity,
@@ -118,5 +119,21 @@ describe('getProductLineItemsQuantity', () => {
         },
       ]),
     ).toBe(10);
+  });
+});
+
+describe('getDeliveryInformationDetails', () => {
+  it('should deal with empty information', () => {
+    // @ts-expect-error
+    expect(getDeliveryInformationDetails({})).toEqual(undefined);
+  });
+  it('should deal with delivery type', () => {
+    expect(
+      getDeliveryInformationDetails({
+        properties: {
+          deliveryType: 'sample',
+        } as Record<string, unknown>,
+      } as EventData<TrackTypesValues>),
+    ).toEqual('{"courierType":"sample"}');
   });
 });

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -1,6 +1,7 @@
 import {
   generatePaymentAttemptReferenceId,
   getCheckoutEventGenericProperties,
+  getDeliveryInformationDetails,
   getOmnitrackingProductId,
   getParameterValueFromEvent,
   getProductLineItems,
@@ -422,6 +423,12 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
       type: 'SUBMIT',
       paymentAttemptReferenceId: generatePaymentAttemptReferenceId(data),
     }),
+  }),
+  [eventTypes.ADDRESS_INFO_ADDED]: data => ({
+    tid: 2911,
+    checkoutStep: data.properties?.step,
+    deliveryInformationDetails: getDeliveryInformationDetails(data),
+    interactionType: data.properties?.interactionType,
   }),
   [eventTypes.PLACE_ORDER_STARTED]: (data: EventData<TrackTypesValues>) => {
     const val = getValParameterForEvent({

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -653,3 +653,22 @@ export const getProductLineItemsQuantity = (
     0,
   );
 };
+
+/**
+ * Obtain Delivery Information Details using event properties data in JSON Format.
+ *
+ * @param data - The event's data.
+ *
+ * @returns - Delivery Information Details in Json Format.
+ */
+export const getDeliveryInformationDetails = (
+  data: EventData<TrackTypesValues>,
+) => {
+  if (data.properties?.deliveryType) {
+    return JSON.stringify({
+      courierType: data.properties.deliveryType,
+    });
+  }
+
+  return undefined;
+};

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -193,7 +193,7 @@ Array [
       "address_finder": undefined,
       "coupon": "ACME2019",
       "currency": "USD",
-      "delivery_type": undefined,
+      "delivery_type": "Standard/Standard",
       "packaging_type": undefined,
       "shipping_tier": "Next Day",
       "value": 24.64,

--- a/tests/__fixtures__/analytics/track/addressInfoAddedTrackData.fixtures.ts
+++ b/tests/__fixtures__/analytics/track/addressInfoAddedTrackData.fixtures.ts
@@ -12,6 +12,9 @@ const fixtures = {
     coupon: 'ACME2019',
     shippingTier: 'Next Day',
     currency: 'USD',
+    step: '1',
+    deliveryType: 'Standard/Standard',
+    interactionType: 'click',
   },
 };
 


### PR DESCRIPTION
## Description
Added address_info_added event mapping on omnitracking integration.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
