### PR TITLE
feat(analytics|react): add omnitracking's signup newsletter events mappings

### DIFF
--- a/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
@@ -117,6 +117,12 @@ Object {
     "Mobile": "mobile",
     "Web": "web",
   },
+  "signupNewsletterGenderTypes": Object {
+    "0": "Woman",
+    "1": "Man",
+    "2": "Unisex",
+    "3": "Kids",
+  },
   "trackTypes": Object {
     "PAGE": "page",
     "SCREEN": "screen",

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -199,6 +199,13 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Sign-up Newsletter\` return should match the snapshot 1`] = `
+Object {
+  "gender": "Woman",
+  "tid": 2831,
+}
+`;
+
 exports[`Omnitracking track events definitions \`bag\` return should match the snapshot 1`] = `
 Object {
   "basketQuantity": 1,

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
@@ -3,6 +3,7 @@ import {
   getCheckoutEventGenericProperties,
   getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
+  getGenderValueFromProperties,
   getOmnitrackingProductId,
   getPageEventFromLocation,
   getPlatformSpecificParameters,
@@ -10,6 +11,7 @@ import {
   getValParameterForEvent,
 } from '../omnitracking-helper';
 import { logger } from '../../../utils';
+import { signupNewsletterGenderTypes } from '../../../types';
 import platformTypes from '../../../types/platformTypes';
 import trackTypes from '../../../types/trackTypes';
 import type {
@@ -190,5 +192,78 @@ describe('getOmnitrackingProductId', () => {
     } as EventData<TrackTypesValues>;
 
     expect(getOmnitrackingProductId(data, true)).toEqual(undefined);
+  });
+});
+describe('getGenderValueFromProperties', () => {
+  it(`should test all ways to return ${signupNewsletterGenderTypes[0]} value`, () => {
+    expect(
+      getGenderValueFromProperties({
+        properties: {
+          gender: 0,
+        } as Record<string, unknown>,
+      } as EventData<TrackTypesValues>),
+    ).toEqual(signupNewsletterGenderTypes[0]);
+
+    expect(
+      getGenderValueFromProperties({
+        properties: {
+          gender: '0',
+        } as Record<string, unknown>,
+      } as EventData<TrackTypesValues>),
+    ).toEqual(signupNewsletterGenderTypes[0]);
+
+    expect(
+      getGenderValueFromProperties({
+        properties: {
+          gender: { id: '0' },
+        } as Record<string, unknown>,
+      } as EventData<TrackTypesValues>),
+    ).toEqual(signupNewsletterGenderTypes[0]);
+  });
+
+  it(`should test all ways to return ${signupNewsletterGenderTypes[0]} and ${signupNewsletterGenderTypes[1]} value`, () => {
+    const expected = `${signupNewsletterGenderTypes[0]},${signupNewsletterGenderTypes[1]}`;
+
+    expect(
+      getGenderValueFromProperties({
+        properties: {
+          gender: [0, 1],
+        } as Record<string, unknown>,
+      } as EventData<TrackTypesValues>),
+    ).toEqual(expected);
+
+    expect(
+      getGenderValueFromProperties({
+        properties: {
+          gender: ['0', '1'],
+        } as Record<string, unknown>,
+      } as EventData<TrackTypesValues>),
+    ).toEqual(expected);
+
+    expect(
+      getGenderValueFromProperties({
+        properties: {
+          gender: [{ id: '0' }, { id: '1' }],
+        } as Record<string, unknown>,
+      } as EventData<TrackTypesValues>),
+    ).toEqual(expected);
+  });
+
+  it('should return custom value', () => {
+    expect(
+      getGenderValueFromProperties({
+        properties: {
+          gender: { name: 'W' },
+        } as Record<string, unknown>,
+      } as EventData<TrackTypesValues>),
+    ).toEqual('W');
+
+    expect(
+      getGenderValueFromProperties({
+        properties: {
+          gender: [{ name: 'W' }, { name: 'M' }],
+        } as Record<string, unknown>,
+      } as EventData<TrackTypesValues>),
+    ).toEqual('W,M');
   });
 });

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -3,6 +3,7 @@ import {
   getCheckoutEventGenericProperties,
   getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
+  getGenderValueFromProperties,
   getOmnitrackingProductId,
   getProductLineItems,
   getProductLineItemsQuantity,
@@ -481,6 +482,10 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
   }),
   [eventTypes.LOGOUT]: () => ({
     tid: 431,
+  }),
+  [eventTypes.SIGNUP_NEWSLETTER]: data => ({
+    tid: 2831,
+    gender: getGenderValueFromProperties(data),
   }),
   [eventTypes.PRODUCT_ADDED_TO_WISHLIST]: (
     data: EventData<TrackTypesValues>,

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -1,5 +1,13 @@
 import { ANALYTICS_UNIQUE_EVENT_ID } from '../../utils/constants';
 import {
+  AnalyticsProduct,
+  EventContext,
+  EventData,
+  signupNewsletterGenderTypes,
+  TrackTypesValues,
+  UserTraits,
+} from '../..';
+import {
   CLIENT_LANGUAGES_LIST,
   DEFAULT_CLIENT_LANGUAGE,
   DEFAULT_SEARCH_QUERY_PARAMETERS,
@@ -18,13 +26,6 @@ import { v4 as uuidV4 } from 'uuid';
 import get from 'lodash/get';
 import pick from 'lodash/pick';
 import platformTypes from '../../types/platformTypes';
-import type {
-  AnalyticsProduct,
-  EventContext,
-  EventData,
-  TrackTypesValues,
-  UserTraits,
-} from '../..';
 import type {
   OmnitrackingCommonEventParameters,
   OmnitrackingPageEventParameters,
@@ -695,3 +696,30 @@ export const getCommonCheckoutStepTrackingData = (
   interactionType: data.properties?.interactionType,
   selectedPaymentMethod: data.properties?.paymentType,
 });
+
+/**
+ * Obtain gender value from properties.
+ *
+ * @param data - The event's data.
+ *
+ * @returns Gender string.
+ */
+export const getGenderValueFromProperties = (
+  data: EventData<TrackTypesValues>,
+) => {
+  type GenderValues = keyof typeof signupNewsletterGenderTypes;
+  type GenderObject = { id: GenderValues; name?: string };
+
+  const genderArray: Array<string> = (
+    Array.isArray(data.properties?.gender)
+      ? data.properties?.gender
+      : [data.properties?.gender]
+  ).map((gender: GenderValues | GenderObject) => {
+    return (
+      (gender as GenderObject).name ||
+      signupNewsletterGenderTypes[(gender as GenderObject).id ?? gender]
+    );
+  });
+
+  return genderArray.reduce((acc, item) => `${acc},${item}`);
+};

--- a/packages/analytics/src/types/index.ts
+++ b/packages/analytics/src/types/index.ts
@@ -4,6 +4,7 @@ import interactionTypes from './interactionTypes';
 import loginMethodParameterTypes from './loginMethodParameterTypes';
 import pageTypes from './pageTypes';
 import platformTypes from './platformTypes';
+import signupNewsletterGenderTypes from './signupNewsletterGenderTypes';
 import trackTypes from './trackTypes';
 
 // Type modules
@@ -15,6 +16,7 @@ export {
   pageTypes,
   platformTypes,
   trackTypes,
+  signupNewsletterGenderTypes,
 };
 
 // Typescript types

--- a/packages/analytics/src/types/signupNewsletterGenderTypes.ts
+++ b/packages/analytics/src/types/signupNewsletterGenderTypes.ts
@@ -1,0 +1,8 @@
+const signupNewsletterGenderTypes = {
+  0: 'Woman',
+  1: 'Man',
+  2: 'Unisex',
+  3: 'Kids',
+};
+
+export default signupNewsletterGenderTypes;

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.ts
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.ts
@@ -652,7 +652,7 @@ const getSignupNewsletterParametersFromEvent = (
   const genderArray: Array<string> = (
     Array.isArray(eventProperties.gender)
       ? eventProperties.gender
-      : new Array(eventProperties.gender)
+      : [eventProperties?.gender]
   ).map((gender: GenderValues | GenderObject) => {
     return (
       (gender as GenderObject).name ||

--- a/packages/react/src/analytics/integrations/shared/dataMappings/index.ts
+++ b/packages/react/src/analytics/integrations/shared/dataMappings/index.ts
@@ -1,6 +1,3 @@
-export const SignupNewsletterGenderMappings = {
-  0: 'Woman',
-  1: 'Man',
-  2: 'Unisex',
-  3: 'Kids',
-};
+import { signupNewsletterGenderTypes } from '@farfetch/blackout-analytics';
+
+export const SignupNewsletterGenderMappings = signupNewsletterGenderTypes;


### PR DESCRIPTION
## Description

- Added signup newsletter event mapping to omnitracking;
- Fix problem related with gender on ga4 integration;

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
