### PR TITLE
fix(redux): fix analytics' setUser middleware on logout action - Next

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -430,13 +430,13 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
   },
   [eventTypes.CHECKOUT_STARTED]: data => ({
     tid: 2918,
-    basketValue: data.properties.total,
-    basketCurrency: data.properties.currency,
+    basketValue: data.properties?.total,
+    basketCurrency: data.properties?.currency,
     lineItems: getProductLineItems(data),
   }),
   [eventTypes.CHECKOUT_STEP_EDITING]: data => ({
     tid: 2923,
-    checkoutStep: data.properties.step,
+    checkoutStep: data.properties?.step,
   }),
   [eventTypes.PAYMENT_INFO_ADDED]: data => ({
     ...getCommonCheckoutStepTrackingData(data),
@@ -530,8 +530,8 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
 
     if (!properties?.contentType || !properties?.id) {
       logger.error(
-        `[Omnitracking] - Event ${data.event} properties "contentType" and "id" should be sent 
-                        on the payload when triggering a "select content" event. If you want to track this 
+        `[Omnitracking] - Event ${data.event} properties "contentType" and "id" should be sent
+                        on the payload when triggering a "select content" event. If you want to track this
                         event, make sure to pass these two properties.`,
       );
       return undefined;
@@ -566,8 +566,8 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
 
     if (!data.properties?.contentType || !data.properties?.id) {
       logger.error(
-        `[Omnitracking] - Event ${data.event} properties "contentType" and "id" should be sent 
-                        on the payload when triggering a "select content" event. If you want to track this 
+        `[Omnitracking] - Event ${data.event} properties "contentType" and "id" should be sent
+                        on the payload when triggering a "select content" event. If you want to track this
                         event, make sure to pass these two properties.`,
       );
       return;
@@ -689,14 +689,14 @@ export const pageEventsMapper: Readonly<OmnitrackingPageEventsMapper> = {
     viewType: 'Wishlist',
     viewSubType: 'Wishlist',
     lineItems: getProductLineItems(data),
-    wishlistQuantity: getProductLineItemsQuantity(data.properties.products),
+    wishlistQuantity: getProductLineItemsQuantity(data.properties?.products),
   }),
   [pageTypes.BAG]: data => ({
     viewType: 'Shopping Bag',
     viewSubType: 'Bag',
     lineItems: getProductLineItems(data),
-    basketQuantity: getProductLineItemsQuantity(data.properties.products),
-    basketValue: data.properties.value,
+    basketQuantity: getProductLineItemsQuantity(data.properties?.products),
+    basketValue: data.properties?.value,
   }),
 };
 

--- a/packages/redux/src/analytics/middlewares/setUser.ts
+++ b/packages/redux/src/analytics/middlewares/setUser.ts
@@ -24,7 +24,6 @@ export const DEFAULT_TRIGGER_SET_USER_ACTION_TYPES = new Set([
 
 export const DEFAULT_TRIGGER_ANONYMIZE_ACTION_TYPES = new Set([
   authenticationActionTypes.LOGOUT_SUCCESS,
-  usersActionTypes.FETCH_USER_FAILURE,
 ]);
 
 // Default user traits picker
@@ -211,10 +210,14 @@ export function analyticsSetUserMiddleware(
               : undefined;
 
           if (eventTypeToTrack) {
-            analyticsInstance.track(eventTypeToTrack, eventPayload);
+            await analyticsInstance.track(eventTypeToTrack, eventPayload);
           }
         } else if (!previousIsGuest && isGuest) {
-          analyticsInstance.track(eventTypes.LOGOUT);
+          await analyticsInstance.track(eventTypes.LOGOUT);
+
+          await analyticsInstance.anonymize();
+
+          currentUser = undefined;
         }
       }
 
@@ -222,7 +225,10 @@ export function analyticsSetUserMiddleware(
     }
 
     if (triggerAnonymizeActions.has(actionType)) {
+      await analyticsInstance.track(eventTypes.LOGOUT);
+
       await analyticsInstance.anonymize();
+
       currentUser = undefined;
     }
 


### PR DESCRIPTION
## Description
This PR fixes a bug when the user manually logs out.
The LOGOUT event was only being triggered when the user session expired.
Now it will be correctly triggered in that case and when the user manually logs out, or when the GET_PROFILE action fails.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
