### PR TITLE
fix(analytics): remove omnitracking's duplicated events

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -398,8 +398,7 @@ describe('Omnitracking', () => {
       });
 
       it('event is `Place Order Started`', async () => {
-        const placeOrderTid1 = 10097;
-        const placeOrderTid2 = 188;
+        const placeOrderTid = 188;
 
         const data = generateTrackMockData({
           event: eventTypes.PLACE_ORDER_STARTED,
@@ -416,83 +415,14 @@ describe('Omnitracking', () => {
           ...mockExpectedTrackPayload,
           parameters: {
             ...mockExpectedTrackPayload.parameters,
-            tid: placeOrderTid1,
-            val: JSON.stringify({
-              type: 'TRANSACTION',
-              paymentAttemptReferenceId: `${loadIntegrationData.user.localId}_${mockedTrackData.timestamp}`,
-            }),
+            orderCode: 'ABC12',
+            promocode: 'promo',
+            shippingTotalValue: 12,
+            tid: placeOrderTid,
           },
         };
 
-        expect(postTrackingSpy).toHaveBeenCalledTimes(2);
-        expect(postTrackingSpy.mock.calls).toEqual([
-          [expectedPayload],
-          [
-            {
-              ...expectedPayload,
-              parameters: {
-                ...expectedPayload.parameters,
-                tid: placeOrderTid2,
-                promocode: 'promo',
-                shippingTotalValue: 12,
-                orderCode: 'ABC12',
-              },
-            },
-          ],
-        ]);
-      });
-
-      it('event is `Sign-up Form Viewed`', async () => {
-        const tid = 10097;
-
-        const data = generateTrackMockData({
-          event: eventTypes.SIGNUP_FORM_VIEWED,
-        });
-
-        const correlationId = loadIntegrationData.user.localId;
-        const paymentAttemptReferenceId = `${correlationId}_${mockedTrackData.timestamp}`;
-
-        await omnitracking.track(data);
-
-        const expectedPayload = {
-          ...mockExpectedTrackPayload,
-          parameters: {
-            ...mockExpectedTrackPayload.parameters,
-            tid,
-            val: JSON.stringify({
-              type: 'REGISTER',
-              paymentAttemptReferenceId,
-            }),
-          },
-        };
-
-        expect(clients.postTracking).toHaveBeenCalledWith(expectedPayload);
-      });
-
-      it('event is `Checkout Step Viewed`', async () => {
-        const tid = 10097;
-
-        const data = generateTrackMockData({
-          event: eventTypes.CHECKOUT_STEP_VIEWED,
-        });
-
-        const correlationId = loadIntegrationData.user.localId;
-        const paymentAttemptReferenceId = `${correlationId}_${mockedTrackData.timestamp}`;
-
-        await omnitracking.track(data);
-
-        const expectedPayload = {
-          ...mockExpectedTrackPayload,
-          parameters: {
-            ...mockExpectedTrackPayload.parameters,
-            tid,
-            val: JSON.stringify({
-              type: 'SUBMIT',
-              paymentAttemptReferenceId,
-            }),
-          },
-        };
-
+        expect(postTrackingSpy).toHaveBeenCalledTimes(1);
         expect(postTrackingSpy).toHaveBeenCalledWith(expectedPayload);
       });
 

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -31,13 +31,6 @@ Object {
 }
 `;
 
-exports[`Omnitracking track events definitions \`Checkout Step Viewed\` return should match the snapshot 1`] = `
-Object {
-  "tid": 10097,
-  "val": "{\\"type\\":\\"SUBMIT\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
-}
-`;
-
 exports[`Omnitracking track events definitions \`Login\` return should match the snapshot 1`] = `
 Object {
   "loginType": "Acme",
@@ -69,19 +62,12 @@ Object {
 `;
 
 exports[`Omnitracking track events definitions \`Place Order Started\` return should match the snapshot 1`] = `
-Array [
-  Object {
-    "tid": 10097,
-    "val": "{\\"type\\":\\"TRANSACTION\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
-  },
-  Object {
-    "orderCode": "50314b8e9bcf000000000000",
-    "promocode": "ACME2019",
-    "shippingTotalValue": 3.6,
-    "tid": 188,
-    "val": "{\\"type\\":\\"TRANSACTION\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
-  },
-]
+Object {
+  "orderCode": "50314b8e9bcf000000000000",
+  "promocode": "ACME2019",
+  "shippingTotalValue": 3.6,
+  "tid": 188,
+}
 `;
 
 exports[`Omnitracking track events definitions \`Product Added to Cart\` return should match the snapshot 1`] = `
@@ -155,13 +141,6 @@ exports[`Omnitracking track events definitions \`Sign-up Form Completed\` return
 Object {
   "loginType": "Acme",
   "tid": 2927,
-}
-`;
-
-exports[`Omnitracking track events definitions \`Sign-up Form Viewed\` return should match the snapshot 1`] = `
-Object {
-  "tid": 10097,
-  "val": "{\\"type\\":\\"REGISTER\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
 }
 `;
 

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -1,5 +1,4 @@
 import {
-  generatePaymentAttemptReferenceId,
   getCheckoutEventGenericProperties,
   getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
@@ -7,7 +6,6 @@ import {
   getParameterValueFromEvent,
   getProductLineItems,
   getProductLineItemsQuantity,
-  getValParameterForEvent,
 } from './omnitracking-helper';
 import eventTypes from '../../types/eventTypes';
 import fromParameterTypes from '../../types/fromParameterTypes';
@@ -414,20 +412,6 @@ export const pageEventsFilter: {
  * specific parameter, if applicable.
  */
 export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
-  [eventTypes.SIGNUP_FORM_VIEWED]: (data: EventData<TrackTypesValues>) => ({
-    tid: 10097,
-    val: getValParameterForEvent({
-      type: 'REGISTER',
-      paymentAttemptReferenceId: generatePaymentAttemptReferenceId(data),
-    }),
-  }),
-  [eventTypes.CHECKOUT_STEP_VIEWED]: (data: EventData<TrackTypesValues>) => ({
-    tid: 10097,
-    val: getValParameterForEvent({
-      type: 'SUBMIT',
-      paymentAttemptReferenceId: generatePaymentAttemptReferenceId(data),
-    }),
-  }),
   [eventTypes.ADDRESS_INFO_ADDED]: data => ({
     tid: 2911,
     checkoutStep: data.properties?.step,
@@ -435,24 +419,12 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     interactionType: data.properties?.interactionType,
   }),
   [eventTypes.PLACE_ORDER_STARTED]: (data: EventData<TrackTypesValues>) => {
-    const val = getValParameterForEvent({
-      type: 'TRANSACTION',
-      paymentAttemptReferenceId: generatePaymentAttemptReferenceId(data),
-    });
-
-    return [
-      {
-        tid: 10097,
-        val,
-      },
-      {
-        tid: 188,
-        val,
-        ...getCheckoutEventGenericProperties(data),
-        promocode: data.properties?.coupon,
-        shippingTotalValue: data.properties?.shipping,
-      },
-    ];
+    return {
+      tid: 188,
+      ...getCheckoutEventGenericProperties(data),
+      promocode: data.properties?.coupon,
+      shippingTotalValue: data.properties?.shipping,
+    };
   },
   [eventTypes.CHECKOUT_STARTED]: data => ({
     tid: 2918,


### PR DESCRIPTION
## Description
Removed events that are now properly handled by the Vitorino script to avoid having them duplicated.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
