### PR TITLE
fix(analytics): make use of omnitracking's page events mapper

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -34,7 +34,7 @@ import type {
 } from '../../../types/analytics.types';
 import type {
   OmnitrackingRequestPayload,
-  OmnitrackingTrackEventMapper,
+  OmnitrackingTrackOrPageEventMapper,
   PageActionEvents,
   PageViewEvents,
 } from '../types/Omnitracking.types';
@@ -721,7 +721,7 @@ describe('Omnitracking', () => {
             (
               definitions.trackEventsMapper[
                 eventMapperKeyTemp
-              ] as OmnitrackingTrackEventMapper
+              ] as OmnitrackingTrackOrPageEventMapper
             )(mockedData),
           ).toMatchSnapshot();
           expect(typeof definitions.trackEventsMapper[eventMapperKeyTemp]).toBe(
@@ -743,7 +743,7 @@ describe('Omnitracking', () => {
           );
 
           expect(
-            definitions.pageEventsMapper[eventMapperKeyTemp](mockedData),
+            definitions.pageEventsMapper[eventMapperKeyTemp]?.(mockedData),
           ).toMatchSnapshot();
           expect(typeof definitions.pageEventsMapper[eventMapperKeyTemp]).toBe(
             'function',

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -13,7 +13,10 @@ import eventTypes from '../../types/eventTypes';
 import fromParameterTypes from '../../types/fromParameterTypes';
 import pageTypes from '../../types/pageTypes';
 import type { EventData, TrackTypesValues } from '../..';
-import type { OmnitrackingTrackEventsMapper } from './types/Omnitracking.types';
+import type {
+  OmnitrackingPageEventsMapper,
+  OmnitrackingTrackEventsMapper,
+} from './types/Omnitracking.types';
 
 export const PRODUCT_ID_PARAMETER = 'productId';
 export const PRODUCT_ID_PARAMETER_FROM_BAG_WISHLIST = 'id';
@@ -579,7 +582,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
  * If there is a page event that can have specific rules or parameters,
  * make sure to define it in this mapper.
  */
-export const pageEventsMapper = {
+export const pageEventsMapper: Readonly<OmnitrackingPageEventsMapper> = {
   [pageTypes.PRODUCT_DETAILS]: (data: EventData<TrackTypesValues>) => ({
     viewType: 'Product',
     viewSubType: 'Product',

--- a/packages/analytics/src/integrations/Omnitracking/types/Omnitracking.types.ts
+++ b/packages/analytics/src/integrations/Omnitracking/types/Omnitracking.types.ts
@@ -14,6 +14,7 @@ import type {
   EventData,
   eventTypes,
   IntegrationOptions,
+  pageTypes,
   platformTypes,
   trackTypes,
   TrackTypesValues,
@@ -59,12 +60,28 @@ export type OmnitrackingAllParameters = OmnitrackingTrackEventParameters &
   OmnitrackingPageEventParameters &
   OmnitrackingCommonEventParameters;
 
-export type OmnitrackingTrackEventMapper = (
+export type OmnitrackingTrackOrPageMapperResult =
+  | OmnitrackingTrackEventParameters
+  | OmnitrackingTrackEventParameters[]
+  | OmnitrackingPageEventParameters
+  | OmnitrackingPageEventParameters[];
+
+export type OmnitrackingTrackOrPageEventMapper = (
   data: EventData<TrackTypesValues>,
-) => OmnitrackingTrackEventParameters | OmnitrackingTrackEventParameters[];
+) => OmnitrackingTrackOrPageMapperResult;
+
+export type OmnitrackingTrackMapperKey =
+  typeof eventTypes[keyof typeof eventTypes];
+
+export type OmnitrackingPageMapperKey =
+  typeof pageTypes[keyof typeof pageTypes];
 
 export type OmnitrackingTrackEventsMapper = {
-  [K in typeof eventTypes[keyof typeof eventTypes]]?: OmnitrackingTrackEventMapper;
+  [k in OmnitrackingTrackMapperKey]?: OmnitrackingTrackOrPageEventMapper;
+};
+
+export type OmnitrackingPageEventsMapper = {
+  [K in OmnitrackingPageMapperKey]?: OmnitrackingTrackOrPageEventMapper;
 };
 
 export type SearchQueryParameters = string[];


### PR DESCRIPTION
## Description
This PR fixes an issue where the page events mapper were just being called in unit tests and wasn't being used on the code itself. This brings a refactor that was done previously on the main branch.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
