### PR TITLE
feat(react|redux): add getProductDenormalized selector

### DIFF
--- a/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
@@ -17,10 +17,12 @@ import {
   mockStateWithUnavailableStock,
 } from 'tests/__fixtures__/bags';
 import {
+  mockBrandId,
   mockMerchantId,
   mockProductId,
   mockSizeScaleId,
 } from 'tests/__fixtures__/products/ids.fixtures';
+import { mockCategoryId } from 'tests/__fixtures__/categories';
 import { withStore } from '../../../../tests/helpers';
 import useBag from '../useBag';
 
@@ -77,26 +79,45 @@ describe('useBag', () => {
         items: [
           {
             ...mockState.entities?.bagItems?.[mockBagItemId],
-            product:
-              mockState.entities?.products?.[
+            product: {
+              ...mockState.entities?.products?.[
                 mockState.entities?.bagItems?.[mockBagItemId]?.product
               ],
+              brand: mockState.entities?.brands?.[mockBrandId],
+              categories: [mockState.entities.categories[mockCategoryId]],
+            },
           },
           {
             ...mockState.entities?.bagItems?.[101],
-            product: mockState.entities?.products?.[11766695],
+            product: {
+              ...mockState.entities?.products?.[11766695],
+              brand: mockState.entities?.brands?.[mockBrandId],
+              categories: [mockState.entities.categories[mockCategoryId]],
+            },
           },
           {
             ...mockState.entities?.bagItems?.[102],
-            product: mockState.entities?.products?.[1002],
+            product: {
+              ...mockState.entities?.products?.[1002],
+              brand: mockState.entities?.brands?.[mockBrandId],
+              categories: [mockState.entities.categories[mockCategoryId]],
+            },
           },
           {
             ...mockState.entities?.bagItems?.[103],
-            product: mockState.entities?.products?.[11766695],
+            product: {
+              ...mockState.entities?.products?.[11766695],
+              brand: mockState.entities?.brands?.[mockBrandId],
+              categories: [mockState.entities.categories[mockCategoryId]],
+            },
           },
           {
             ...mockState.entities?.bagItems?.[104],
-            product: mockState.entities?.products?.[11766695],
+            product: {
+              ...mockState.entities?.products?.[11766695],
+              brand: mockState.entities?.brands?.[mockBrandId],
+              categories: [mockState.entities.categories[mockCategoryId]],
+            },
           },
         ],
         hadUnavailableItems: false,

--- a/packages/react/src/bags/hooks/types/useBag.ts
+++ b/packages/react/src/bags/hooks/types/useBag.ts
@@ -2,7 +2,7 @@ import type {
   BagItemActionMetadata,
   BagItemHydrated,
   CustomAttributesAdapted,
-  ProductEntity,
+  ProductEntityDenormalized,
   SizeAdapted,
 } from '@farfetch/blackout-redux';
 import type { Config, GetBagQuery } from '@farfetch/blackout-client';
@@ -18,7 +18,7 @@ export type HandleAddOrUpdateItem = (
   }: {
     customAttributes?: CustomAttributesAdapted | string;
     from?: string;
-    product: ProductEntity;
+    product: ProductEntityDenormalized;
     productAggregatorId?: Exclude<
       BagItemHydrated['productAggregator'],
       null

--- a/packages/react/src/bags/hooks/useBag.ts
+++ b/packages/react/src/bags/hooks/useBag.ts
@@ -11,7 +11,7 @@ import {
   getBag,
   getBagError,
   getBagItems,
-  getProduct,
+  getProductDenormalized,
   isBagFetched,
   isBagLoading,
   removeBagItem as removeBagItemAction,
@@ -162,7 +162,7 @@ const useBag = (options: UseBagOptions = {}) => {
       metadata?: BagItemActionMetadata,
     ) => {
       const state = getState();
-      const product = getProduct(state, productId);
+      const product = getProductDenormalized(state, productId);
 
       if (!product) {
         throw new ProductError();

--- a/packages/react/src/products/hooks/__tests__/useProductDetails.test.tsx
+++ b/packages/react/src/products/hooks/__tests__/useProductDetails.test.tsx
@@ -33,6 +33,21 @@ describe('useProductDetails', () => {
         ...mockProduct,
         isOneSize: false,
         isOutOfStock: false,
+        brand: {
+          description: null,
+          id: 6326412,
+          name: 'Balenciaga',
+          priceType: 0,
+          slug: 'balenciaga',
+        },
+        categories: [
+          {
+            id: 135981,
+            name: 'Trousers',
+            parentId: 135967,
+            gender: 'Woman',
+          },
+        ],
       },
       actions: {
         reset: expect.any(Function),

--- a/packages/react/src/products/hooks/__tests__/useProductListing.test.tsx
+++ b/packages/react/src/products/hooks/__tests__/useProductListing.test.tsx
@@ -5,6 +5,7 @@ import {
   resetProductsLists,
 } from '@farfetch/blackout-redux';
 import { mockBrandResponse } from 'tests/__fixtures__/brands';
+import { mockCategory } from 'tests/__fixtures__/categories';
 import {
   mockProductsListHash,
   mockProductsListHashWithoutParameters,
@@ -27,9 +28,13 @@ jest.mock('@farfetch/blackout-redux', () => ({
 
 const slug = getSlug(mockProductsListPathname);
 
-const expectedProductsWithBrand = Object.values(
+const expectedProductsDenormalized = Object.values(
   mockProductsListNormalizedPayload.entities.products,
-).map(product => ({ ...product, brand: mockBrandResponse }));
+).map(product => ({
+  ...product,
+  brand: mockBrandResponse,
+  categories: [mockCategory],
+}));
 
 describe('useProductListing', () => {
   beforeEach(jest.clearAllMocks);
@@ -65,7 +70,7 @@ describe('useProductListing', () => {
       isLoading: false,
       data: {
         ...mockList,
-        items: expectedProductsWithBrand,
+        items: expectedProductsDenormalized,
         hash: mockProductsListHashWithoutParameters,
         pagination: {
           number: mockList.products.number,
@@ -203,7 +208,7 @@ describe('useProductListing', () => {
         data: {
           ...mockList,
           hash: mockProductsListHash,
-          items: expectedProductsWithBrand,
+          items: expectedProductsDenormalized,
           pagination: {
             number: mockList.products.number,
             pageSize: mockList.config.pageSize,

--- a/packages/react/src/products/hooks/__tests__/useRecentlyViewedProducts.test.tsx
+++ b/packages/react/src/products/hooks/__tests__/useRecentlyViewedProducts.test.tsx
@@ -4,6 +4,7 @@ import {
   saveRecentlyViewedProduct,
 } from '@farfetch/blackout-redux';
 import { mockBrandResponse } from 'tests/__fixtures__/brands';
+import { mockCategory } from 'tests/__fixtures__/categories';
 import {
   mockProductId,
   mockProductsListHashWithProductIds,
@@ -24,9 +25,13 @@ jest.mock('@farfetch/blackout-redux', () => ({
   fetchProductSet: jest.fn(() => () => Promise.resolve()),
 }));
 
-const expectedProductsWithBrand = Object.values(
+const expectedProductsDenormalized = Object.values(
   mockProductsListNormalizedPayload.entities.products,
-).map(product => ({ ...product, brand: mockBrandResponse }));
+).map(product => ({
+  ...product,
+  brand: mockBrandResponse,
+  categories: [mockCategory],
+}));
 
 describe('useRecentlyViewedProducts', () => {
   beforeEach(jest.clearAllMocks);
@@ -76,7 +81,7 @@ describe('useRecentlyViewedProducts', () => {
         number: 1,
         totalPages: 1,
         totalItems: 2,
-        products: expectedProductsWithBrand,
+        products: expectedProductsDenormalized,
       },
       actions: {
         fetch: expect.any(Function),

--- a/packages/react/src/products/hooks/useProductDetails.ts
+++ b/packages/react/src/products/hooks/useProductDetails.ts
@@ -1,6 +1,6 @@
 import {
   fetchProductDetails,
-  getProduct,
+  getProductDenormalized,
   getProductError,
   isProductFetched,
   isProductLoading,
@@ -42,7 +42,7 @@ const useProductDetails = (
     isProductFetched(state, productId),
   );
   const product = useSelector((state: StoreState) =>
-    getProduct(state, productId),
+    getProductDenormalized(state, productId),
   );
   const isOutOfStock = useSelector((state: StoreState) =>
     isProductOutOfStock(state, productId),

--- a/packages/react/src/wishlists/hooks/__tests__/useWishlist.test.tsx
+++ b/packages/react/src/wishlists/hooks/__tests__/useWishlist.test.tsx
@@ -66,15 +66,22 @@ describe('useWishlist', () => {
         items: [
           {
             ...stateMockData.entities?.wishlistItems?.[mockWishlistItemId],
-            product:
-              stateMockData.entities?.products?.[
+            product: {
+              ...stateMockData.entities?.products?.[
                 stateMockData.entities?.wishlistItems?.[mockWishlistItemId]
                   ?.product
               ],
+              brand: stateMockData.entities?.brands?.[2450],
+              categories: [stateMockData.entities?.categories?.[136301]],
+            },
           },
           {
             ...stateMockData.entities?.wishlistItems?.[102],
-            product: stateMockData.entities?.products?.[1002],
+            product: {
+              ...stateMockData.entities?.products?.[1002],
+              brand: stateMockData.entities?.brands?.[2450],
+              categories: [stateMockData.entities?.categories?.[136301]],
+            },
           },
         ],
         id: mockWishlistId,

--- a/packages/react/src/wishlists/hooks/__tests__/useWishlistItem.test.tsx
+++ b/packages/react/src/wishlists/hooks/__tests__/useWishlistItem.test.tsx
@@ -38,11 +38,14 @@ describe('useWishlistItem', () => {
       },
       data: {
         ...mockWishlistState.entities?.wishlistItems?.[mockWishlistItemId],
-        product:
-          mockWishlistState.entities?.products?.[
+        product: {
+          ...mockWishlistState.entities?.products?.[
             mockWishlistState.entities?.wishlistItems?.[mockWishlistItemId]
               ?.product
           ],
+          brand: mockWishlistState.entities?.brands?.[2450],
+          categories: [mockWishlistState.entities?.categories?.[136301]],
+        },
       },
     });
   });

--- a/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
@@ -886,6 +886,7 @@ Object {
   "getProductAttributes": [Function],
   "getProductAttributesError": [Function],
   "getProductBreadcrumbs": [Function],
+  "getProductDenormalized": [Function],
   "getProductError": [Function],
   "getProductFittings": [Function],
   "getProductFittingsError": [Function],

--- a/packages/redux/src/analytics/middlewares/bag.ts
+++ b/packages/redux/src/analytics/middlewares/bag.ts
@@ -1,14 +1,13 @@
 import { bagsActionTypes, getBagItem } from '../../bags';
 import {
   calculatePriceDiscount,
-  getBrand,
   getCategory,
   getCurrency,
   getSize,
   getSizeFullInformation,
   getVariant,
 } from './helpers';
-import { getProduct } from '../../products';
+import { getProductDenormalized } from '../../products';
 import Analytics, { eventTypes, utils } from '@farfetch/blackout-analytics';
 import get from 'lodash/get';
 import isNil from 'lodash/isNil';
@@ -142,11 +141,11 @@ const getProductData = async (
   // Now we can safely retrieve the correct bag item data from the store.
   const bagItem = getBagItem(state, bagItemId);
   const id = productIdMeta || get(bagItem, 'product.id'); // If no productId property exists on the action meta, use the id on the bagItem if available
-  const product = getProduct(state, id);
+  const product = getProductDenormalized(state, id);
   const { sku, shortDescription, name: productName } = product || {};
   const name = shortDescription || productName;
-  const category = getCategory(state, product);
-  const brand = getBrand(state, product);
+  const category = getCategory(product);
+  const brand = product?.brand?.name;
   const variant = getVariant(product);
   const priceWithDiscount =
     get(bagItem, 'price.includingTaxes') || // price might be defined only on bagItem on a hard-refresh of the bag page

--- a/packages/redux/src/analytics/middlewares/helpers.ts
+++ b/packages/redux/src/analytics/middlewares/helpers.ts
@@ -1,24 +1,24 @@
 import { getBrand as getBrandSelector } from '../../brands';
-import { getCategory as getCategorySelector } from '../../categories';
 import Analytics, { utils } from '@farfetch/blackout-analytics';
 import get from 'lodash/get';
-import type { ProductEntity } from '../../entities/types';
+import type {
+  ProductEntity,
+  ProductEntityDenormalized,
+} from '../../entities/types';
 import type { StoreState } from '../../types';
 
 /**
  * Returns the different product categories separated with a `/`.
  *
- * @param state   - The current application state.
  * @param product - The product object.
  *
  * @returns String with all category names joined with a '/' character.
  */
 export const getCategory = (
-  state: StoreState,
-  product: ProductEntity | undefined,
+  product: ProductEntityDenormalized | undefined,
 ): string =>
   get(product, 'categories', [])
-    .map(id => get(getCategorySelector(state, id), 'name'))
+    .map(category => category.name)
     .join('/');
 
 /**
@@ -50,7 +50,7 @@ export const getBrand = (
  * @returns The product variant.
  */
 export const getVariant = (
-  product: ProductEntity | undefined,
+  product: ProductEntity | ProductEntityDenormalized | undefined,
 ): string | undefined => {
   const mainVariant = get(product, 'colors', []).find(color =>
     get(color, 'tags', []).some(tag => tag === 'DesignerColor'),
@@ -68,7 +68,7 @@ export const getVariant = (
  * @returns The size name.
  */
 export const getSize = (
-  product: ProductEntity | undefined,
+  product: ProductEntity | ProductEntityDenormalized | undefined,
   sizeId: number,
 ): string | undefined =>
   get(
@@ -88,7 +88,7 @@ export const getSize = (
  * @returns The size information.
  */
 export const getSizeFullInformation = (
-  product: ProductEntity | undefined,
+  product: ProductEntity | ProductEntityDenormalized | undefined,
   sizeId: number,
 ) => get(product, 'sizes', []).find(size => get(size, 'id') === sizeId);
 

--- a/packages/redux/src/analytics/middlewares/wishlist.ts
+++ b/packages/redux/src/analytics/middlewares/wishlist.ts
@@ -1,6 +1,5 @@
 import {
   calculatePriceDiscount,
-  getBrand,
   getCategory,
   getCurrency,
   getSizeFullInformation,
@@ -159,8 +158,8 @@ const getProductData = async (
   return {
     id: get(product, 'id'),
     name: get(product, 'name')?.trim(),
-    brand: getBrand(state, product),
-    category: getCategory(state, product),
+    brand: product?.brand?.name,
+    category: getCategory(product),
     discountValue: discount,
     price: priceWithDiscount,
     priceWithoutDiscount,

--- a/packages/redux/src/bags/__tests__/selectors.test.ts
+++ b/packages/redux/src/bags/__tests__/selectors.test.ts
@@ -8,10 +8,13 @@ import {
   mockState,
 } from 'tests/__fixtures__/bags';
 import {
+  mockBrandId,
   mockProductEntity,
+  mockProductEntityDenormalized,
   mockProductId,
   mockProductTypeToExclude,
 } from 'tests/__fixtures__/products';
+import { mockCategoryId } from 'tests/__fixtures__/categories';
 import { toBlackoutError } from '@farfetch/blackout-client';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -87,7 +90,7 @@ describe('bags redux selectors', () => {
   describe('getBagItem()', () => {
     const expectedResult = {
       ...mockBagItemEntity,
-      product: mockProductEntity,
+      product: mockProductEntityDenormalized,
     };
 
     it('should return all data regarding a bag item', () => {
@@ -113,23 +116,43 @@ describe('bags redux selectors', () => {
       const expectedResult = [
         {
           ...mockState.entities.bagItems[mockBagItemId],
-          product: mockState.entities.products[mockProductId],
+          product: {
+            ...mockState.entities.products[mockProductId],
+            brand: mockState.entities.brands[mockBrandId],
+            categories: [mockState.entities.categories[mockCategoryId]],
+          },
         },
         {
           ...mockState.entities.bagItems[101],
-          product: mockState.entities.products[mockProductId],
+          product: {
+            ...mockState.entities.products[mockProductId],
+            brand: mockState.entities.brands[mockBrandId],
+            categories: [mockState.entities.categories[mockCategoryId]],
+          },
         },
         {
           ...mockState.entities.bagItems[102],
-          product: mockState.entities.products[1002],
+          product: {
+            ...mockState.entities.products[1002],
+            brand: mockState.entities.brands[mockBrandId],
+            categories: [mockState.entities.categories[mockCategoryId]],
+          },
         },
         {
           ...mockState.entities.bagItems[103],
-          product: mockState.entities.products[mockProductId],
+          product: {
+            ...mockState.entities.products[mockProductId],
+            brand: mockState.entities.brands[mockBrandId],
+            categories: [mockState.entities.categories[mockCategoryId]],
+          },
         },
         {
           ...mockState.entities.bagItems[104],
-          product: mockState.entities.products[mockProductId],
+          product: {
+            ...mockState.entities.products[mockProductId],
+            brand: mockState.entities.brands[mockBrandId],
+            categories: [mockState.entities.categories[mockCategoryId]],
+          },
         },
       ];
 
@@ -283,7 +306,11 @@ describe('bags redux selectors', () => {
       const expectedResult = [
         {
           ...state.entities.bagItems[102],
-          product: state.entities.products[1002],
+          product: {
+            ...state.entities.products[1002],
+            brand: state.entities.brands[mockBrandId],
+            categories: [state.entities.categories[mockCategoryId]],
+          },
         },
       ];
 
@@ -338,13 +365,13 @@ describe('bags redux selectors', () => {
   });
 
   describe('findProductInBag()', () => {
-    const product = mockProductEntity;
+    const product = mockProductEntityDenormalized;
     const size = mockBagItemEntity.size;
 
     it('should return the bag item that already exists', () => {
       const expectedResult = {
         ...mockState.entities.bagItems[mockBagItemId],
-        product: mockProductEntity,
+        product: mockProductEntityDenormalized,
       };
 
       expect(

--- a/packages/redux/src/bags/selectors.ts
+++ b/packages/redux/src/bags/selectors.ts
@@ -10,7 +10,7 @@ import {
   getResult,
 } from './reducer';
 import { getEntities, getEntityById } from '../entities/selectors';
-import { getProduct } from '../products/selectors/product';
+import { getProductDenormalized } from '../products/selectors/product';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import type { BagItem, ProductType } from '@farfetch/blackout-client';
@@ -18,6 +18,7 @@ import type {
   BagItemEntity,
   BagItemHydrated,
   ProductEntity,
+  ProductEntityDenormalized,
 } from '../entities/types';
 import type { BagsState } from './types';
 import type { CustomAttributesAdapted, SizeAdapted } from '../helpers/adapters';
@@ -116,7 +117,7 @@ export const getBagItem: (
         bagItemId,
       ) as BagItemEntity;
 
-      return getProduct(state, bagItem?.product);
+      return getProductDenormalized(state, bagItem?.product);
     },
   ],
   (bagItem, product): BagItemHydrated => ({ ...bagItem, product }),
@@ -181,11 +182,11 @@ export const getBagItemsIds = (state: StoreState) =>
  */
 export const getBagItems = createSelector(
   [
+    (state: StoreState) => state,
     getBagItemsIds,
     (state: StoreState) => getEntities(state, 'bagItems'),
-    (state: StoreState) => getEntities(state, 'products'),
   ],
-  (bagItemsIds, bagItems, products): BagItemHydrated[] =>
+  (state, bagItemsIds, bagItems): BagItemHydrated[] =>
     bagItemsIds?.reduce<BagItemHydrated[]>((acc, bagItemId) => {
       const bagItem = bagItems?.[bagItemId];
       const productId = bagItem?.product;
@@ -195,7 +196,7 @@ export const getBagItems = createSelector(
           ...acc,
           {
             ...bagItem,
-            product: products?.[productId],
+            product: getProductDenormalized(state, productId),
           },
         ];
       }
@@ -464,7 +465,7 @@ export const findProductInBag = createSelector(
       state: StoreState,
       productParams: {
         customAttributes?: CustomAttributesAdapted;
-        product: ProductEntity;
+        product: ProductEntityDenormalized;
         size: SizeAdapted;
         merchantId: number;
       },

--- a/packages/redux/src/bags/utils/buildBagItem.ts
+++ b/packages/redux/src/bags/utils/buildBagItem.ts
@@ -1,4 +1,7 @@
-import type { BagItemEntity, ProductEntity } from '../../entities/types';
+import type {
+  BagItemEntity,
+  ProductEntityDenormalized,
+} from '../../entities/types';
 import type {
   CustomAttributesAdapted,
   SizeAdapted,
@@ -12,7 +15,7 @@ type BuildBagItemParams = {
   // Specific merchant id.
   merchantId: number;
   // Product with all information.
-  product: ProductEntity;
+  product: ProductEntityDenormalized;
   // Product bundle aggregator id.
   productAggregatorId?: Exclude<BagItemEntity['productAggregator'], null>['id'];
   // Number of units.

--- a/packages/redux/src/bags/utils/generateBagItemHash.ts
+++ b/packages/redux/src/bags/utils/generateBagItemHash.ts
@@ -2,12 +2,13 @@ import type {
   BagItemEntity,
   MerchantEntity,
   ProductEntity,
+  ProductEntityDenormalized,
 } from '../../entities/types';
 import type { CustomAttributesAdapted } from '../../helpers/adapters';
 
 type Params = Partial<{
   productId: ProductEntity['id'];
-  product: ProductEntity;
+  product: ProductEntityDenormalized;
   customAttributes: CustomAttributesAdapted | string;
   merchantId: MerchantEntity['id'];
   merchant: MerchantEntity['id'];

--- a/packages/redux/src/categories/selectors/categories.ts
+++ b/packages/redux/src/categories/selectors/categories.ts
@@ -1,4 +1,4 @@
-import { getEntities } from '../../entities';
+import { getEntities } from '../../entities/selectors';
 import { getError, getIsLoading, getResult } from '../reducer/categories';
 import type { CategoriesState } from '../types';
 import type { StoreState } from '../../types';

--- a/packages/redux/src/categories/selectors/category.ts
+++ b/packages/redux/src/categories/selectors/category.ts
@@ -1,4 +1,4 @@
-import { getEntityById } from '../../entities';
+import { getEntityById } from '../../entities/selectors';
 import { getError, getIsLoading } from '../reducer/category';
 import type { Category } from '@farfetch/blackout-client';
 import type { CategoryState } from '../types';

--- a/packages/redux/src/entities/types/bagItem.types.ts
+++ b/packages/redux/src/entities/types/bagItem.types.ts
@@ -5,7 +5,7 @@ import type {
   SizeAdapted,
 } from '../../helpers/adapters';
 import type { MerchantEntity } from './merchant.types';
-import type { ProductEntity } from './product.types';
+import type { ProductEntity, ProductEntityDenormalized } from './product.types';
 
 export type BagItemEntity = Omit<
   BagItem,
@@ -39,5 +39,5 @@ export type BagItemEntity = Omit<
 };
 
 export type BagItemHydrated = Omit<BagItemEntity, 'product'> & {
-  product: ProductEntity | undefined;
+  product: ProductEntityDenormalized | undefined;
 };

--- a/packages/redux/src/entities/types/product.types.ts
+++ b/packages/redux/src/entities/types/product.types.ts
@@ -19,6 +19,7 @@ import type {
   WishlistItem,
 } from '@farfetch/blackout-client';
 import type { BrandEntity } from './brand.types';
+import type { CategoryEntity } from './category.types';
 import type {
   CustomAttributesAdapted,
   PriceAdapted,
@@ -173,6 +174,10 @@ export type ProductEntity = {
   name?: BagItem['productName'] | WishlistItem['productName'];
 };
 
-export type ProductEntityDenormalized = Omit<ProductEntity, 'brand'> & {
+export type ProductEntityDenormalized = Omit<
+  ProductEntity,
+  'brand' | 'categories'
+> & {
   brand?: BrandEntity;
+  categories?: CategoryEntity[];
 };

--- a/packages/redux/src/entities/types/wishlistItem.types.ts
+++ b/packages/redux/src/entities/types/wishlistItem.types.ts
@@ -1,6 +1,6 @@
 import type { AttributesAdapted, PriceAdapted } from '../../helpers/adapters';
 import type { WishlistItem as OriginalWishlistItem } from '@farfetch/blackout-client';
-import type { ProductEntity } from './product.types';
+import type { ProductEntity, ProductEntityDenormalized } from './product.types';
 
 export type WishlistItemEntity = {
   attributes: OriginalWishlistItem['attributes'];
@@ -24,6 +24,6 @@ export type WishlistItemsEntities = Record<
 >;
 
 export type WishlistItemHydrated = WishlistItemEntity & {
-  product: ProductEntity | undefined;
+  product: ProductEntityDenormalized | undefined;
   parentSets: Record<'id' | 'name', string>[] | undefined;
 };

--- a/packages/redux/src/products/selectors/__tests__/details.test.ts
+++ b/packages/redux/src/products/selectors/__tests__/details.test.ts
@@ -2,11 +2,13 @@ import * as fromBags from '../../../bags/selectors';
 import * as fromProductEntities from '../product';
 import * as selectors from '../details';
 import {
+  mockBrandId,
   mockBreadCrumbs,
   mockGroupedEntries,
   mockProductId,
   mockProductsState,
 } from 'tests/__fixtures__/products';
+import { mockCategoryId } from 'tests/__fixtures__/categories';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -134,16 +136,28 @@ describe('Product', () => {
     const sizeId =
       mockProductsState.entities.products[mockProductId].sizes[0].id;
     const getProductReturn = mockProductsState.entities.products[mockProductId];
+    const getProductDenormalizedReturn = {
+      ...mockProductsState.entities.products[mockProductId],
+      brand: mockProductsState.entities.brands[mockBrandId],
+      categories: [mockProductsState.entities.categories[mockCategoryId]],
+    };
+
     let spyGetProduct;
+    let spyGetProductDenormalized;
     let spyGetBagItems;
 
     beforeEach(() => {
       spyGetProduct = jest.spyOn(fromProductEntities, 'getProduct');
+      spyGetProductDenormalized = jest.spyOn(
+        fromProductEntities,
+        'getProductDenormalized',
+      );
       spyGetBagItems = jest.spyOn(fromBags, 'getBagItems');
     });
 
     afterEach(() => {
       spyGetProduct.mockRestore();
+      spyGetProductDenormalized.mockRestore();
       spyGetBagItems.mockRestore();
     });
 
@@ -214,7 +228,9 @@ describe('Product', () => {
       const getBagItemsReturn = false;
       const globalQuantity = getProductReturn.sizes[0].globalQuantity;
 
-      spyGetProduct.mockImplementation(() => getProductReturn);
+      spyGetProductDenormalized.mockImplementation(
+        () => getProductDenormalizedReturn,
+      );
       spyGetBagItems.mockImplementation(() => getBagItemsReturn);
 
       expect(

--- a/packages/redux/src/products/selectors/__tests__/lists.test.ts
+++ b/packages/redux/src/products/selectors/__tests__/lists.test.ts
@@ -12,6 +12,7 @@ import {
   mockProductsState,
   mockSetId,
 } from 'tests/__fixtures__/products';
+import { mockCategory } from 'tests/__fixtures__/categories';
 import cloneDeep from 'lodash/cloneDeep';
 import type { FacetValue } from '@farfetch/blackout-client';
 
@@ -171,11 +172,17 @@ describe('products list redux selectors', () => {
 
   describe('getProductsListProducts()', () => {
     const expectedResult = [
-      { id: 12913172, shortDescription: 'foo', brand: mockBrandResponse },
+      {
+        id: 12913172,
+        shortDescription: 'foo',
+        brand: mockBrandResponse,
+        categories: [mockCategory],
+      },
       {
         id: 12913174,
         shortDescription: 'bar',
         brand: mockBrandResponse,
+        categories: [mockCategory],
         groupedEntries: mockGroupedEntries,
       },
     ];
@@ -201,18 +208,22 @@ describe('products list redux selectors', () => {
       {
         ...mockProductsListNormalizedPayload.entities.products[12913172],
         brand: mockBrandResponse,
+        categories: [mockCategory],
       },
       {
         ...mockProductsListNormalizedPayload.entities.products[12913174],
         brand: mockBrandResponse,
+        categories: [mockCategory],
       },
       {
         ...mockProductsListNormalizedPayload.entities.products[12913172],
         brand: mockBrandResponse,
+        categories: [mockCategory],
       },
       {
         ...mockProductsListNormalizedPayload.entities.products[12913174],
         brand: mockBrandResponse,
+        categories: [mockCategory],
       },
     ];
 

--- a/packages/redux/src/products/selectors/details.ts
+++ b/packages/redux/src/products/selectors/details.ts
@@ -6,7 +6,7 @@ import {
   getProductQuantityInBag,
 } from '../../bags';
 import { getError, getIsHydrated, getIsLoading } from '../reducer/details';
-import { getProduct } from './product';
+import { getProduct, getProductDenormalized } from './product';
 import type { ProductEntity } from '../../entities/types';
 import type { ProductsState } from '../types';
 import type { SizeAdapted } from '../../helpers/adapters';
@@ -112,7 +112,7 @@ export const getProductSizeRemainingQuantity = (
   productId: ProductEntity['id'],
   sizeId: SizeAdapted['id'],
 ): number => {
-  const product = getProduct(state, productId);
+  const product = getProductDenormalized(state, productId);
   const size = product?.sizes?.find(({ id }) => id === sizeId) as SizeAdapted;
   const stockAvailable = size?.globalQuantity ?? 0;
   const bagItem =
@@ -148,7 +148,7 @@ export const getProductSizeRemainingQuantity = (
 export const getAllProductSizesRemainingQuantity = createSelector(
   [
     (state: StoreState, productId: ProductEntity['id']) =>
-      getProduct(state, productId),
+      getProductDenormalized(state, productId),
     getBagItems,
   ],
   (product, bagItems): ProductEntity['sizes'] => {

--- a/packages/redux/src/products/selectors/lists.ts
+++ b/packages/redux/src/products/selectors/lists.ts
@@ -5,6 +5,7 @@ import {
 } from '../utils';
 import { createSelector } from 'reselect';
 import { getBrands } from '../../brands/selectors';
+import { getCategories } from '../../categories';
 import { getEntities, getEntityById } from '../../entities/selectors';
 import {
   getError,
@@ -159,14 +160,17 @@ export const getProductsListProducts = createSelector(
       getProductsListProductsIds(state, checkHash(hash)),
     state => getEntities(state, 'products'),
     getBrands,
+    getCategories,
   ],
-  (listProductsIds, products, brands) => {
+  (listProductsIds, products, brands, categories) => {
     return listProductsIds?.map(id => {
       const product = products?.[id];
       const brand =
         brands && product?.brand ? brands[product.brand] : undefined;
+      const productCategories =
+        categories && product?.categories?.map(id => categories[id]);
 
-      return { ...product, brand };
+      return { ...product, brand, categories: productCategories };
     });
   },
 ) as (

--- a/packages/redux/src/products/selectors/product.ts
+++ b/packages/redux/src/products/selectors/product.ts
@@ -1,9 +1,14 @@
 import { createSelector } from 'reselect';
+import { getBrands } from '../../brands';
+import { getCategories } from '../../categories';
 import { getEntityById } from '../../entities/selectors/entity';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import orderBy from 'lodash/orderBy';
-import type { ProductEntity } from '../../entities/types';
+import type {
+  ProductEntity,
+  ProductEntityDenormalized,
+} from '../../entities/types';
 import type { StoreState } from '../../types';
 
 /**
@@ -16,6 +21,37 @@ import type { StoreState } from '../../types';
  */
 export const getProduct = (state: StoreState, productId: ProductEntity['id']) =>
   getEntityById(state, 'products', productId);
+
+/**
+ * Returns a specific product denormalized by its id .
+ *
+ * @param state     - Application state.
+ * @param productId - Numeric identifier of the product.
+ *
+ * @returns Product normalized.
+ */
+export const getProductDenormalized = (
+  state: StoreState,
+  productId: ProductEntity['id'],
+) => {
+  const product = getProduct(state, productId);
+
+  if (!product) {
+    return undefined;
+  }
+
+  const brands = getBrands(state);
+  const categories = getCategories(state);
+  const brand = brands?.[product.brand];
+  const productCategories =
+    categories && product.categories?.map(id => categories[id]);
+
+  return {
+    ...product,
+    brand,
+    categories: productCategories,
+  } as ProductEntityDenormalized;
+};
 
 /**
  * Checks if a specific product is "one size" by its id.

--- a/packages/redux/src/wishlists/selectors/__tests__/wishlists.test.ts
+++ b/packages/redux/src/wishlists/selectors/__tests__/wishlists.test.ts
@@ -101,7 +101,11 @@ describe('wishlists redux selectors', () => {
     const expectedResult = {
       ...wishlistItemEntity,
       ...mockWishlistStateEntity,
-      product: { ...mockProductsEntity[mockProductId] },
+      product: {
+        ...mockProductsEntity[mockProductId],
+        brand: mockWishlistState.entities.brands[2450],
+        categories: [mockWishlistState.entities.categories[136301]],
+      },
     };
 
     it('should return all data regarding a wishlist item', () => {
@@ -127,7 +131,11 @@ describe('wishlists redux selectors', () => {
               .name,
           },
         ],
-        product: mockWishlistState.entities.products[mockProductId],
+        product: {
+          ...mockWishlistState.entities.products[mockProductId],
+          brand: mockWishlistState.entities.brands[2450],
+          categories: [mockWishlistState.entities.categories[136301]],
+        },
       };
 
       expect(
@@ -151,7 +159,11 @@ describe('wishlists redux selectors', () => {
       const expectedResult = [
         {
           ...mockWishlistState.entities.wishlistItems[mockWishlistItemId],
-          product: mockWishlistState.entities.products[mockProductId],
+          product: {
+            ...mockWishlistState.entities.products[mockProductId],
+            brand: mockWishlistState.entities.brands[2450],
+            categories: [mockWishlistState.entities.categories[136301]],
+          },
         },
         {
           ...mockWishlistState.entities.wishlistItems[mockWishlistItemId],
@@ -160,6 +172,8 @@ describe('wishlists redux selectors', () => {
             ...mockProductsEntity[mockProductId],
             id: 1002,
             description: 'wide leg pant',
+            brand: mockWishlistState.entities.brands[2450],
+            categories: [mockWishlistState.entities.categories[136301]],
           },
           quantity: 2,
         },
@@ -181,7 +195,11 @@ describe('wishlists redux selectors', () => {
                 .name,
             },
           ],
-          product: mockWishlistState.entities.products[mockProductId],
+          product: {
+            ...mockWishlistState.entities.products[mockProductId],
+            brand: mockWishlistState.entities.brands[2450],
+            categories: [mockWishlistState.entities.categories[136301]],
+          },
         },
         {
           ...mockWishlistState.entities.wishlistItems[mockWishlistItemId],
@@ -191,6 +209,8 @@ describe('wishlists redux selectors', () => {
             ...mockProductsEntity[mockProductId],
             id: 1002,
             description: 'wide leg pant',
+            brand: mockWishlistState.entities.brands[2450],
+            categories: [mockWishlistState.entities.categories[136301]],
           },
           quantity: 2,
         },
@@ -263,6 +283,8 @@ describe('wishlists redux selectors', () => {
         ...mockWishlistStateEntity,
         product: {
           ...mockProductsEntity[mockProductId],
+          brand: mockWishlistState.entities.brands[2450],
+          categories: [mockWishlistState.entities.categories[136301]],
         },
       };
 

--- a/packages/redux/src/wishlists/selectors/__tests__/wishlistsSets.test.ts
+++ b/packages/redux/src/wishlists/selectors/__tests__/wishlistsSets.test.ts
@@ -4,17 +4,12 @@ import * as selectors from '..';
 import {
   mockProductId,
   mockWishlistItemId,
-  mockWishlistNormalizedPayload,
   mockWishlistSetId,
   mockWishlistState,
 } from 'tests/__fixtures__/wishlists';
-import { mockProductsEntity } from 'tests/__fixtures__/products';
 import { toBlackoutError } from '@farfetch/blackout-client';
 
 describe('wishlists redux selectors', () => {
-  const productEntity =
-    mockWishlistNormalizedPayload.entities.products[mockProductId];
-
   beforeEach(jest.clearAllMocks);
 
   describe('getWishlistSetsError()', () => {
@@ -152,7 +147,11 @@ describe('wishlists redux selectors', () => {
             ...mockWishlistState.entities.wishlistSets[mockWishlistSetId]
               .wishlistSetItems[0],
             ...mockWishlistState.entities.wishlistItems[mockWishlistItemId],
-            product: { ...mockProductsEntity[mockProductId], ...productEntity },
+            product: {
+              ...mockWishlistState.entities.products[mockProductId],
+              brand: mockWishlistState.entities.brands[2450],
+              categories: [mockWishlistState.entities.categories[136301]],
+            },
           },
         ],
       };
@@ -211,7 +210,11 @@ describe('wishlists redux selectors', () => {
               ...mockWishlistState.entities.wishlistSets[mockWishlistSetId]
                 .wishlistSetItems[0],
               ...mockWishlistState.entities.wishlistItems[mockWishlistItemId],
-              product: mockWishlistState.entities.products[mockProductId],
+              product: {
+                ...mockWishlistState.entities.products[mockProductId],
+                brand: mockWishlistState.entities.brands[2450],
+                categories: [mockWishlistState.entities.categories[136301]],
+              },
             },
           ],
         },

--- a/packages/redux/src/wishlists/selectors/wishlists.ts
+++ b/packages/redux/src/wishlists/selectors/wishlists.ts
@@ -3,7 +3,7 @@ import * as fromWishlistSetsReducer from '../reducer/wishlistsSets';
 import { buildWishlistItem, generateWishlistItemHash } from '../utils';
 import { createSelector } from 'reselect';
 import { getEntityById } from '../../entities/selectors';
-import { getProduct } from '../../products/selectors/product';
+import { getProductDenormalized } from '../../products/selectors/product';
 import type { BuildWishlistItemData } from '../utils/buildWishlistItem';
 import type {
   ProductEntity,
@@ -103,7 +103,7 @@ export const getWishlistItem: (
         wishlistItemId,
       ) as WishlistItemEntity;
 
-      return getProduct(state, wishlistItem?.product);
+      return getProductDenormalized(state, wishlistItem?.product);
     },
     (
       state: StoreState,

--- a/packages/redux/src/wishlists/selectors/wishlistsSets.ts
+++ b/packages/redux/src/wishlists/selectors/wishlistsSets.ts
@@ -1,6 +1,7 @@
 import * as fromWishlistSetsReducer from '../reducer/wishlistsSets';
 import { createSelector } from 'reselect';
 import { getEntities, getEntityById } from '../../entities/selectors';
+import { getProductDenormalized } from '../../products';
 import type { StoreState } from '../../types';
 import type { WishlistSet } from '@farfetch/blackout-client';
 import type {
@@ -173,9 +174,9 @@ export const getWishlistSet: (
       setId: WishlistSet['setId'],
     ): WishlistSetEntity | undefined =>
       getEntityById(state, 'wishlistSets', setId),
-    (state: StoreState) => getEntities(state, 'products'),
+    (state: StoreState) => state,
   ],
-  (wishlistItems, wishlistSet, products) => {
+  (wishlistItems, wishlistSet, state) => {
     if (!wishlistSet) {
       return;
     }
@@ -188,7 +189,9 @@ export const getWishlistSet: (
         return {
           ...setItem,
           ...wishlistItems?.[setItem.wishlistItemId],
-          product: wishlistItemProductId && products?.[wishlistItemProductId],
+          product:
+            wishlistItemProductId &&
+            getProductDenormalized(state, wishlistItemProductId),
         };
       }) || [];
 

--- a/packages/redux/src/wishlists/utils/generateWishlistItemHash.ts
+++ b/packages/redux/src/wishlists/utils/generateWishlistItemHash.ts
@@ -1,9 +1,13 @@
-import type { ProductEntity, WishlistItemEntity } from '../../entities/types';
+import type {
+  ProductEntity,
+  ProductEntityDenormalized,
+  WishlistItemEntity,
+} from '../../entities/types';
 
 type WishlistItemHashData = Partial<{
   merchant: number;
   merchantId: number;
-  product: ProductEntity | undefined;
+  product: ProductEntityDenormalized | undefined;
   productId: ProductEntity['id'];
   scale: number;
   size: WishlistItemEntity['size'] | number;

--- a/tests/__fixtures__/bags/bag.fixtures.ts
+++ b/tests/__fixtures__/bags/bag.fixtures.ts
@@ -5,17 +5,36 @@ import {
 } from '@farfetch/blackout-client';
 import { mockBagItemEntity, mockBagItemId } from './bagItem.fixtures';
 import {
+  mockBrandId,
   mockProductEntity,
   mockProductId,
   mockProductSizeAdapted,
   mockProductSizes,
   mockProductTypeToExclude,
 } from '../products';
-import type { SizeAdapted } from '@farfetch/blackout-redux';
+import { mockCategoryId } from '../categories';
+import type {
+  BrandEntity,
+  CategoryEntity,
+  SizeAdapted,
+} from '@farfetch/blackout-redux';
 
 export const mockBagId = '7894746';
 export const mockError = {
   message: 'Unexpected Error',
+};
+
+const mockCategoryEntity: CategoryEntity = {
+  id: mockCategoryId,
+  name: 'dress',
+  gender: 0,
+  parentId: 0,
+};
+
+const mockBrandEntity: BrandEntity = {
+  id: mockBrandId,
+  description: 'Gucci',
+  name: 'Gucci',
 };
 
 export const mockBagItemData = {
@@ -165,6 +184,12 @@ export const mockState = {
         merchant: 1223,
         isAvailable: true,
       },
+    },
+    brands: {
+      [mockBrandId]: mockBrandEntity,
+    },
+    categories: {
+      [mockCategoryId]: mockCategoryEntity,
     },
     products: {
       [mockProductId]: mockProductEntity,

--- a/tests/__fixtures__/bags/bagItem.fixtures.ts
+++ b/tests/__fixtures__/bags/bagItem.fixtures.ts
@@ -7,7 +7,11 @@ import {
   BagItem,
   PurchaseChannel,
 } from '@farfetch/blackout-client';
-import { mockMerchantId, mockProductEntity, mockProductId } from '../products';
+import {
+  mockMerchantId,
+  mockProductEntityDenormalized,
+  mockProductId,
+} from '../products';
 
 export const mockBagItemId = 134;
 export const mockProductAggregatorId = 321;
@@ -213,5 +217,5 @@ export const mockBagItemEntity = {
 
 export const mockBagItemHydrated = {
   ...mockBagItemEntity,
-  product: mockProductEntity,
+  product: mockProductEntityDenormalized,
 };

--- a/tests/__fixtures__/products/products.fixtures.ts
+++ b/tests/__fixtures__/products/products.fixtures.ts
@@ -14,7 +14,10 @@ import { mockProductSizeGuides } from './productSizeGuides.fixtures';
 import { mockProductSizesAdapted } from './productSizes.fixtures';
 import { mockProductVariants } from './productVariantsMerchantsLocations.fixtures';
 import { mockProductVariantsMeasurements } from './productVariantsMeasurements.fixtures';
-import type { ProductEntity } from '@farfetch/blackout-redux';
+import type {
+  ProductEntity,
+  ProductEntityDenormalized,
+} from '@farfetch/blackout-redux';
 
 export const mockTag = { name: 'NewSeason', id: 1 };
 
@@ -237,6 +240,7 @@ export const mockProduct = {
   attributes: mockProductAttributes,
   brand: mockBrandId,
   breadCrumbs: mockBreadCrumbs,
+  categories: [mockCategoryId],
   fittings: mockProductFittings,
   id: mockProductId,
   isDuplicated: false,
@@ -269,6 +273,307 @@ export const mockProduct = {
 export const mockProductEntity: ProductEntity = {
   brand: mockBrandId,
   categories: [mockCategoryId],
+  merchant: mockMerchantId,
+  associations: null,
+  associationsInformation: {
+    hasColorGrouping: false,
+    hasGrouping: false,
+  },
+  id: mockProductId,
+  scaleId: mockSizeScaleId,
+  breadCrumbs: [
+    {
+      text: 'Woman',
+      slug: 'woman',
+      link: 'shopping/woman',
+      parent: false,
+    },
+  ],
+  description: 'biz',
+  fittings: [
+    {
+      type: 'Size Selection',
+      description:
+        'This piece fits true to size. We recommend you get your regular size',
+    },
+    {
+      type: 'Overall fit',
+      description: 'Cut for a slim fit',
+    },
+    {
+      type: 'Fabric weight & type',
+      description: 'Made with a mid-weight fabric',
+    },
+  ],
+  images: [
+    {
+      order: 1,
+      size: '54',
+      url: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_54.jpg',
+      sources: {
+        54: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_54.jpg',
+        600: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_600.jpg',
+      },
+    },
+    {
+      order: 2,
+      size: '54',
+      url: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_54.jpg',
+      sources: {
+        54: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_54.jpg',
+        600: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_600.jpg',
+      },
+    },
+    {
+      order: 3,
+      size: '54',
+      url: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_54.jpg',
+      sources: {
+        54: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_54.jpg',
+        600: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_600.jpg',
+      },
+    },
+    {
+      order: 4,
+      size: '54',
+      url: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_54.jpg',
+      sources: {
+        54: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_54.jpg',
+        600: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_600.jpg',
+      },
+    },
+    {
+      order: 5,
+      size: '54',
+      url: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_54.jpg',
+      sources: {
+        54: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_54.jpg',
+        600: 'https://cdn-images.farfetch-contents.com/converse-x-jw-anderson-chuck-70-hi-sneakers_13145097_17128969_600.jpg',
+      },
+    },
+  ],
+  measurements: [
+    {
+      description: 'Bust',
+      unit: null,
+      value: 85,
+    },
+    {
+      description: 'Height',
+      unit: null,
+      value: 178,
+    },
+    {
+      description: 'Hips',
+      unit: null,
+      value: 90,
+    },
+    {
+      description: 'Waist',
+      unit: null,
+      value: 62,
+    },
+  ],
+  price: {
+    formatted: {
+      includingTaxes: '$129.74',
+      includingTaxesWithoutDiscount: '$129.74',
+    },
+    includingTaxes: 129.7446,
+    includingTaxesWithoutDiscount: 129.7446,
+    taxes: {
+      type: 'VAT',
+      rate: 0,
+      amount: 0,
+    },
+    isFormatted: false,
+  },
+  shortDescription: 'foo',
+  sizes: mockProductSizesAdapted,
+  sizeGuides: [
+    {
+      annotations: [],
+      order: 0,
+      brand: {
+        id: mockBrandId,
+        name: 'Gucci',
+      },
+      maps: [
+        {
+          isDefault: false,
+          categoryId: mockCategoryId,
+          sizeScaleId: 950,
+          description: 'CHLOÉ STANDARD',
+          abbreviation: '',
+          maps: [
+            {
+              description: 'XXXS',
+              position: 0,
+            },
+            {
+              description: 'M',
+              position: 1,
+            },
+            {
+              description: 'L',
+              position: 2,
+            },
+          ],
+        },
+        {
+          isDefault: false,
+          categoryId: mockCategoryId,
+          sizeScaleId: 955,
+          description: 'CHLOÉ FRANCE',
+          abbreviation: 'FR',
+          maps: [
+            {
+              description: '0',
+              position: 0,
+            },
+            {
+              description: '2',
+              position: 1,
+            },
+            {
+              description: '4',
+              position: 2,
+            },
+          ],
+        },
+        {
+          isDefault: false,
+          categoryId: mockCategoryId,
+          sizeScaleId: 960,
+          description: 'CHLOÉ US',
+          abbreviation: 'US',
+          maps: [
+            {
+              description: '0',
+              position: 0,
+            },
+            {
+              description: '1',
+              position: 1,
+            },
+            {
+              description: '2',
+              position: 2,
+            },
+          ],
+        },
+        {
+          isDefault: false,
+          categoryId: mockCategoryId,
+          sizeScaleId: 965,
+          description: 'CHLOÉ UK',
+          abbreviation: 'UK',
+          maps: [
+            {
+              description: '50',
+              position: 0,
+            },
+            {
+              description: '55',
+              position: 1,
+            },
+            {
+              description: '60',
+              position: 2,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  sku: '000000000006175920',
+  preferedMerchant: {
+    merchantId: 9359,
+    byAttribute: [
+      {
+        merchantId: 9359,
+        type: 0,
+        value: '$129.74',
+      },
+    ],
+  },
+  variants: [
+    {
+      id: mockVariantId,
+      merchantId: 10948,
+      merchantsLocations: [
+        {
+          merchantLocationId: 1,
+          quantity: 0,
+          variantId: mockVariantId,
+        },
+        {
+          merchantLocationId: 2,
+          quantity: 1,
+          variantId: mockVariantId,
+        },
+        {
+          merchantLocationId: 3,
+          quantity: 99,
+          variantId: mockVariantId,
+        },
+      ],
+      price: {
+        formatted: {
+          includingTaxes: '$129.74',
+          includingTaxesWithoutDiscount: '$129.74',
+        },
+        includingTaxes: 129.7446,
+        includingTaxesWithoutDiscount: 129.7446,
+        isFormatted: false,
+      },
+      size: 'S',
+      attributes: [],
+      sizeDescription: 'S',
+      scaleAbbreviation: 'S',
+      scale: 'S',
+      quantity: 99,
+      isOneSize: false,
+      availableAt: [],
+      purchaseChannel: 0,
+      barcodes: [],
+      formattedPrice: '$129.74',
+      formattedPriceWithoutDiscount: '$129.74',
+    },
+  ],
+  slug: 'bar',
+  colors: [
+    {
+      color: {
+        id: 112504,
+        name: 'Red',
+      },
+      tags: ['MainColor'],
+    },
+    {
+      color: {
+        id: 2323429,
+        name: 'degrade vermelho',
+      },
+      tags: ['DesignerColor'],
+    },
+  ],
+};
+
+export const mockProductEntityDenormalized: ProductEntityDenormalized = {
+  brand: {
+    id: mockBrandId,
+    description: 'Gucci',
+    name: 'Gucci',
+  },
+  categories: [
+    {
+      id: mockCategoryId,
+      name: 'dress',
+      gender: 0,
+      parentId: 0,
+    },
+  ],
   merchant: mockMerchantId,
   associations: null,
   associationsInformation: {

--- a/tests/__fixtures__/products/productsLists.fixtures.ts
+++ b/tests/__fixtures__/products/productsLists.fixtures.ts
@@ -1,6 +1,7 @@
 import { FacetValue, GenderCode } from '@farfetch/blackout-client';
 import { mockBrandId } from '../brands';
 import { mockBreadCrumbs } from './products.fixtures';
+import { mockCategoryId } from '../categories';
 import { mockPriceAdaptedEmpty, mockPricesResponse } from './price.fixtures';
 import { mockSetId } from './ids.fixtures';
 import type { ProductsListEntity } from '@farfetch/blackout-redux';
@@ -876,12 +877,18 @@ export const mockProductsListNormalizedPayload = {
     merchants: { undefined: { id: undefined } },
     genders: { undefined: { id: undefined } },
     products: {
-      12913172: { id: 12913172, shortDescription: 'foo', brand: mockBrandId },
+      12913172: {
+        id: 12913172,
+        shortDescription: 'foo',
+        brand: mockBrandId,
+        categories: [mockCategoryId],
+      },
       12913174: {
         id: 12913174,
         shortDescription: 'bar',
         groupedEntries: mockGroupedEntries,
         brand: mockBrandId,
+        categories: [mockCategoryId],
       },
     },
     facets: mockFacetsNormalized,

--- a/tests/__fixtures__/products/state.fixtures.ts
+++ b/tests/__fixtures__/products/state.fixtures.ts
@@ -1,4 +1,5 @@
 import { mockState as brandsMockState } from '../brands';
+import { mockCategoriesState } from '../categories';
 import { mockMerchantId, mockProductId } from './ids.fixtures';
 import { mockProduct } from './products.fixtures';
 import { mockProductGroupingAdapted } from './productGrouping.fixtures';
@@ -170,7 +171,22 @@ export const mockProductsState = {
   },
   entities: {
     ...mockProductsListNormalizedPayload.entities,
-    ...brandsMockState.entities,
+    brands: {
+      ...brandsMockState.entities.brands,
+      6326412: {
+        description: null,
+        id: 6326412,
+        name: 'Balenciaga',
+        priceType: 0,
+        slug: 'balenciaga',
+      },
+    },
+    categories: {
+      ...mockCategoriesState.entities.categories,
+      135967: {
+        id: 135967,
+      },
+    },
     bagItems: {
       101: {
         id: 101,

--- a/tests/__fixtures__/wishlists/wishlists.fixtures.ts
+++ b/tests/__fixtures__/wishlists/wishlists.fixtures.ts
@@ -164,6 +164,19 @@ export const mockWishlistState = {
         description: 'wide leg pant',
       },
     },
+    categories: {
+      136301: { id: 136301, name: 'Shoes', gender: 1, parentId: 0 },
+    },
+    brands: {
+      2450: {
+        description:
+          'Demna Gvasalia brings Balenciaga back to its creative roots.',
+        id: 2450,
+        name: 'Balenciaga',
+        priceType: 0,
+        slug: 'rockstud-sling-back-flats-12854475',
+      },
+    },
     wishlistSets: {
       [mockWishlistSetId]: {
         id: mockWishlistSetId,


### PR DESCRIPTION
## Description

- Added `getProductDenormalized` selector. 
- Replaced `getProduct` selector by the new `getProductDenormalized` selector inside `bag`, `wishlist`, and `details` selectors.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
