### PR TITLE
fix(core): fix analytics' setUser middleware on logout action

### DIFF
--- a/packages/core/src/analytics/redux/middlewares/__tests__/setUser.test.js
+++ b/packages/core/src/analytics/redux/middlewares/__tests__/setUser.test.js
@@ -456,7 +456,7 @@ describe('setUserMiddleware', () => {
       });
     });
 
-    it('Should trigger a logout event when the user changes to a guest user from a logged in user', async () => {
+    it('Should trigger a logout event when the user changes to a guest user from a logged in user (session expired)', async () => {
       const setUserMiddleware = require('../setUser').default;
 
       const store = mockStore(mockStateGuestUser, [
@@ -485,6 +485,36 @@ describe('setUserMiddleware', () => {
       assertSetUserSpyCalledWith(guestUserId, guestUserInfo);
 
       expect(trackSpy).toHaveBeenCalledWith(eventTypes.LOGOUT);
+    });
+
+    it('Should trigger a logout event when the user changes to a guest user from a logged in user (Manual logout)', async () => {
+      const setUserMiddleware = require('../setUser').default;
+
+      const store = mockStore(mockStateGuestUser, [
+        setUserMiddleware(analytics),
+      ]);
+
+      // Set user as logged in
+      await dispatchUserChangingAction(
+        store,
+        authenticationActionTypes.LOGIN_SUCCESS,
+        loggedInUserEntity,
+        { isLoginAction: true, method: loginMethodParameterTypes.TENANT },
+      );
+
+      assertSetUserSpyCalledWith(loggedInUserId, loggedInUserInfo);
+
+      jest.clearAllMocks();
+
+      // Change the user to a guest now
+      await dispatchUserChangingAction(
+        store,
+        authenticationActionTypes.LOGOUT_SUCCESS,
+        guestUserEntity,
+      );
+
+      expect(trackSpy).toHaveBeenCalledWith(eventTypes.LOGOUT);
+      expect(anonymizeSpy).toHaveBeenCalled();
     });
 
     it('Should not track any event if there was not a change to the user logged-in status', async () => {

--- a/packages/core/src/analytics/redux/middlewares/setUser.js
+++ b/packages/core/src/analytics/redux/middlewares/setUser.js
@@ -18,7 +18,6 @@ export const DEFAULT_TRIGGER_SET_USER_ACTION_TYPES = new Set([
 
 export const DEFAULT_TRIGGER_ANONYMIZE_ACTION_TYPES = new Set([
   authenticationActionTypes.LOGOUT_SUCCESS,
-  profileActionTypes.GET_PROFILE_FAILURE,
 ]);
 
 // Default user traits picker
@@ -176,7 +175,12 @@ export default (analyticsInstance, actionTypesOrOptions) => {
             analyticsInstance.track(eventTypeToTrack, eventPayload);
           }
         } else if (!previousIsGuest && isGuest) {
+          // When the session expires and there's still a `currentUser` stored
           analyticsInstance.track(eventTypes.LOGOUT);
+
+          await analyticsInstance.anonymize();
+
+          currentUser = null;
         }
       }
 
@@ -184,7 +188,11 @@ export default (analyticsInstance, actionTypesOrOptions) => {
     }
 
     if (triggerAnonymizeActions.has(actionType)) {
+      // When the user manually logs out
+      await analyticsInstance.track(eventTypes.LOGOUT);
+
       await analyticsInstance.anonymize();
+
       currentUser = null;
     }
 


### PR DESCRIPTION
## Description
This PR fixes a bug when the user manually logs out.
The `LOGOUT` event was only being triggered when the user session expired. 
Now it will be correctly triggered in that case and when the user manually logs out, or when the GET_PROFILE action fails.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
