### PR TITLE
fix(redux): fix bag reducer

### DIFF
--- a/packages/redux/src/bags/__tests__/reducer.test.ts
+++ b/packages/redux/src/bags/__tests__/reducer.test.ts
@@ -82,24 +82,19 @@ describe('bags redux reducer', () => {
       expect(state).toBeNull();
     });
 
-    it('should handle ADD_BAG_ITEM_FAILURE action type', () => {
+    it.each([
+      actionTypes.ADD_BAG_ITEM_FAILURE,
+      actionTypes.FETCH_BAG_FAILURE,
+      actionTypes.REMOVE_BAG_ITEM_FAILURE,
+      actionTypes.UPDATE_BAG_ITEM_FAILURE,
+    ])('should handle %s action type', actionType => {
       const expectedResult = 'foo';
 
       expect(
         reducer(undefined, {
           payload: { error: expectedResult },
-          type: actionTypes.ADD_BAG_ITEM_FAILURE,
-        }).error,
-      ).toBe(expectedResult);
-    });
-
-    it('should handle FETCH_BAG_FAILURE action type', () => {
-      const expectedResult = 'foo';
-
-      expect(
-        reducer(undefined, {
-          payload: { error: expectedResult },
-          type: actionTypes.FETCH_BAG_FAILURE,
+          type: actionType,
+          meta: { bagItemId: mockBagItemId },
         }).error,
       ).toBe(expectedResult);
     });
@@ -147,13 +142,19 @@ describe('bags redux reducer', () => {
       expect(state).toBe(initialState.result);
     });
 
-    it('should handle FETCH_BAG_SUCCESS action type', () => {
+    it.each([
+      actionTypes.ADD_BAG_ITEM_SUCCESS,
+      actionTypes.FETCH_BAG_SUCCESS,
+      actionTypes.REMOVE_BAG_ITEM_SUCCESS,
+      actionTypes.UPDATE_BAG_ITEM_SUCCESS,
+    ])('should handle %s action type', actionType => {
       const expectedResult = { bar: 'foo', id: mockBagId };
 
       expect(
         reducer(undefined, {
           payload: { result: expectedResult },
-          type: actionTypes.FETCH_BAG_SUCCESS,
+          type: actionType,
+          meta: { bagItemId: mockBagItemId },
         }).result,
       ).toBe(expectedResult);
     });
@@ -173,55 +174,58 @@ describe('bags redux reducer', () => {
       expect(state).toBe(false);
     });
 
-    it('should handle ADD_BAG_ITEM_REQUEST action type', () => {
-      expect(
-        reducer(undefined, {
-          type: actionTypes.ADD_BAG_ITEM_REQUEST,
-        }).isLoading,
-      ).toBe(true);
-    });
+    it.each([
+      actionTypes.ADD_BAG_ITEM_REQUEST,
+      actionTypes.FETCH_BAG_REQUEST,
+      actionTypes.REMOVE_BAG_ITEM_REQUEST,
+      actionTypes.UPDATE_BAG_ITEM_REQUEST,
+    ])(
+      'should change `isLoading` to true when %s action type is dispatched',
+      actionType => {
+        expect(
+          reducer(undefined, {
+            type: actionType,
+            meta: { bagItemId: mockBagItemId },
+          }).isLoading,
+        ).toBe(true);
+      },
+    );
 
-    it('should handle ADD_BAG_ITEM_FAILURE action type', () => {
-      expect(
-        reducer(undefined, {
-          payload: { error: '' },
-          type: actionTypes.ADD_BAG_ITEM_FAILURE,
-        }).isLoading,
-      ).toBe(initialState.isLoading);
-    });
+    it.each([
+      actionTypes.ADD_BAG_ITEM_FAILURE,
+      actionTypes.FETCH_BAG_FAILURE,
+      actionTypes.REMOVE_BAG_ITEM_FAILURE,
+      actionTypes.UPDATE_BAG_ITEM_FAILURE,
+    ])(
+      'should change `isLoading` to false when %s action type is dispatched',
+      actionType => {
+        expect(
+          reducer(undefined, {
+            type: actionType,
+            meta: { bagItemId: mockBagItemId },
+            payload: { error: new Error('dummy error') },
+          }).isLoading,
+        ).toBe(false);
+      },
+    );
 
-    it('should handle ADD_BAG_ITEM_SUCCESS action type', () => {
-      expect(
-        reducer(undefined, {
-          type: actionTypes.ADD_BAG_ITEM_SUCCESS,
-          payload: { result: { items: [mockBagItemId] } },
-        }).isLoading,
-      ).toBe(initialState.isLoading);
-    });
-
-    it('should handle FETCH_BAG_REQUEST action type', () => {
-      expect(
-        reducer(undefined, { type: actionTypes.FETCH_BAG_REQUEST }).isLoading,
-      ).toBe(true);
-    });
-
-    it('should handle FETCH_BAG_FAILURE action type', () => {
-      expect(
-        reducer(undefined, {
-          payload: { error: '' },
-          type: actionTypes.FETCH_BAG_FAILURE,
-        }).isLoading,
-      ).toBe(initialState.isLoading);
-    });
-
-    it('should handle FETCH_BAG_SUCCESS action type', () => {
-      expect(
-        reducer(undefined, {
-          payload: { result: { id: mockBagId } },
-          type: actionTypes.FETCH_BAG_SUCCESS,
-        }).isLoading,
-      ).toBe(initialState.isLoading);
-    });
+    it.each([
+      actionTypes.ADD_BAG_ITEM_SUCCESS,
+      actionTypes.FETCH_BAG_SUCCESS,
+      actionTypes.REMOVE_BAG_ITEM_SUCCESS,
+      actionTypes.UPDATE_BAG_ITEM_SUCCESS,
+    ])(
+      'should change `isLoading` to false when %s action type is dispatched',
+      actionType => {
+        expect(
+          reducer(undefined, {
+            type: actionType,
+            payload: { result: { id: mockBagId } },
+            meta: { bagItemId: mockBagItemId },
+          }).isLoading,
+        ).toBe(false);
+      },
+    );
 
     it('should handle other actions by returning the previous state', () => {
       const state = { ...initialState, isLoading: false };

--- a/packages/redux/src/bags/reducer.ts
+++ b/packages/redux/src/bags/reducer.ts
@@ -26,6 +26,8 @@ const error = (
   switch (action.type) {
     case actionTypes.ADD_BAG_ITEM_FAILURE:
     case actionTypes.FETCH_BAG_FAILURE:
+    case actionTypes.UPDATE_BAG_ITEM_FAILURE:
+    case actionTypes.REMOVE_BAG_ITEM_FAILURE:
       return action.payload.error;
     case actionTypes.ADD_BAG_ITEM_REQUEST:
     case actionTypes.REMOVE_BAG_ITEM_REQUEST:
@@ -65,11 +67,17 @@ const isLoading = (state = INITIAL_STATE.isLoading, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.ADD_BAG_ITEM_REQUEST:
     case actionTypes.FETCH_BAG_REQUEST:
+    case actionTypes.UPDATE_BAG_ITEM_REQUEST:
+    case actionTypes.REMOVE_BAG_ITEM_REQUEST:
       return true;
     case actionTypes.ADD_BAG_ITEM_FAILURE:
     case actionTypes.ADD_BAG_ITEM_SUCCESS:
     case actionTypes.FETCH_BAG_FAILURE:
     case actionTypes.FETCH_BAG_SUCCESS:
+    case actionTypes.UPDATE_BAG_ITEM_SUCCESS:
+    case actionTypes.UPDATE_BAG_ITEM_FAILURE:
+    case actionTypes.REMOVE_BAG_ITEM_SUCCESS:
+    case actionTypes.REMOVE_BAG_ITEM_FAILURE:
       return INITIAL_STATE.isLoading;
     default:
       return state;


### PR DESCRIPTION
## Description

- This adds missing actions to some slices of the bag reducer in order to correctly update its state. For example, when using the `useBag` hook, if the product is already on the bag, an update will be performed to that bag item which would not update the `isLoading` slice of the bag reducer to `true`.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
