### PR TITLE
feat(analytics|react): add omnitracking's interact content events mappings next

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -100,6 +100,16 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Interact Content\` return should match the snapshot 1`] = `
+Object {
+  "actionArea": "dummy",
+  "contentType": "biz",
+  "interactionType": "Click",
+  "tid": 2882,
+  "val": "507f1f77bcf86cd799439011",
+}
+`;
+
 exports[`Omnitracking track events definitions \`Login\` return should match the snapshot 1`] = `
 Object {
   "loginType": "Acme",

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -579,6 +579,15 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     tid: 2917,
     filtersApplied: data.properties?.filters,
   }),
+  [eventTypes.INTERACT_CONTENT]: (data: EventData<TrackTypesValues>) => {
+    return {
+      tid: 2882,
+      contentType: data.properties?.contentType,
+      interactionType: data.properties?.interactionType,
+      val: data.properties?.id,
+      actionArea: data.properties?.state,
+    } as OmnitrackingTrackEventParameters;
+  },
 } as const;
 
 /**

--- a/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.ts
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.ts
@@ -1467,6 +1467,7 @@ describe('GA4 Integration', () => {
                 some_other_property: 12312312,
                 interaction_type: interactionTypes.CLICK,
                 __blackoutAnalyticsEventId: expect.any(String),
+                state: 'dummy',
               });
             });
           });

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -303,6 +303,7 @@ Array [
       "content_type": "biz",
       "interaction_type": "Click",
       "some_other_property": 12312312,
+      "state": "dummy",
     },
   ],
 ]

--- a/tests/__fixtures__/analytics/track/interactContentTrackData.fixtures.ts
+++ b/tests/__fixtures__/analytics/track/interactContentTrackData.fixtures.ts
@@ -8,6 +8,7 @@ const fixtures = {
     interactionType: interactionTypes.CLICK,
     contentType: 'biz',
     someOtherProperty: 12312312,
+    state: 'dummy',
   },
 };
 


### PR DESCRIPTION
## Description

- Added interact content event mapping to omnitracking next;

### Dependencies

None.

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
