### PR TITLE
feat(analytics|react): add omnitracking's order completed mappings

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -51,6 +51,13 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Order Completed\` return should match the snapshot 1`] = `
+Object {
+  "orderCode": "ABC12",
+  "tid": 2831,
+}
+`;
+
 exports[`Omnitracking track events definitions \`Payment Info Added\` return should match the snapshot 1`] = `
 Object {
   "checkoutStep": undefined,

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -473,6 +473,10 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     ...getCommonCheckoutStepTrackingData(data),
     tid: 2913,
   }),
+  [eventTypes.ORDER_COMPLETED]: data => ({
+    tid: 2831,
+    ...getCheckoutEventGenericProperties(data),
+  }),
   [eventTypes.LOGOUT]: () => ({
     tid: 431,
   }),

--- a/packages/react/src/analytics/integrations/GA/__tests__/__snapshots__/GA.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA/__tests__/__snapshots__/GA.test.ts.snap
@@ -84,7 +84,7 @@ Array [
     "purchase",
     Object {
       "coupon": "ACME2019",
-      "id": "50314b8e9bcf000000000000",
+      "id": "ABC12",
       "revenue": 24.64,
       "shipping": 3.6,
       "tax": 2.04,
@@ -95,7 +95,7 @@ Array [
     "event",
     "Ecommerce",
     "Order Completed",
-    "50314b8e9bcf000000000000",
+    "ABC12",
   ],
 ]
 `;

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -355,7 +355,7 @@ Array [
       ],
       "shipping": 3.6,
       "tax": 2.04,
-      "transaction_id": "50314b8e9bcf000000000000",
+      "transaction_id": "ABC12",
       "value": 24.64,
     },
   ],

--- a/packages/react/src/analytics/integrations/Zaraz/__tests__/__snapshots__/Zaraz.test.ts.snap
+++ b/packages/react/src/analytics/integrations/Zaraz/__tests__/__snapshots__/Zaraz.test.ts.snap
@@ -23,8 +23,8 @@ Array [
     "Order Completed",
     Object {
       "currency": "USD",
-      "name": "50314b8e9bcf000000000000",
-      "order_id": "50314b8e9bcf000000000000",
+      "name": "ABC12",
+      "order_id": "ABC12",
       "products": Array [
         Object {
           "product_id": "507f1f77bcf86cd799439011",

--- a/tests/__fixtures__/analytics/track/orderCompletedTrackData.fixtures.ts
+++ b/tests/__fixtures__/analytics/track/orderCompletedTrackData.fixtures.ts
@@ -5,7 +5,8 @@ const fixtures = {
   ...baseTrackData,
   event: eventTypes.ORDER_COMPLETED,
   properties: {
-    orderId: '50314b8e9bcf000000000000',
+    orderId: 'ABC12',
+    checkoutOrderId: 21312312,
     total: 24.64,
     shipping: 3.6,
     tax: 2.04,


### PR DESCRIPTION
## Description
- Added order completed event mapping to the omnitracking integration.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
