### PR TITLE
fix(analytics|react): fix checkout steps mapping for GA4 and omnitracking parity

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Omnitracking track events definitions \`Address Info Added\` return should match the snapshot 1`] = `
 Object {
   "checkoutStep": "1",
-  "deliveryInformationDetails": "{\\"courierType\\":\\"Standard/Standard\\"}",
+  "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\"}",
   "interactionType": "click",
   "tid": 2911,
 }
@@ -120,7 +120,7 @@ Object {
 exports[`Omnitracking track events definitions \`Shipping Info Added\` return should match the snapshot 1`] = `
 Object {
   "checkoutStep": "2",
-  "deliveryInformationDetails": "{\\"courierType\\":\\"Standard/Standard\\"}",
+  "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\"}",
   "interactionType": "click",
   "selectedPaymentMethod": "credit",
   "tid": 2914,
@@ -130,7 +130,7 @@ Object {
 exports[`Omnitracking track events definitions \`Shipping Method Added\` return should match the snapshot 1`] = `
 Object {
   "checkoutStep": "2",
-  "deliveryInformationDetails": "{\\"courierType\\":\\"Standard/Standard\\"}",
+  "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\"}",
   "interactionType": "click",
   "selectedPaymentMethod": "credit",
   "tid": 2913,

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
@@ -135,6 +135,16 @@ describe('getDeliveryInformationDetails', () => {
           deliveryType: 'sample',
         } as Record<string, unknown>,
       } as EventData<TrackTypesValues>),
+    ).toEqual('{"deliveryType":"sample"}');
+  });
+
+  it('should deal with shipping tier', () => {
+    expect(
+      getDeliveryInformationDetails({
+        properties: {
+          shippingTier: 'sample',
+        } as Record<string, unknown>,
+      } as EventData<TrackTypesValues>),
     ).toEqual('{"courierType":"sample"}');
   });
 });
@@ -145,13 +155,15 @@ describe('getCommonCheckoutStepTrackingData', () => {
       getCommonCheckoutStepTrackingData({
         properties: {
           step: 2,
-          deliveryType: 'sample',
+          deliveryType: 'sample_delivery',
+          shippingTier: 'sample_shipping',
           interactionType: 'click',
         } as Record<string, unknown>,
       } as EventData<TrackTypesValues>),
     ).toEqual({
       checkoutStep: 2,
-      deliveryInformationDetails: '{"courierType":"sample"}',
+      deliveryInformationDetails:
+        '{"deliveryType":"sample_delivery","courierType":"sample_shipping"}',
       interactionType: 'click',
     });
   });

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -664,9 +664,10 @@ export const getProductLineItemsQuantity = (
 export const getDeliveryInformationDetails = (
   data: EventData<TrackTypesValues>,
 ) => {
-  if (data.properties?.deliveryType) {
+  if (data.properties?.deliveryType || data.properties?.shippingTier) {
     return JSON.stringify({
-      courierType: data.properties.deliveryType,
+      deliveryType: data.properties.deliveryType,
+      courierType: data.properties.shippingTier,
     });
   }
 


### PR DESCRIPTION
## Description
This PR fixes a bug in the omnitracking and GA4 parity for the checkout steps events.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
