### PR TITLE
feat(analytics): add omnitracking's product clicked event mappings

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -81,6 +81,15 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Product Clicked\` return should match the snapshot 1`] = `
+Object {
+  "actionArea": "PLP",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1}]",
+  "productId": "507f1f77bcf86cd799439011",
+  "tid": 2926,
+}
+`;
+
 exports[`Omnitracking track events definitions \`Product List Viewed\` return should match the snapshot 1`] = `
 Object {
   "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25},{\\"productId\\":\\"507f1f77bcf86cd799439012\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25}]",

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -549,6 +549,12 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     tid: 2927,
     loginType: data.properties?.method,
   }),
+  [eventTypes.PRODUCT_CLICKED]: (data: EventData<TrackTypesValues>) => ({
+    tid: 2926,
+    actionArea: data.properties?.from,
+    productId: getOmnitrackingProductId(data),
+    lineItems: getProductLineItems(data),
+  }),
 } as const;
 
 /**


### PR DESCRIPTION

## Description

- Added add product clicked event mapping to omnitracking;

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
