### PR TITLE
feat(analytics): add omnitracking's shipping and payment mappings

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -51,6 +51,16 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Payment Info Added\` return should match the snapshot 1`] = `
+Object {
+  "checkoutStep": undefined,
+  "deliveryInformationDetails": undefined,
+  "interactionType": undefined,
+  "selectedPaymentMethod": "credit card",
+  "tid": 2912,
+}
+`;
+
 exports[`Omnitracking track events definitions \`Place Order Started\` return should match the snapshot 1`] = `
 Array [
   Object {
@@ -102,6 +112,26 @@ Object {
   "actionArea": "PDP",
   "productId": "123456",
   "tid": 1205,
+}
+`;
+
+exports[`Omnitracking track events definitions \`Shipping Info Added\` return should match the snapshot 1`] = `
+Object {
+  "checkoutStep": "2",
+  "deliveryInformationDetails": "{\\"courierType\\":\\"Standard/Standard\\"}",
+  "interactionType": "click",
+  "selectedPaymentMethod": "credit",
+  "tid": 2914,
+}
+`;
+
+exports[`Omnitracking track events definitions \`Shipping Method Added\` return should match the snapshot 1`] = `
+Object {
+  "checkoutStep": "2",
+  "deliveryInformationDetails": "{\\"courierType\\":\\"Standard/Standard\\"}",
+  "interactionType": "click",
+  "selectedPaymentMethod": "credit",
+  "tid": 2913,
 }
 `;
 

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
@@ -1,6 +1,7 @@
 import {
   generatePaymentAttemptReferenceId,
   getCheckoutEventGenericProperties,
+  getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
   getPageEventFromLocation,
   getPlatformSpecificParameters,
@@ -135,5 +136,23 @@ describe('getDeliveryInformationDetails', () => {
         } as Record<string, unknown>,
       } as EventData<TrackTypesValues>),
     ).toEqual('{"courierType":"sample"}');
+  });
+});
+
+describe('getCommonCheckoutStepTrackingData', () => {
+  it('should obtain common checkout parameters', () => {
+    expect(
+      getCommonCheckoutStepTrackingData({
+        properties: {
+          step: 2,
+          deliveryType: 'sample',
+          interactionType: 'click',
+        } as Record<string, unknown>,
+      } as EventData<TrackTypesValues>),
+    ).toEqual({
+      checkoutStep: 2,
+      deliveryInformationDetails: '{"courierType":"sample"}',
+      interactionType: 'click',
+    });
   });
 });

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -1,6 +1,7 @@
 import {
   generatePaymentAttemptReferenceId,
   getCheckoutEventGenericProperties,
+  getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
   getOmnitrackingProductId,
   getParameterValueFromEvent,
@@ -459,6 +460,18 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
   [eventTypes.CHECKOUT_STEP_EDITING]: data => ({
     tid: 2923,
     checkoutStep: data.properties.step,
+  }),
+  [eventTypes.PAYMENT_INFO_ADDED]: data => ({
+    ...getCommonCheckoutStepTrackingData(data),
+    tid: 2912,
+  }),
+  [eventTypes.SHIPPING_INFO_ADDED]: data => ({
+    ...getCommonCheckoutStepTrackingData(data),
+    tid: 2914,
+  }),
+  [eventTypes.SHIPPING_METHOD_ADDED]: data => ({
+    ...getCommonCheckoutStepTrackingData(data),
+    tid: 2913,
   }),
   [eventTypes.LOGOUT]: () => ({
     tid: 431,

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -672,3 +672,19 @@ export const getDeliveryInformationDetails = (
 
   return undefined;
 };
+
+/**
+ * Obtain Common Checkout Details.
+ *
+ * @param data - The event's data.
+ *
+ * @returns - Omnitracking's common checkout parameters.
+ */
+export const getCommonCheckoutStepTrackingData = (
+  data: EventData<TrackTypesValues>,
+) => ({
+  checkoutStep: data.properties?.step,
+  deliveryInformationDetails: getDeliveryInformationDetails(data),
+  interactionType: data.properties?.interactionType,
+  selectedPaymentMethod: data.properties?.paymentType,
+});

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -793,7 +793,7 @@ Array [
       "address_finder": undefined,
       "coupon": "ACME2019",
       "currency": "USD",
-      "delivery_type": undefined,
+      "delivery_type": "Standard/Standard",
       "items": Array [
         Object {
           "affiliation": undefined,
@@ -834,7 +834,7 @@ Array [
       "address_finder": undefined,
       "coupon": "ACME2019",
       "currency": "USD",
-      "delivery_type": undefined,
+      "delivery_type": "Standard/Standard",
       "packaging_type": undefined,
       "shipping_tier": "Next Day",
       "value": 24.64,

--- a/tests/__fixtures__/analytics/track/shippingInfoAddedTrackData.fixtures.ts
+++ b/tests/__fixtures__/analytics/track/shippingInfoAddedTrackData.fixtures.ts
@@ -12,6 +12,10 @@ const fixtures = {
     coupon: 'ACME2019',
     shippingTier: 'Next Day',
     currency: 'USD',
+    step: '2',
+    deliveryType: 'Standard/Standard',
+    interactionType: 'click',
+    paymentType: 'credit',
     products: [
       {
         id: '507f1f77bcf86cd799439011',

--- a/tests/__fixtures__/analytics/track/shippingMethodAddedTrackData.fixtures.ts
+++ b/tests/__fixtures__/analytics/track/shippingMethodAddedTrackData.fixtures.ts
@@ -12,6 +12,10 @@ const fixtures = {
     coupon: 'ACME2019',
     shippingTier: 'Next Day',
     currency: 'USD',
+    step: '2',
+    deliveryType: 'Standard/Standard',
+    interactionType: 'click',
+    paymentType: 'credit',
   },
 };
 


### PR DESCRIPTION
## Description
This PR adds mappings for the following events:
- `Payment Info Added`
- `Shipping Info Added`
- `Shipping Method Added`
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
