### PR TITLE
fix(react): remove unnecessary castle.io tracking requests

### DIFF
--- a/tests/__fixtures__/analytics/baseAnalyticsEventData.fixtures.ts
+++ b/tests/__fixtures__/analytics/baseAnalyticsEventData.fixtures.ts
@@ -17,6 +17,8 @@ const fixtures = {
       lastName: 'bar',
       phoneNumber: '+351-99999999',
       username: 'foo.bar',
+      wishlistId: '123123',
+      countryCode: 'US',
     },
   },
   consent: {


### PR DESCRIPTION
## Description
This PR includes the removal of the unnecessary tracking requests being sent to castle.io, along with a fix on the `registered_at` property to comply with the castle's date format.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
