### PR TITLE
feat(analytics): add omnitracking's select content events mappings

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -700,6 +700,70 @@ describe('Omnitracking', () => {
         },
       );
     });
+
+    describe('select content', () => {
+      const expectedErrorMessage =
+        'properties "contentType" and "id" should be sent';
+
+      it('should log error if a select content does not contain a contentType parameter', async () => {
+        const data = generateTrackMockData({
+          event: eventTypes.SELECT_CONTENT,
+          properties: {
+            id: 123,
+          },
+        });
+
+        delete data.properties.contentType;
+
+        await omnitracking.track(data);
+
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          expect.stringContaining(expectedErrorMessage),
+        );
+        expect(postTrackingSpy).not.toHaveBeenCalled();
+      });
+
+      it('should log error if a select content does not contain an id parameter', async () => {
+        const data = generateTrackMockData({
+          event: eventTypes.SELECT_CONTENT,
+          properties: {
+            contentType: 'foo',
+          },
+        });
+
+        delete data.properties.id;
+
+        await omnitracking.track(data);
+
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          expect.stringContaining(expectedErrorMessage),
+        );
+        expect(postTrackingSpy).not.toHaveBeenCalled();
+      });
+
+      it('should not log error if an select content has all required parameters', async () => {
+        const data = generateTrackMockData({
+          event: eventTypes.SELECT_CONTENT,
+          properties: {
+            contentType: 'foo',
+            id: 123,
+          },
+        });
+
+        // setting unique view id to pass on validation of missing page event before event track
+        omnitracking.currentUniqueViewId = mocked_view_uid;
+        await omnitracking.track(data);
+
+        expect(mockLoggerError).not.toHaveBeenCalled();
+        expect(postTrackingSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            parameters: expect.objectContaining({
+              tid: 2895,
+            }),
+          }),
+        );
+      });
+    });
   });
 
   describe('options', () => {

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -134,6 +134,16 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Select Content\` return should match the snapshot 1`] = `
+Object {
+  "contentType": "biz",
+  "interactionType": "click",
+  "productId": 12345,
+  "tid": 2895,
+  "val": 12312312,
+}
+`;
+
 exports[`Omnitracking track events definitions \`Share\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "PDP",

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
@@ -3,6 +3,7 @@ import {
   getCheckoutEventGenericProperties,
   getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
+  getOmnitrackingProductId,
   getPageEventFromLocation,
   getPlatformSpecificParameters,
   getProductLineItemsQuantity,
@@ -154,5 +155,40 @@ describe('getCommonCheckoutStepTrackingData', () => {
       deliveryInformationDetails: '{"courierType":"sample"}',
       interactionType: 'click',
     });
+  });
+});
+
+describe('getOmnitrackingProductId', () => {
+  it('should return product id over id', () => {
+    const data = {
+      properties: {
+        productId: 123,
+        id: 432,
+      } as Record<string, unknown>,
+    } as EventData<TrackTypesValues>;
+
+    expect(getOmnitrackingProductId(data)).toEqual(123);
+  });
+
+  it('should return id without product id', () => {
+    const data = {
+      properties: {
+        productId: undefined,
+        id: 432,
+      } as Record<string, unknown>,
+    } as EventData<TrackTypesValues>;
+
+    expect(getOmnitrackingProductId(data)).toEqual(432);
+  });
+
+  it('should return undefined instead of id property if method has been called with true on useOnlyProductIdField parameter', () => {
+    const data = {
+      properties: {
+        productId: undefined,
+        id: 432,
+      } as Record<string, unknown>,
+    } as EventData<TrackTypesValues>;
+
+    expect(getOmnitrackingProductId(data, true)).toEqual(undefined);
   });
 });

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -9,11 +9,15 @@ import {
   getProductLineItemsQuantity,
   getValParameterForEvent,
 } from './omnitracking-helper';
+import { logger } from '../../utils';
 import eventTypes from '../../types/eventTypes';
 import fromParameterTypes from '../../types/fromParameterTypes';
 import pageTypes from '../../types/pageTypes';
 import type { EventData, TrackTypesValues } from '../..';
-import type { OmnitrackingTrackEventsMapper } from './types/Omnitracking.types';
+import type {
+  OmnitrackingTrackEventParameters,
+  OmnitrackingTrackEventsMapper,
+} from './types/Omnitracking.types';
 
 export const PRODUCT_ID_PARAMETER = 'productId';
 export const PRODUCT_ID_PARAMETER_FROM_BAG_WISHLIST = 'id';
@@ -566,6 +570,26 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     priceCurrency: data.properties?.currency,
     lineItems: getProductLineItems(data),
   }),
+  [eventTypes.SELECT_CONTENT]: (data: EventData<TrackTypesValues>) => {
+    const properties = data.properties;
+
+    if (!properties?.contentType || !properties?.id) {
+      logger.error(
+        `[Omnitracking] - Event ${data.event} properties "contentType" and "id" should be sent 
+                        on the payload when triggering a "select content" event. If you want to track this 
+                        event, make sure to pass these two properties.`,
+      );
+      return undefined;
+    }
+
+    return {
+      tid: 2895,
+      contentType: properties?.contentType,
+      interactionType: properties?.interactionType,
+      val: properties?.id,
+      productId: getOmnitrackingProductId(data, true),
+    } as OmnitrackingTrackEventParameters;
+  },
 } as const;
 
 /**

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -551,11 +551,18 @@ export const getClientLanguageFromCulture = (culture = '') => {
  * Obtain product Id omnitracking parameter.
  *
  * @param data - The event tracking data.
+ * @param useOnlyProductIdField - Should be true when it's only to use productId field.
  *
  * @returns The product id.
  */
-export const getOmnitrackingProductId = (data: EventData<TrackTypesValues>) => {
-  return data?.properties?.productId || data?.properties?.id;
+export const getOmnitrackingProductId = (
+  data: EventData<TrackTypesValues>,
+  useOnlyProductIdField = false,
+) => {
+  return (
+    data?.properties?.productId ||
+    (useOnlyProductIdField ? undefined : data?.properties?.id)
+  );
 };
 
 /**

--- a/packages/analytics/src/integrations/Omnitracking/types/Omnitracking.types.ts
+++ b/packages/analytics/src/integrations/Omnitracking/types/Omnitracking.types.ts
@@ -61,7 +61,10 @@ export type OmnitrackingAllParameters = OmnitrackingTrackEventParameters &
 
 export type OmnitrackingTrackEventMapper = (
   data: EventData<TrackTypesValues>,
-) => OmnitrackingTrackEventParameters | OmnitrackingTrackEventParameters[];
+) =>
+  | OmnitrackingTrackEventParameters
+  | OmnitrackingTrackEventParameters[]
+  | undefined;
 
 export type OmnitrackingTrackEventsMapper = {
   [K in typeof eventTypes[keyof typeof eventTypes]]?: OmnitrackingTrackEventMapper;

--- a/tests/__fixtures__/analytics/track/selectContentTrackData.fixtures.ts
+++ b/tests/__fixtures__/analytics/track/selectContentTrackData.fixtures.ts
@@ -6,6 +6,8 @@ const fixtures = {
   event: eventTypes.SELECT_CONTENT,
   properties: {
     contentType: 'biz',
+    productId: 12345,
+    interactionType: 'click',
     id: 12312312,
   },
 };


### PR DESCRIPTION
## Description

- Added select content event mapping to omnitracking;

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
