### PR TITLE
feat(analytics|react): add omnitracking's scroll track on interact content event mappings next

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../constants';
 import analyticsTrackTypes from '../../../types/trackTypes';
 import eventTypes from '../../../types/eventTypes';
+import interactionTypes from '../../../types/interactionTypes';
 import merge from 'lodash/merge';
 import mocked_view_uid from '../__fixtures__/mocked_view_uid';
 import pageTypes from '../../../types/pageTypes';
@@ -625,6 +626,87 @@ describe('Omnitracking', () => {
           expect.objectContaining({
             parameters: expect.objectContaining({
               tid: 2895,
+            }),
+          }),
+        );
+      });
+    });
+
+    describe('interact content', () => {
+      it('should not track an interact content event if the required parameters are missing', async () => {
+        const data = generateTrackMockData({
+          event: eventTypes.INTERACT_CONTENT,
+          properties: {
+            interactionType: undefined,
+          },
+        });
+
+        // setting unique view id to pass on validation of missing page event before event track
+        omnitracking.currentUniqueViewId = mocked_view_uid;
+        await omnitracking.track(data);
+
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Event Interact Content properties "contentType" and "id" should be sent',
+          ),
+        );
+      });
+
+      it('should track scroll event', async () => {
+        const data = generateTrackMockData({
+          event: eventTypes.INTERACT_CONTENT,
+          properties: {
+            interactionType: interactionTypes.SCROLL,
+            target: document.body,
+            percentageScrolled: 50,
+          },
+        });
+
+        // setting unique view id to pass on validation of missing page event before event track
+        omnitracking.currentUniqueViewId = mocked_view_uid;
+        await omnitracking.track(data);
+
+        expect(postTrackingSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            parameters: expect.objectContaining({
+              tid: 668,
+            }),
+          }),
+        );
+      });
+
+      it('should not track an event when interactionType is scroll but target is not document.body', async () => {
+        const data = generateTrackMockData({
+          event: eventTypes.INTERACT_CONTENT,
+          properties: {
+            interactionType: interactionTypes.SCROLL,
+            target: undefined,
+            percentageScrolled: 50,
+          },
+        });
+        await omnitracking.track(data);
+
+        expect(postTrackingSpy).toHaveBeenCalledTimes(0);
+      });
+
+      it('should track a default interact content event', async () => {
+        const data = generateTrackMockData({
+          event: eventTypes.INTERACT_CONTENT,
+          properties: {
+            interactionType: interactionTypes.CLICK,
+            contentType: 'logo',
+            id: 'home_logo',
+          },
+        });
+
+        // setting unique view id to pass on validation of missing page event before event track
+        omnitracking.currentUniqueViewId = mocked_view_uid;
+        await omnitracking.track(data);
+
+        expect(postTrackingSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            parameters: expect.objectContaining({
+              tid: 2882,
             }),
           }),
         );

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -11,6 +11,7 @@ import {
 } from './omnitracking-helper';
 import { logger } from '../../utils';
 import eventTypes from '../../types/eventTypes';
+import interactionTypes from '../../types/interactionTypes';
 import pageTypes from '../../types/pageTypes';
 import type { EventData, TrackTypesValues } from '../..';
 import type {
@@ -580,6 +581,25 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     filtersApplied: data.properties?.filters,
   }),
   [eventTypes.INTERACT_CONTENT]: (data: EventData<TrackTypesValues>) => {
+    if (data.properties?.interactionType === interactionTypes.SCROLL) {
+      if (data.properties?.target === document.body)
+        return {
+          tid: 668,
+          scrollDepth: data.properties?.percentageScrolled,
+        };
+
+      return;
+    }
+
+    if (!data.properties?.contentType || !data.properties?.id) {
+      logger.error(
+        `[Omnitracking] - Event ${data.event} properties "contentType" and "id" should be sent 
+                        on the payload when triggering a "select content" event. If you want to track this 
+                        event, make sure to pass these two properties.`,
+      );
+      return;
+    }
+
     return {
       tid: 2882,
       contentType: data.properties?.contentType,


### PR DESCRIPTION
## Description

Added interact content's scroll track support on omnitracking;

### Dependencies

[561](https://github.com/Farfetch/blackout/pull/561)

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
