### PR TITLE
feat(redux|react): add pickup reschedule hooks

### DIFF
--- a/packages/client/src/returns/types/getReturn.types.ts
+++ b/packages/client/src/returns/types/getReturn.types.ts
@@ -1,4 +1,7 @@
 import type { Config } from '../..';
 import type { Return } from './return.types';
 
-export type GetReturn = (id: Return['id'], config?: Config) => Promise<Return>;
+export type GetReturn = (
+  returnId: Return['id'],
+  config?: Config,
+) => Promise<Return>;

--- a/packages/client/src/returns/types/getReturnPickupCapability.types.ts
+++ b/packages/client/src/returns/types/getReturnPickupCapability.types.ts
@@ -2,7 +2,7 @@ import type { Config, Return } from '../..';
 import type { ReturnPickupCapability } from './returnPickupCapability.types';
 
 export type GetReturnPickupCapability = (
-  id: Return['id'],
+  returnId: Return['id'],
   pickupDay: string,
   config?: Config,
 ) => Promise<ReturnPickupCapability>;

--- a/packages/client/src/returns/types/getReturnPickupRescheduleRequests.types.ts
+++ b/packages/client/src/returns/types/getReturnPickupRescheduleRequests.types.ts
@@ -3,6 +3,6 @@ import type { PickupRescheduleRequests } from './pickupRescheduleRequests.types'
 import type { Return } from './return.types';
 
 export type GetReturnPickupRescheduleRequests = (
-  id: Return['id'],
+  returnId: Return['id'],
   config?: Config,
 ) => Promise<PickupRescheduleRequests>;

--- a/packages/client/src/returns/types/patchReturn.types.ts
+++ b/packages/client/src/returns/types/patchReturn.types.ts
@@ -6,7 +6,7 @@ export type PatchReturnData = {
 };
 
 export type PatchReturn = (
-  id: Return['id'],
+  returnId: Return['id'],
   data: PatchReturnData,
   config?: Config,
 ) => Promise<void>;

--- a/packages/client/src/returns/types/postReturnPickupRescheduleRequests.types.ts
+++ b/packages/client/src/returns/types/postReturnPickupRescheduleRequests.types.ts
@@ -2,8 +2,13 @@ import type { Config } from '../../types';
 import type { PickupRescheduleRequest } from './pickupRescheduleRequests.types';
 import type { Return } from './return.types';
 
+export type PostReturnPickupRescheduleRequestData = Omit<
+  PickupRescheduleRequest,
+  'id' | 'status'
+>;
+
 export type PostReturnPickupRescheduleRequest = (
-  id: Return['id'],
-  data: PickupRescheduleRequest,
+  returnId: Return['id'],
+  data: PostReturnPickupRescheduleRequestData,
   config?: Config,
 ) => Promise<number>;

--- a/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
@@ -222,6 +222,8 @@ Object {
   "useRecentlyViewedProducts": [Function],
   "useReturn": [Function],
   "useReturnPickupCapability": [Function],
+  "useReturnPickupRescheduleRequest": [Function],
+  "useReturnPickupRescheduleRequests": [Function],
   "useSearchDidYouMean": [Function],
   "useSearchIntents": [Function],
   "useSearchSuggestions": [Function],

--- a/packages/react/src/returns/hooks/__tests__/useReturnPickupRescheduleRequest.test.ts
+++ b/packages/react/src/returns/hooks/__tests__/useReturnPickupRescheduleRequest.test.ts
@@ -1,0 +1,431 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { flushPromises } from '../../../../tests/helpers';
+import {
+  PickupRescheduleRequest,
+  RescheduleStatus,
+  toBlackoutError,
+} from '@farfetch/blackout-client';
+import {
+  rescheduleRequestId,
+  responses,
+  returnId,
+} from 'tests/__fixtures__/returns';
+import { useReturnPickupRescheduleRequest } from '../../..';
+import useReturnPickupRescheduleRequests from '../useReturnPickupRescheduleRequests';
+
+const mockReturnPickupRescheduleResponse =
+  responses.getReturnPickupRescheduleRequest.success;
+const mockFetchPickupRescheduleRequestsFn = jest.fn();
+const mockCreatePickupRescheduleRequestFn = jest.fn();
+const mockFetchPickupRescheduleRequest = jest.fn(() => {
+  return Promise.resolve(mockReturnPickupRescheduleResponse);
+});
+const mockFetchPickupRescheduleError = toBlackoutError(
+  new Error('dummy error'),
+);
+
+const defaultReturnPickupReschedule = {
+  data: undefined,
+  isLoading: false,
+  isFetched: false,
+  error: null,
+  actions: {
+    fetch: expect.any(Function),
+    create: expect.any(Function),
+  },
+};
+
+const defaultReturnPickupRescheduleFetched = {
+  ...defaultReturnPickupReschedule,
+  isFetched: true,
+  data: {
+    id: '1654321',
+    status: 0,
+    timeWindow: {
+      end: '/Date(1574413200000)/',
+      start: '1574445600000',
+    },
+  },
+};
+
+jest.mock('../useReturnPickupRescheduleRequests', () => {
+  return jest.fn(() => {
+    return {
+      ...jest.requireActual('../useReturnPickupRescheduleRequests'),
+      data: undefined,
+      isLoading: false,
+      isFetched: false,
+      error: null,
+      actions: {
+        fetch: mockFetchPickupRescheduleRequestsFn,
+        create: mockCreatePickupRescheduleRequestFn,
+        fetchPickupRescheduleRequest: mockFetchPickupRescheduleRequest,
+      },
+    };
+  });
+});
+
+const mockFetchConfig = {
+  myCustomParameter: 10,
+};
+
+describe('useReturnPickupRescheduleRequest', () => {
+  beforeEach(jest.clearAllMocks);
+  afterEach(cleanup);
+
+  it('should return correctly with initial state and call all hook dependencies with the correct options', () => {
+    const {
+      result: { current },
+    } = renderHook(() =>
+      useReturnPickupRescheduleRequest(returnId, rescheduleRequestId, {
+        enableAutoFetch: false,
+        fetchConfig: mockFetchConfig,
+      }),
+    );
+    const staticPickupRescheduleRequestsOptions = { enableAutoFetch: false };
+
+    expect(current).toStrictEqual(defaultReturnPickupReschedule);
+
+    expect(mockFetchPickupRescheduleRequest).not.toHaveBeenCalled();
+
+    expect(useReturnPickupRescheduleRequests).toHaveBeenCalledWith(
+      returnId,
+      staticPickupRescheduleRequestsOptions,
+    );
+  });
+
+  it('should return correctly when the reschedule request is fetched', async () => {
+    const { result } = renderHook(() =>
+      useReturnPickupRescheduleRequest(returnId, rescheduleRequestId, {
+        enableAutoFetch: true,
+        fetchConfig: mockFetchConfig,
+      }),
+    );
+
+    // Awaits for the microtasks to finish so we can assure that all the promises
+    // were completed and the reference updated.
+    await act(() => flushPromises());
+
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupRescheduleFetched,
+      isFetched: true,
+    });
+  });
+
+  it('should return correctly when there is an error', async () => {
+    mockFetchPickupRescheduleRequest.mockRejectedValueOnce(
+      mockFetchPickupRescheduleError,
+    );
+
+    const { result } = renderHook(() =>
+      useReturnPickupRescheduleRequest(returnId, rescheduleRequestId, {
+        enableAutoFetch: true,
+        fetchConfig: mockFetchConfig,
+      }),
+    );
+
+    // Awaits for the microtasks to finish so we can assure that all the promises
+    // were completed and the reference updated.
+    await act(() => flushPromises());
+
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupReschedule,
+      isFetched: true,
+      error: mockFetchPickupRescheduleError,
+    });
+  });
+
+  it('should return correctly when it is loading', () => {
+    const { result } = renderHook(() =>
+      useReturnPickupRescheduleRequest(returnId, rescheduleRequestId, {
+        enableAutoFetch: true,
+        fetchConfig: mockFetchConfig,
+      }),
+    );
+
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupReschedule,
+      isLoading: true,
+    });
+  });
+
+  it('should clear data if the hook is rerendered with different parameters than the current data it has', async () => {
+    const { result, rerender } = renderHook<unknown, { id: number }>(
+      ({ id }) =>
+        useReturnPickupRescheduleRequest(id, rescheduleRequestId, {
+          enableAutoFetch: true,
+          fetchConfig: mockFetchConfig,
+        }),
+      { initialProps: { id: returnId } },
+    );
+
+    // Awaits for the microtasks to finish so we can assure that all the promises
+    // were completed and the reference updated.
+    await act(() => flushPromises());
+
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupRescheduleFetched,
+      isFetched: true,
+    });
+
+    act(() => rerender({ id: returnId + 1 }));
+
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupReschedule,
+      isLoading: true,
+    });
+  });
+
+  it('should not update state if the response is for a different request', async () => {
+    let fetchPromiseResolve: (
+      value: PickupRescheduleRequest | PromiseLike<PickupRescheduleRequest>,
+    ) => void;
+    const fetchPromise = new Promise<PickupRescheduleRequest>(
+      resolve => (fetchPromiseResolve = resolve),
+    );
+
+    // Set the first call to fetchPickupRequest client to await for a promise
+    // to simulate the request taking too long.
+    mockFetchPickupRescheduleRequest.mockImplementationOnce(async () => {
+      return await fetchPromise;
+    });
+
+    // Render the hook with auto fetch true to force the fetch request
+    const { result } = renderHook(() =>
+      useReturnPickupRescheduleRequest(returnId, rescheduleRequestId, {
+        enableAutoFetch: true,
+        fetchConfig: mockFetchConfig,
+      }),
+    );
+
+    // Awaits for the microtasks to finish so we can assure that all the promises
+    // were completed and the reference updated.
+    await act(() => flushPromises());
+
+    // Make sure it is loading
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupReschedule,
+      isLoading: true,
+    });
+
+    // Call fetch with a different reschedule request id than the one passed
+    // when invoking the hook. This request should success immediately as it will use
+    // the default mock instead of the one used on the previous request.
+    await result.current.actions.fetch(rescheduleRequestId + 1);
+
+    // Awaits for the microtasks to finish so we can assure that all the promises
+    // were completed and the reference updated.
+    await act(() => flushPromises());
+
+    // Make sure it continues to be loading as it should not change the state.
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupReschedule,
+      isLoading: true,
+    });
+
+    const successResponse = {
+      id: rescheduleRequestId,
+      timeWindow: {
+        start: '158860601111',
+        end: '/Date(158860601111)/',
+      },
+      status: RescheduleStatus.Failed,
+    };
+
+    // Resolve the pending request and check if it has changed state now with
+    // the value resolved with the promise.
+    await act(async () => await fetchPromiseResolve!(successResponse));
+
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupRescheduleFetched,
+      data: {
+        ...successResponse,
+      },
+    });
+  });
+
+  describe('options', () => {
+    describe('enableAutoFetch', () => {
+      it('should fetch data if `enableAutoFetch` option is not specified and returnId parameter is passed', () => {
+        renderHook(() =>
+          useReturnPickupRescheduleRequest(returnId, rescheduleRequestId, {
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        expect(mockFetchPickupRescheduleRequest).toHaveBeenCalledWith(
+          rescheduleRequestId,
+          returnId,
+          mockFetchConfig,
+        );
+      });
+
+      it('should fetch data if `enableAutoFetch` option is true', () => {
+        renderHook(() =>
+          useReturnPickupRescheduleRequest(returnId, rescheduleRequestId, {
+            enableAutoFetch: true,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        expect(mockFetchPickupRescheduleRequest).toHaveBeenCalledWith(
+          rescheduleRequestId,
+          returnId,
+          mockFetchConfig,
+        );
+      });
+
+      it('should not fetch data if `enableAutoFetch` option is false', () => {
+        renderHook(() =>
+          useReturnPickupRescheduleRequest(returnId, rescheduleRequestId, {
+            enableAutoFetch: false,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        expect(mockFetchPickupRescheduleRequest).not.toHaveBeenCalled();
+      });
+
+      it('should not fetch data if `enableAutoFetch` option is true and returnId parameter is not passed', () => {
+        renderHook(() =>
+          useReturnPickupRescheduleRequest(undefined, rescheduleRequestId, {
+            enableAutoFetch: false,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        expect(mockFetchPickupRescheduleRequest).not.toHaveBeenCalled();
+      });
+
+      it('should not fetch data if `enableAutoFetch` option is true and pickup reschedule request id parameter is not passed', () => {
+        renderHook(() =>
+          useReturnPickupRescheduleRequest(returnId, undefined, {
+            enableAutoFetch: false,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        expect(mockFetchPickupRescheduleRequest).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('actions', () => {
+    describe('fetch', () => {
+      it('should call `fetch` action with the return id and reschedule request id parameters passed to the hook if no parameters are passed to the function', () => {
+        const {
+          result: {
+            current: {
+              actions: { fetch },
+            },
+          },
+        } = renderHook(() =>
+          useReturnPickupRescheduleRequest(returnId, rescheduleRequestId, {
+            enableAutoFetch: false,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        fetch();
+
+        expect(mockFetchPickupRescheduleRequest).toHaveBeenCalledWith(
+          rescheduleRequestId,
+          returnId,
+          mockFetchConfig,
+        );
+      });
+
+      it('should call `fetch` action with the return id and reschedule request id parameters passed to the function', () => {
+        const {
+          result: {
+            current: {
+              actions: { fetch },
+            },
+          },
+        } = renderHook(() =>
+          useReturnPickupRescheduleRequest(undefined, undefined, {
+            enableAutoFetch: false,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        fetch(rescheduleRequestId, returnId);
+
+        expect(mockFetchPickupRescheduleRequest).toHaveBeenCalledWith(
+          rescheduleRequestId,
+          returnId,
+          mockFetchConfig,
+        );
+      });
+
+      it('should fail when return id parameters is not passed to both the hook and the function', () => {
+        const {
+          result: {
+            current: {
+              actions: { fetch },
+            },
+          },
+        } = renderHook(() =>
+          useReturnPickupRescheduleRequest(undefined, undefined, {
+            enableAutoFetch: false,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        return expect(fetch()).rejects.toThrow('No returnId provided');
+      });
+
+      it('should fail when reschedule request id parameters are not passed to both the hook and the function', () => {
+        const {
+          result: {
+            current: {
+              actions: { fetch },
+            },
+          },
+        } = renderHook(() =>
+          useReturnPickupRescheduleRequest(returnId, undefined, {
+            enableAutoFetch: false,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        return expect(fetch()).rejects.toThrow(
+          'No pickup reschedule request id provided',
+        );
+      });
+    });
+
+    describe('create', () => {
+      it('should call `create` from the `useReturnPickupRescheduleRequests` hook', async () => {
+        const {
+          result: {
+            current: {
+              actions: { create },
+            },
+          },
+        } = renderHook(() =>
+          useReturnPickupRescheduleRequest(returnId, rescheduleRequestId, {
+            enableAutoFetch: false,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        const anotherConfig = {};
+        const createPickupRescheduleData = {
+          timeWindow: {
+            start: '2022-11-23T13:18:58Z',
+            end: '2022-11-24T13:18:58Z',
+          },
+        };
+
+        await create(createPickupRescheduleData, returnId, anotherConfig);
+
+        expect(mockCreatePickupRescheduleRequestFn).toHaveBeenCalledWith(
+          createPickupRescheduleData,
+          returnId,
+          anotherConfig,
+        );
+      });
+    });
+  });
+});

--- a/packages/react/src/returns/hooks/__tests__/useReturnPickupRescheduleRequests.test.ts
+++ b/packages/react/src/returns/hooks/__tests__/useReturnPickupRescheduleRequests.test.ts
@@ -1,0 +1,469 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { flushPromises } from '../../../../tests/helpers';
+import {
+  getReturnPickupRescheduleRequest,
+  getReturnPickupRescheduleRequests,
+  postReturnPickupRescheduleRequest,
+  toBlackoutError,
+} from '@farfetch/blackout-client';
+import {
+  rescheduleRequestId,
+  responses,
+  returnId,
+} from 'tests/__fixtures__/returns';
+import { useReturnPickupRescheduleRequests } from '../../..';
+
+const mockReturnPickupReschedulesResponse =
+  responses.getReturnPickupRescheduleRequests.success;
+
+jest.mock('@farfetch/blackout-client', () => {
+  const original = jest.requireActual('@farfetch/blackout-client');
+
+  return {
+    ...original,
+    getReturnPickupRescheduleRequests: jest.fn(() =>
+      Promise.resolve(mockReturnPickupReschedulesResponse),
+    ),
+    postReturnPickupRescheduleRequest: jest.fn(),
+    getReturnPickupRescheduleRequest: jest.fn(() => ({
+      type: 'fetch_return_pickup_capability',
+    })),
+  };
+});
+
+const mockFetchPickupReschedulesError = toBlackoutError(
+  new Error('dummy error'),
+);
+
+const defaultReturnPickupReschedules = {
+  data: undefined,
+  isLoading: false,
+  isFetched: false,
+  error: null,
+  actions: {
+    fetch: expect.any(Function),
+    create: expect.any(Function),
+    fetchPickupRescheduleRequest: expect.any(Function),
+  },
+};
+
+const defaultReturnPickupReschedulesFetched = {
+  ...defaultReturnPickupReschedules,
+  isFetched: true,
+  data: [
+    {
+      id: '1654321',
+      status: 0,
+      timeWindow: {
+        end: '/Date(1574413200000)/',
+        start: '1574445600000',
+      },
+    },
+  ],
+};
+
+const mockFetchConfig = {
+  myCustomParameter: 10,
+};
+
+describe('useReturnPickupRescheduleRequests', () => {
+  beforeEach(jest.clearAllMocks);
+  afterEach(cleanup);
+
+  it('should return correctly with initial state and call all hook dependencies with the correct options', () => {
+    const {
+      result: { current },
+    } = renderHook(() =>
+      useReturnPickupRescheduleRequests(returnId, {
+        enableAutoFetch: false,
+        fetchConfig: mockFetchConfig,
+      }),
+    );
+
+    expect(current).toStrictEqual(defaultReturnPickupReschedules);
+
+    expect(getReturnPickupRescheduleRequests).not.toHaveBeenCalled();
+  });
+
+  it('should return correctly when the reschedule request is fetched', async () => {
+    const { result } = renderHook(() =>
+      useReturnPickupRescheduleRequests(returnId, {
+        enableAutoFetch: true,
+        fetchConfig: mockFetchConfig,
+      }),
+    );
+
+    // Awaits for the microtasks to finish so we can assure that all the promises
+    // were completed and the reference updated.
+    await act(() => flushPromises());
+
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupReschedulesFetched,
+    });
+  });
+
+  it('should return correctly when there is an error', async () => {
+    (getReturnPickupRescheduleRequests as jest.Mock).mockRejectedValueOnce(
+      mockFetchPickupReschedulesError,
+    );
+
+    const { result } = renderHook(() =>
+      useReturnPickupRescheduleRequests(returnId, {
+        enableAutoFetch: true,
+        fetchConfig: mockFetchConfig,
+      }),
+    );
+
+    // Awaits for the microtasks to finish so we can assure that all the promises
+    // were completed and the reference updated.
+    await act(() => flushPromises());
+
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupReschedules,
+      isFetched: true,
+      error: mockFetchPickupReschedulesError,
+    });
+  });
+
+  it('should return correctly when it is loading', () => {
+    const { result } = renderHook(() =>
+      useReturnPickupRescheduleRequests(returnId, {
+        enableAutoFetch: true,
+        fetchConfig: mockFetchConfig,
+      }),
+    );
+
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupReschedules,
+      isLoading: true,
+    });
+  });
+
+  it('should clear data if the hook is rerendered with different parameters than the current data it has', async () => {
+    const { result, rerender } = renderHook<unknown, { id: number }>(
+      ({ id }) =>
+        useReturnPickupRescheduleRequests(id, {
+          enableAutoFetch: true,
+          fetchConfig: mockFetchConfig,
+        }),
+      { initialProps: { id: returnId } },
+    );
+
+    // Awaits for the microtasks to finish so we can assure that all the promises
+    // were completed and the reference updated.
+    await act(() => flushPromises());
+
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupReschedulesFetched,
+      isFetched: true,
+    });
+
+    act(() => rerender({ id: returnId + 1 }));
+
+    expect(result.current).toStrictEqual({
+      ...defaultReturnPickupReschedules,
+      isLoading: true,
+    });
+  });
+
+  describe('options', () => {
+    describe('enableAutoFetch', () => {
+      it('should fetch data if `enableAutoFetch` option is not specified and returnId parameter is passed', () => {
+        renderHook(() =>
+          useReturnPickupRescheduleRequests(returnId, {
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        expect(getReturnPickupRescheduleRequests).toHaveBeenCalledWith(
+          returnId,
+          mockFetchConfig,
+        );
+      });
+
+      it('should fetch data if `enableAutoFetch` option is true', () => {
+        renderHook(() =>
+          useReturnPickupRescheduleRequests(returnId, {
+            enableAutoFetch: true,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        expect(getReturnPickupRescheduleRequests).toHaveBeenCalledWith(
+          returnId,
+          mockFetchConfig,
+        );
+      });
+
+      it('should fetch data if `enableAutoFetch` option is not passed', () => {
+        renderHook(() =>
+          useReturnPickupRescheduleRequests(returnId, {
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        expect(getReturnPickupRescheduleRequests).toHaveBeenCalledWith(
+          returnId,
+          mockFetchConfig,
+        );
+      });
+
+      it('should not fetch data if `enableAutoFetch` option is false', () => {
+        renderHook(() =>
+          useReturnPickupRescheduleRequests(returnId, {
+            enableAutoFetch: false,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        expect(getReturnPickupRescheduleRequests).not.toHaveBeenCalled();
+      });
+
+      it('should not fetch data if `enableAutoFetch` option is true and returnId parameter is not passed', () => {
+        renderHook(() =>
+          useReturnPickupRescheduleRequests(undefined, {
+            enableAutoFetch: false,
+            fetchConfig: mockFetchConfig,
+          }),
+        );
+
+        expect(getReturnPickupRescheduleRequests).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('actions', () => {
+      describe('fetch', () => {
+        it('should call `getReturnPickupRescheduleRequests` action with the return id parameter passed to the hook if no parameters are passed to the action', () => {
+          const {
+            result: {
+              current: {
+                actions: { fetch },
+              },
+            },
+          } = renderHook(() =>
+            useReturnPickupRescheduleRequests(returnId, {
+              enableAutoFetch: false,
+              fetchConfig: mockFetchConfig,
+            }),
+          );
+
+          fetch();
+
+          expect(getReturnPickupRescheduleRequests).toHaveBeenCalledWith(
+            returnId,
+            mockFetchConfig,
+          );
+        });
+
+        it('should call `getReturnPickupRescheduleRequests` action with the return id parameter passed to the action', () => {
+          const {
+            result: {
+              current: {
+                actions: { fetch },
+              },
+            },
+          } = renderHook(() =>
+            useReturnPickupRescheduleRequests(undefined, {
+              enableAutoFetch: false,
+              fetchConfig: mockFetchConfig,
+            }),
+          );
+
+          fetch(returnId);
+
+          expect(getReturnPickupRescheduleRequests).toHaveBeenCalledWith(
+            returnId,
+            mockFetchConfig,
+          );
+        });
+
+        it('should fail when return id parameter is not passed to both the hook and the function', () => {
+          const {
+            result: {
+              current: {
+                actions: { fetch },
+              },
+            },
+          } = renderHook(() =>
+            useReturnPickupRescheduleRequests(undefined, {
+              enableAutoFetch: false,
+              fetchConfig: mockFetchConfig,
+            }),
+          );
+
+          return expect(fetch()).rejects.toThrow('No returnId provided');
+        });
+      });
+
+      describe('create', () => {
+        it('should call `postReturnPickupRescheduleRequest` function with the return id parameter passed to the hook if no return id is passed to the action', async () => {
+          const {
+            result: {
+              current: {
+                actions: { create },
+              },
+            },
+          } = renderHook(() =>
+            useReturnPickupRescheduleRequests(returnId, {
+              enableAutoFetch: false,
+              fetchConfig: mockFetchConfig,
+            }),
+          );
+
+          const anotherConfig = {};
+          const createPickupRescheduleData = {
+            timeWindow: {
+              start: '2022-11-23T13:18:58Z',
+              end: '2022-11-24T13:18:58Z',
+            },
+          };
+
+          await create(createPickupRescheduleData, undefined, anotherConfig);
+
+          expect(postReturnPickupRescheduleRequest).toHaveBeenCalledWith(
+            returnId,
+            createPickupRescheduleData,
+            anotherConfig,
+          );
+        });
+
+        it('should call `postReturnPickupRescheduleRequest` function with the return id parameter passed to the action', async () => {
+          const {
+            result: {
+              current: {
+                actions: { create },
+              },
+            },
+          } = renderHook(() =>
+            useReturnPickupRescheduleRequests(undefined, {
+              enableAutoFetch: false,
+              fetchConfig: mockFetchConfig,
+            }),
+          );
+
+          const anotherConfig = {};
+          const createPickupRescheduleData = {
+            timeWindow: {
+              start: '2022-11-23T13:18:58Z',
+              end: '2022-11-24T13:18:58Z',
+            },
+          };
+
+          await create(createPickupRescheduleData, returnId, anotherConfig);
+
+          expect(postReturnPickupRescheduleRequest).toHaveBeenCalledWith(
+            returnId,
+            createPickupRescheduleData,
+            anotherConfig,
+          );
+        });
+
+        it('should fail when return id parameter is not passed to both the hook and the function', async () => {
+          const {
+            result: {
+              current: {
+                actions: { create },
+              },
+            },
+          } = renderHook(() =>
+            useReturnPickupRescheduleRequests(undefined, {
+              enableAutoFetch: false,
+              fetchConfig: mockFetchConfig,
+            }),
+          );
+
+          const anotherConfig = {};
+          const createPickupRescheduleData = {
+            timeWindow: {
+              start: '2022-11-23T13:18:58Z',
+              end: '2022-11-24T13:18:58Z',
+            },
+          };
+
+          return expect(
+            create(createPickupRescheduleData, undefined, anotherConfig),
+          ).rejects.toThrow('No returnId provided');
+        });
+      });
+
+      describe('fetchPickupRescheduleRequest', () => {
+        it('should call `getReturnPickupRescheduleRequest` action with the return id parameter passed to the hook if no return id is passed to the function', async () => {
+          const {
+            result: {
+              current: {
+                actions: { fetchPickupRescheduleRequest },
+              },
+            },
+          } = renderHook(() =>
+            useReturnPickupRescheduleRequests(returnId, {
+              enableAutoFetch: false,
+              fetchConfig: mockFetchConfig,
+            }),
+          );
+
+          await fetchPickupRescheduleRequest(
+            rescheduleRequestId,
+            undefined,
+            mockFetchConfig,
+          );
+
+          expect(getReturnPickupRescheduleRequest).toHaveBeenCalledWith(
+            returnId,
+            rescheduleRequestId,
+            mockFetchConfig,
+          );
+        });
+
+        it('should call `getReturnPickupRescheduleRequest` action with the return id parameter passed to the function', async () => {
+          const {
+            result: {
+              current: {
+                actions: { fetchPickupRescheduleRequest },
+              },
+            },
+          } = renderHook(() =>
+            useReturnPickupRescheduleRequests(undefined, {
+              enableAutoFetch: false,
+              fetchConfig: mockFetchConfig,
+            }),
+          );
+
+          await fetchPickupRescheduleRequest(
+            rescheduleRequestId,
+            returnId,
+            mockFetchConfig,
+          );
+
+          expect(getReturnPickupRescheduleRequest).toHaveBeenCalledWith(
+            returnId,
+            rescheduleRequestId,
+            mockFetchConfig,
+          );
+        });
+
+        it('should fail when return id parameter is not passed to both the hook and the function', async () => {
+          const {
+            result: {
+              current: {
+                actions: { fetchPickupRescheduleRequest },
+              },
+            },
+          } = renderHook(() =>
+            useReturnPickupRescheduleRequests(undefined, {
+              enableAutoFetch: false,
+              fetchConfig: mockFetchConfig,
+            }),
+          );
+
+          return expect(
+            fetchPickupRescheduleRequest(
+              rescheduleRequestId,
+              undefined,
+              mockFetchConfig,
+            ),
+          ).rejects.toThrow('No returnId provided');
+        });
+      });
+    });
+  });
+});

--- a/packages/react/src/returns/hooks/index.ts
+++ b/packages/react/src/returns/hooks/index.ts
@@ -1,4 +1,6 @@
 export { default as useReturn } from './useReturn';
 export { default as useReturnPickupCapability } from './useReturnPickupCapability';
+export { default as useReturnPickupRescheduleRequest } from './useReturnPickupRescheduleRequest';
+export { default as useReturnPickupRescheduleRequests } from './useReturnPickupRescheduleRequests';
 
 export * from './types';

--- a/packages/react/src/returns/hooks/types/index.ts
+++ b/packages/react/src/returns/hooks/types/index.ts
@@ -1,2 +1,4 @@
 export * from './useReturn';
 export * from './useReturnPickupCapability';
+export * from './useReturnPickupRescheduleRequest';
+export * from './useReturnPickupRescheduleRequests';

--- a/packages/react/src/returns/hooks/types/useReturnPickupRescheduleRequest.ts
+++ b/packages/react/src/returns/hooks/types/useReturnPickupRescheduleRequest.ts
@@ -1,0 +1,6 @@
+import type { Config } from '@farfetch/blackout-client';
+
+export type UseReturnPickupRescheduleRequestOptions = {
+  enableAutoFetch?: boolean;
+  fetchConfig?: Config;
+};

--- a/packages/react/src/returns/hooks/types/useReturnPickupRescheduleRequests.ts
+++ b/packages/react/src/returns/hooks/types/useReturnPickupRescheduleRequests.ts
@@ -1,0 +1,6 @@
+import type { Config } from '@farfetch/blackout-client';
+
+export type UseReturnPickupRescheduleRequestsOptions = {
+  enableAutoFetch?: boolean;
+  fetchConfig?: Config;
+};

--- a/packages/react/src/returns/hooks/useReturn.ts
+++ b/packages/react/src/returns/hooks/useReturn.ts
@@ -21,6 +21,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import useAction from '../../helpers/useAction';
 import useReturnPickupCapability from './useReturnPickupCapability';
+import useReturnPickupRescheduleRequests from './useReturnPickupRescheduleRequests';
 import type { UseReturnOptions } from './types';
 
 /**
@@ -172,7 +173,7 @@ function useReturn(returnId?: Return['id'], options: UseReturnOptions = {}) {
   }
 
   // We can only export the actions here since the pickupDay parameter
-  // will be always undefined, so the pickup capability state can never
+  // will always be undefined, so the pickup capability state can never
   // be fetched correctly from the hook.
   const {
     actions: { fetch: fetchPickupCapability, reset: resetPickupCapability },
@@ -180,15 +181,31 @@ function useReturn(returnId?: Return['id'], options: UseReturnOptions = {}) {
     enableAutoFetch: false,
   });
 
+  const {
+    data: pickupRescheduleRequests,
+    isLoading: arePickupRescheduleRequestsLoading,
+    error: pickupRescheduleRequestsError,
+    actions: {
+      fetch: fetchPickupRescheduleRequests,
+      create: createPickupRescheduleRequest,
+      fetchPickupRescheduleRequest,
+    },
+  } = useReturnPickupRescheduleRequests(implicitReturnId, {
+    enableAutoFetch: false,
+  });
+
   const data = useMemo(() => {
-    if (!returnEntity) {
+    const hasAnyData = returnEntity || pickupRescheduleRequests;
+
+    if (!hasAnyData) {
       return undefined;
     }
 
     return {
       ...returnEntity,
+      pickupRescheduleRequests,
     };
-  }, [returnEntity]);
+  }, [returnEntity, pickupRescheduleRequests]);
 
   useEffect(() => {
     if (!isLoading && !isFetched && enableAutoFetch && returnIdHookParameter) {
@@ -204,11 +221,16 @@ function useReturn(returnId?: Return['id'], options: UseReturnOptions = {}) {
       create,
       fetchPickupCapability,
       resetPickupCapability,
+      fetchPickupRescheduleRequests,
+      createPickupRescheduleRequest,
+      fetchPickupRescheduleRequest,
     },
     data,
     returnError: error,
     isReturnLoading: isLoading,
     isReturnFetched: isFetched,
+    arePickupRescheduleRequestsLoading,
+    pickupRescheduleRequestsError,
   };
 }
 

--- a/packages/react/src/returns/hooks/useReturnPickupRescheduleRequest.ts
+++ b/packages/react/src/returns/hooks/useReturnPickupRescheduleRequest.ts
@@ -1,0 +1,290 @@
+import {
+  BlackoutError,
+  Config,
+  getReturnPickupRescheduleRequest,
+  PickupRescheduleRequest,
+  Return,
+} from '@farfetch/blackout-client';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import useReturnPickupRescheduleRequests from './useReturnPickupRescheduleRequests';
+import type { UseReturnPickupRescheduleRequestOptions } from './types';
+
+const actionTypes = {
+  FetchPickupRescheduleRequestRequest:
+    'FETCH_PICKUP_RESCHEDULE_REQUEST_REQUEST',
+  FetchPickupRescheduleRequestSuccess:
+    'FETCH_PICKUP_RESCHEDULE_REQUEST_SUCCESS',
+  FetchPickupRescheduleRequestFailure:
+    'FETCH_PICKUP_RESCHEDULE_REQUEST_FAILURE',
+  ClearPickupRescheduleRequestState: 'CLEAR_PICKUP_RESCHEDULE_REQUEST_STATE',
+} as const;
+
+type State = {
+  isLoading: boolean;
+  error: BlackoutError | null;
+  result?: PickupRescheduleRequest;
+  currentRequestId: number;
+  currentReturnId: Return['id'];
+  currentPickupRescheduleRequestId: PickupRescheduleRequest['id'];
+} | null;
+
+type FetchActionBase = {
+  meta: {
+    requestId: number;
+    returnId: Return['id'];
+    pickupRescheduleRequestId: PickupRescheduleRequest['id'];
+    isSyncedWithHookParams: boolean;
+  };
+};
+
+type FetchPickupRescheduleRequestRequestAction = FetchActionBase & {
+  type: typeof actionTypes.FetchPickupRescheduleRequestRequest;
+};
+
+type FetchPickupRescheduleRequestSuccessAction = FetchActionBase & {
+  type: typeof actionTypes.FetchPickupRescheduleRequestSuccess;
+  payload: PickupRescheduleRequest;
+};
+
+type FetchPickupRescheduleRequestFailureAction = FetchActionBase & {
+  type: typeof actionTypes.FetchPickupRescheduleRequestFailure;
+  payload: BlackoutError;
+};
+
+type ClearPickupRescheduleRequestStateAction = {
+  type: typeof actionTypes.ClearPickupRescheduleRequestState;
+};
+
+type Action =
+  | FetchPickupRescheduleRequestFailureAction
+  | FetchPickupRescheduleRequestRequestAction
+  | FetchPickupRescheduleRequestSuccessAction
+  | ClearPickupRescheduleRequestStateAction;
+
+const initialState: State = null;
+
+function reducer(state: State, action: Action) {
+  switch (action.type) {
+    case actionTypes.FetchPickupRescheduleRequestRequest: {
+      const isSyncedWithHookParams = action.meta.isSyncedWithHookParams;
+
+      if (!isSyncedWithHookParams) {
+        return state;
+      }
+
+      const actionReturnId = action.meta.returnId;
+      const actionPickupRescheduleRequestId =
+        action.meta.pickupRescheduleRequestId;
+
+      const newState = {
+        isLoading: true,
+        error: null,
+        currentRequestId: action.meta.requestId,
+        currentReturnId: action.meta.returnId,
+        currentPickupRescheduleRequestId: action.meta.pickupRescheduleRequestId,
+        // If the action is requesting data for the same return and
+        // pickup reschedule request, keep the previous result on the
+        // state, otherwise set it to undefined.
+        result:
+          actionReturnId === state?.currentReturnId &&
+          actionPickupRescheduleRequestId ===
+            state?.currentPickupRescheduleRequestId
+            ? state.result
+            : undefined,
+      };
+
+      return newState;
+    }
+    case actionTypes.FetchPickupRescheduleRequestSuccess: {
+      // Do not update the state if:
+      // - the returnId and pickupRescheduleRequestId from the action are not equal to the returnId and pickupRescheduleRequestId parameters from the hook.
+      // - the returnId and pickupRescheduleRequestId from the action are not equal to the returnId and pickupRescheduleRequestId from the state (set on the request action dispatch).
+      // - the returnIds/pickupRescheduleRequestIds are the same but the requestId from the action is not the same from the state (set on the request action dispatch).
+      if (
+        !action.meta.isSyncedWithHookParams ||
+        !state ||
+        state.currentRequestId !== action.meta.requestId ||
+        state.currentReturnId !== action.meta.returnId ||
+        state.currentPickupRescheduleRequestId !==
+          action.meta.pickupRescheduleRequestId
+      ) {
+        return state;
+      }
+
+      const newState = {
+        ...state,
+        isLoading: false,
+        result: action.payload,
+      };
+
+      return newState;
+    }
+    case actionTypes.FetchPickupRescheduleRequestFailure: {
+      // Do not update the state if:
+      // - the returnId and pickupRescheduleRequestId from the action are not equal to the returnId and pickupRescheduleRequestId parameters from the hook.
+      // - the returnId and pickupRescheduleRequestId from the action are not equal to the returnId and pickupRescheduleRequestId from the state (set on the request action dispatch).
+      // - the returnIds/pickupRescheduleRequestIds are the same but the requestId from the action is not the same from the state (set on the request action dispatch).
+      if (
+        !action.meta.isSyncedWithHookParams ||
+        !state ||
+        state.currentRequestId !== action.meta.requestId ||
+        state.currentReturnId !== action.meta.returnId ||
+        state.currentPickupRescheduleRequestId !==
+          action.meta.pickupRescheduleRequestId
+      ) {
+        return state;
+      }
+
+      const newState = {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+      };
+
+      return newState;
+    }
+    case actionTypes.ClearPickupRescheduleRequestState: {
+      return initialState;
+    }
+    default:
+      return state;
+  }
+}
+
+function useReturnPickupRescheduleRequest(
+  returnId?: Return['id'],
+  pickupRescheduleRequestId?: PickupRescheduleRequest['id'],
+  options: UseReturnPickupRescheduleRequestOptions = {},
+) {
+  const { enableAutoFetch = true, fetchConfig } = options;
+  const currentRequestId = useRef(0);
+  const returnIdHookParameter = returnId;
+  const pickupRescheduleRequestIdHookParameter = pickupRescheduleRequestId;
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const returnIdRequestState =
+    returnIdHookParameter === state?.currentReturnId &&
+    pickupRescheduleRequestIdHookParameter ===
+      state?.currentPickupRescheduleRequestId
+      ? state
+      : undefined;
+
+  const isLoading = returnIdRequestState?.isLoading || false;
+  const error = returnIdRequestState?.error || null;
+  const data = returnIdRequestState?.result;
+  const isFetched = !!(data || error) && !isLoading;
+
+  const {
+    actions: { create, fetchPickupRescheduleRequest },
+  } = useReturnPickupRescheduleRequests(returnId, { enableAutoFetch: false });
+
+  const fetch = useCallback(
+    (
+      pickupRescheduleRequestId:
+        | PickupRescheduleRequest['id']
+        | undefined = pickupRescheduleRequestIdHookParameter,
+      returnId: Return['id'] | undefined = returnIdHookParameter,
+      config: Config | undefined = fetchConfig,
+    ) => {
+      if (!returnId) {
+        return Promise.reject(new Error('No returnId provided'));
+      }
+
+      if (!pickupRescheduleRequestId) {
+        return Promise.reject(
+          new Error('No pickup reschedule request id provided'),
+        );
+      }
+
+      const isSyncedWithHookParams =
+        returnId === returnIdHookParameter &&
+        pickupRescheduleRequestId === pickupRescheduleRequestIdHookParameter;
+      const requestId = currentRequestId.current++;
+      const actionMetadata = {
+        returnId,
+        requestId,
+        pickupRescheduleRequestId,
+        isSyncedWithHookParams,
+      };
+
+      dispatch({
+        type: actionTypes.FetchPickupRescheduleRequestRequest,
+        meta: actionMetadata,
+      });
+
+      fetchPickupRescheduleRequest(
+        pickupRescheduleRequestId,
+        returnId,
+        config,
+      ).then(
+        pickupRescheduleRequest => {
+          dispatch({
+            type: actionTypes.FetchPickupRescheduleRequestSuccess,
+            meta: actionMetadata,
+            payload: pickupRescheduleRequest,
+          });
+        },
+        e => {
+          dispatch({
+            type: actionTypes.FetchPickupRescheduleRequestFailure,
+            meta: actionMetadata,
+            payload: e,
+          });
+        },
+      );
+
+      return getReturnPickupRescheduleRequest;
+    },
+    [
+      fetchConfig,
+      fetchPickupRescheduleRequest,
+      pickupRescheduleRequestIdHookParameter,
+      returnIdHookParameter,
+    ],
+  );
+
+  // If the state contains data that does not match the parameters
+  // from this hook render, dispatch a clear state action to reset
+  // the local state. This will rerender the hook automatically but will
+  // prevent the rerender of children if this was only done in a useEffect.
+  if (
+    state?.currentReturnId &&
+    state?.currentPickupRescheduleRequestId &&
+    (returnIdHookParameter !== state?.currentReturnId ||
+      pickupRescheduleRequestIdHookParameter !==
+        state?.currentPickupRescheduleRequestId)
+  ) {
+    dispatch({ type: actionTypes.ClearPickupRescheduleRequestState });
+  }
+
+  useEffect(() => {
+    if (
+      !isLoading &&
+      !isFetched &&
+      enableAutoFetch &&
+      returnIdHookParameter &&
+      pickupRescheduleRequestIdHookParameter
+    ) {
+      fetch();
+    }
+  }, [
+    enableAutoFetch,
+    fetch,
+    isFetched,
+    isLoading,
+    returnIdHookParameter,
+    pickupRescheduleRequestIdHookParameter,
+  ]);
+
+  return {
+    isLoading,
+    isFetched,
+    error,
+    data,
+    actions: {
+      fetch,
+      create,
+    },
+  };
+}
+
+export default useReturnPickupRescheduleRequest;

--- a/packages/react/src/returns/hooks/useReturnPickupRescheduleRequests.ts
+++ b/packages/react/src/returns/hooks/useReturnPickupRescheduleRequests.ts
@@ -1,0 +1,263 @@
+import {
+  BlackoutError,
+  Config,
+  getReturnPickupRescheduleRequest,
+  getReturnPickupRescheduleRequests,
+  PickupRescheduleRequest,
+  PickupRescheduleRequests,
+  postReturnPickupRescheduleRequest,
+  PostReturnPickupRescheduleRequestData,
+  Return,
+} from '@farfetch/blackout-client';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import type { UseReturnPickupRescheduleRequestsOptions } from './types';
+
+const actionTypes = {
+  FetchPickupRescheduleRequestsRequest:
+    'FETCH_PICKUP_RESCHEDULE_REQUESTS_REQUEST',
+  FetchPickupRescheduleRequestsSuccess:
+    'FETCH_PICKUP_RESCHEDULE_REQUESTS_SUCCESS',
+  FetchPickupRescheduleRequestsFailure:
+    'FETCH_PICKUP_RESCHEDULE_REQUESTS_FAILURE',
+  ClearPickupRescheduleRequestsState: 'CLEAR_PICKUP_RESCHEDULE_REQUESTS_STATE',
+} as const;
+
+type State = {
+  isLoading: boolean;
+  error: BlackoutError | null;
+  result?: PickupRescheduleRequests;
+  currentRequestId: number;
+  currentReturnId: Return['id'];
+} | null;
+
+type FetchActionBase = {
+  meta: {
+    requestId: number;
+    returnId: Return['id'];
+    isSyncedWithHookParams: boolean;
+  };
+};
+
+type FetchPickupRescheduleRequestsRequestAction = FetchActionBase & {
+  type: typeof actionTypes.FetchPickupRescheduleRequestsRequest;
+};
+
+type FetchPickupRescheduleRequestsSuccessAction = FetchActionBase & {
+  type: typeof actionTypes.FetchPickupRescheduleRequestsSuccess;
+  payload: PickupRescheduleRequests;
+};
+
+type FetchPickupRescheduleRequestsFailureAction = FetchActionBase & {
+  type: typeof actionTypes.FetchPickupRescheduleRequestsFailure;
+  payload: BlackoutError;
+};
+
+type ClearPickupRescheduleRequestsStateAction = {
+  type: typeof actionTypes.ClearPickupRescheduleRequestsState;
+};
+
+type Action =
+  | FetchPickupRescheduleRequestsFailureAction
+  | FetchPickupRescheduleRequestsRequestAction
+  | FetchPickupRescheduleRequestsSuccessAction
+  | ClearPickupRescheduleRequestsStateAction;
+
+const initialState: State = null;
+
+function reducer(state: State, action: Action) {
+  switch (action.type) {
+    case actionTypes.FetchPickupRescheduleRequestsRequest: {
+      const isSyncedWithHookParams = action.meta.isSyncedWithHookParams;
+
+      if (!isSyncedWithHookParams) {
+        return state;
+      }
+
+      const actionReturnId = action.meta.returnId;
+
+      const newState = {
+        isLoading: true,
+        error: null,
+        currentRequestId: action.meta.requestId,
+        currentReturnId: action.meta.returnId,
+        // If the action is requesting data for the same return
+        // keep the previous result on the state, otherwise
+        // set it to undefined.
+        result:
+          actionReturnId === state?.currentReturnId ? state.result : undefined,
+      };
+
+      return newState;
+    }
+    case actionTypes.FetchPickupRescheduleRequestsSuccess: {
+      // Do not update the state if:
+      // - the returnId from the action is not equal to the returnId parameter from the hook.
+      // - the returnId from the action is not equal to the returnId from the state (set on the request action dispatch).
+      // - the returnIds are the same but the requestId from the action is not the same from the state (set on the request action dispatch).
+      if (
+        !action.meta.isSyncedWithHookParams ||
+        !state ||
+        state.currentRequestId !== action.meta.requestId ||
+        state.currentReturnId !== action.meta.returnId
+      ) {
+        return state;
+      }
+
+      const newState = {
+        ...state,
+        isLoading: false,
+        result: action.payload,
+      };
+
+      return newState;
+    }
+    case actionTypes.FetchPickupRescheduleRequestsFailure: {
+      // Do not update the state if:
+      // - the returnId from the action is not equal to the returnId parameter from the hook.
+      // - the returnId from the action is not equal to the returnId from the state (set on the request action dispatch).
+      // - the returnIds are the same but the requestId from the action is not the same from the state (set on the request action dispatch).
+      if (
+        !action.meta.isSyncedWithHookParams ||
+        !state ||
+        state.currentRequestId !== action.meta.requestId ||
+        state.currentReturnId !== action.meta.returnId
+      ) {
+        return state;
+      }
+
+      const newState = {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+      };
+
+      return newState;
+    }
+    case actionTypes.ClearPickupRescheduleRequestsState: {
+      return initialState;
+    }
+    default:
+      return state;
+  }
+}
+
+function useReturnPickupRescheduleRequests(
+  returnId?: Return['id'],
+  options: UseReturnPickupRescheduleRequestsOptions = {},
+) {
+  const { enableAutoFetch = true, fetchConfig } = options;
+  const currentRequestId = useRef(0);
+  const returnIdHookParameter = returnId;
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const returnIdRequestState =
+    returnIdHookParameter === state?.currentReturnId ? state : undefined;
+  const isLoading = returnIdRequestState?.isLoading || false;
+  const error = returnIdRequestState?.error || null;
+  const data = returnIdRequestState?.result;
+  const isFetched = !!(data || error) && !isLoading;
+
+  const fetch = useCallback(
+    (
+      returnId: Return['id'] | undefined = returnIdHookParameter,
+      config: Config | undefined = fetchConfig,
+    ) => {
+      if (!returnId) {
+        return Promise.reject(new Error('No returnId provided'));
+      }
+
+      const isSyncedWithHookParams = returnId === returnIdHookParameter;
+      const requestId = currentRequestId.current++;
+      const actionMetadata = { returnId, requestId, isSyncedWithHookParams };
+
+      dispatch({
+        type: actionTypes.FetchPickupRescheduleRequestsRequest,
+        meta: actionMetadata,
+      });
+
+      getReturnPickupRescheduleRequests(returnId, config).then(
+        pickupRescheduleRequests => {
+          dispatch({
+            type: actionTypes.FetchPickupRescheduleRequestsSuccess,
+            meta: actionMetadata,
+            payload: pickupRescheduleRequests,
+          });
+        },
+        e => {
+          dispatch({
+            type: actionTypes.FetchPickupRescheduleRequestsFailure,
+            meta: actionMetadata,
+            payload: e,
+          });
+        },
+      );
+
+      return getReturnPickupRescheduleRequests;
+    },
+    [fetchConfig, returnIdHookParameter],
+  );
+
+  const create = useCallback(
+    (
+      data: PostReturnPickupRescheduleRequestData,
+      returnId: Return['id'] | undefined = returnIdHookParameter,
+      config?: Config,
+    ) => {
+      if (!returnId) {
+        return Promise.reject(new Error('No returnId provided'));
+      }
+
+      return postReturnPickupRescheduleRequest(returnId, data, config);
+    },
+    [returnIdHookParameter],
+  );
+
+  const fetchPickupRescheduleRequest = useCallback(
+    (
+      rescheduleRequestId: PickupRescheduleRequest['id'],
+      returnId: Return['id'] | undefined = returnIdHookParameter,
+      config?: Config,
+    ) => {
+      if (!returnId) {
+        return Promise.reject(new Error('No returnId provided'));
+      }
+
+      return getReturnPickupRescheduleRequest(
+        returnId,
+        rescheduleRequestId,
+        config,
+      );
+    },
+    [returnIdHookParameter],
+  );
+
+  // If the state contains data that does not match the parameters
+  // from this hook render, dispatch a clear state action to reset
+  // the local state. This will rerender the hook automatically but will
+  // prevent the rerender of children if this was only done in a useEffect.
+  if (
+    state?.currentReturnId &&
+    returnIdHookParameter !== state?.currentReturnId
+  ) {
+    dispatch({ type: actionTypes.ClearPickupRescheduleRequestsState });
+  }
+
+  useEffect(() => {
+    if (!isLoading && !isFetched && enableAutoFetch && returnIdHookParameter) {
+      fetch();
+    }
+  }, [enableAutoFetch, fetch, isFetched, isLoading, returnIdHookParameter]);
+
+  return {
+    isLoading,
+    isFetched,
+    error,
+    data,
+    actions: {
+      fetch,
+      create,
+      fetchPickupRescheduleRequest,
+    },
+  };
+}
+
+export default useReturnPickupRescheduleRequests;

--- a/packages/react/tests/helpers/flushPromises.ts
+++ b/packages/react/tests/helpers/flushPromises.ts
@@ -1,3 +1,3 @@
 export default function flushPromises() {
-  return new Promise(resolve => setImmediate(resolve));
+  return new Promise(setImmediate);
 }

--- a/packages/redux/src/returns/actions/factories/createReturnPickupRescheduleRequestFactory.ts
+++ b/packages/redux/src/returns/actions/factories/createReturnPickupRescheduleRequestFactory.ts
@@ -1,8 +1,8 @@
 import * as actionTypes from '../../actionTypes';
 import {
   Config,
-  PickupRescheduleRequest,
   PostReturnPickupRescheduleRequest,
+  PostReturnPickupRescheduleRequestData,
   Return,
   toBlackoutError,
 } from '@farfetch/blackout-client';
@@ -17,7 +17,11 @@ import type { Dispatch } from 'redux';
  */
 const createReturnPickupRescheduleRequestFactory =
   (postReturnPickupRescheduleRequest: PostReturnPickupRescheduleRequest) =>
-  (id: Return['id'], data: PickupRescheduleRequest, config?: Config) =>
+  (
+    id: Return['id'],
+    data: PostReturnPickupRescheduleRequestData,
+    config?: Config,
+  ) =>
   async (dispatch: Dispatch): Promise<number> => {
     dispatch({
       type: actionTypes.CREATE_RETURN_PICKUP_RESCHEDULE_REQUEST_REQUEST,

--- a/tests/__fixtures__/returns/returns.fixtures.ts
+++ b/tests/__fixtures__/returns/returns.fixtures.ts
@@ -17,7 +17,7 @@ export const returnTimeWindowData = {
 };
 
 export const getReturnPickupRescheduleRequestsData = {
-  id: '',
+  id: rescheduleRequestId,
   timeWindow: returnTimeWindowData,
   status: RescheduleStatus.InProgress,
 };


### PR DESCRIPTION
## Description

- This add the hooks useReturnPickupRescheduleRequests and useReturnPickupRescheduleRequest to
manage return pickup reschedule requests.
- Adds some types fixing as well.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
