### PR TITLE
fix(react): remove useSeoMedata default app links and fix useProductD…

### DIFF
--- a/packages/react/src/contents/hooks/__tests__/useSeoMetadata.test.tsx
+++ b/packages/react/src/contents/hooks/__tests__/useSeoMetadata.test.tsx
@@ -9,8 +9,8 @@ import {
   result,
   resultNoSocialMeta,
 } from './__fixtures__/useSeoMetadata.fixtures';
-import { withStore } from '../../../../tests/helpers';
 import { useSeoMetadata } from '..';
+import { withStore } from '../../../../tests/helpers';
 
 jest.mock('@farfetch/blackout-redux', () => {
   const original = jest.requireActual('@farfetch/blackout-redux');
@@ -20,11 +20,6 @@ jest.mock('@farfetch/blackout-redux', () => {
     fetchSEOMetadata: jest.fn(() => ({ type: 'foo-bar' })),
   };
 });
-
-jest.mock('../../utils/seoMetadata', () => ({
-  ...jest.requireActual('../../utils/seoMetadata'),
-  getDefaultAppLinks: () => mockDefaultAppLinks,
-}));
 
 describe('useSeoMetadata', () => {
   beforeEach(() => {
@@ -57,7 +52,10 @@ describe('useSeoMetadata', () => {
   });
 
   it('should return data', () => {
-    const props = { query };
+    const props = {
+      query,
+      appIconLinks: mockDefaultAppLinks,
+    };
 
     const {
       result: { current },
@@ -69,7 +67,7 @@ describe('useSeoMetadata', () => {
   });
 
   it('should return no social metatags', () => {
-    const props = { query };
+    const props = { query, appIconLinks: mockDefaultAppLinks };
 
     const {
       result: { current },

--- a/packages/react/src/contents/hooks/useSeoMetadata.ts
+++ b/packages/react/src/contents/hooks/useSeoMetadata.ts
@@ -1,4 +1,4 @@
-import { buildLinks, buildMetas, getDefaultAppLinks } from '../utils';
+import { buildLinks, buildMetas } from '../utils';
 import {
   fetchSEOMetadata,
   getSEOMetadataError,
@@ -28,7 +28,7 @@ import type { UseSeoMetadataOptions } from './types/useSeoMetadataOptions.types'
 const useSeoMetadata = (
   {
     query,
-    appIconLinks = getDefaultAppLinks(),
+    appIconLinks = {},
     links = [],
     metas = [],
   }: {

--- a/packages/react/src/contents/utils/seoMetadata.ts
+++ b/packages/react/src/contents/utils/seoMetadata.ts
@@ -108,28 +108,3 @@ export const buildIconLinks = ({
 
   return [...regularIconsProps, ...appleIconsProps, ...maskIconProps];
 };
-
-export const getDefaultAppLinks = () => {
-  return {
-    appleIcons: [
-      {
-        href: require('shared/media/favicon/apple-touch-icon.png'),
-        sizes: '180x180',
-      },
-    ],
-    icons: [
-      {
-        href: require('shared/media/favicon/favicon-16x16.png'),
-        sizes: '16x16',
-      },
-      {
-        href: require('shared/media/favicon/favicon-32x32.png'),
-        sizes: '32x32',
-      },
-    ],
-    maskIcon: {
-      color: '#5bbad5',
-      href: require('shared/media/favicon/safari-pinned-tab.svg'),
-    },
-  };
-};

--- a/packages/react/src/products/hooks/useProductDetails.ts
+++ b/packages/react/src/products/hooks/useProductDetails.ts
@@ -56,7 +56,8 @@ const useProductDetails = (
     [fetchAction, productId, fetchQuery, fetchForceDispatch, fetchConfig],
   );
 
-  const shouldLoadDetails = enableAutoFetch && !isLoading && !error && !product;
+  const shouldLoadDetails =
+    enableAutoFetch && !isLoading && !error && !isFetched;
 
   useEffect(() => {
     shouldLoadDetails &&


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
-->
- Remove `getDefaultAppLinks` to avoid breaking the storybook and leave up to each tenant the creation of a default with the correct existing paths
- Change `useProductDetails` `shouldLoadDetails` condition to allow a product's details to be fetched even if the product exists on the store (i.e. when navigating from a PLP to a PDP, the product might exist but it doesn't have the necessary details)

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
