### PR TITLE
fix(react): fix add/update bag item errors in useBag hook

### DIFF
--- a/packages/react/src/bags/hooks/errors/index.ts
+++ b/packages/react/src/bags/hooks/errors/index.ts
@@ -9,3 +9,22 @@ export class SizeError extends Error {
     super('Invalid size id.');
   }
 }
+
+export class AddUpdateItemBagError extends Error {
+  constructor(public code: number) {
+    const message =
+      code === 3
+        ? 'No stock available for this item'
+        : 'Missing stock information';
+    super(message);
+  }
+}
+
+export class BagItemNotFoundError extends Error {
+  code: number;
+
+  constructor() {
+    super('Bag item not found');
+    this.code = 1;
+  }
+}

--- a/tests/__fixtures__/bags/bag.fixtures.ts
+++ b/tests/__fixtures__/bags/bag.fixtures.ts
@@ -7,9 +7,11 @@ import { mockBagItemEntity, mockBagItemId } from './bagItem.fixtures';
 import {
   mockProductEntity,
   mockProductId,
+  mockProductSizeAdapted,
   mockProductSizes,
   mockProductTypeToExclude,
 } from '../products';
+import type { SizeAdapted } from '@farfetch/blackout-redux';
 
 export const mockBagId = '7894746';
 export const mockError = {
@@ -346,4 +348,41 @@ export const mockNormalizedPayload = {
     products: { [mockProductId]: { id: mockProductId } },
   },
   result: { items: [mockBagItemId] },
+};
+
+export const mockStateWithSizeWithoutStock = {
+  ...mockState,
+  entities: {
+    ...mockState.entities,
+    products: {
+      ...mockState.entities.products,
+      [mockProductId]: {
+        ...mockState.entities.products[mockProductId],
+        sizes: [{ id: 1 }],
+      },
+    },
+  },
+};
+
+export const mockStateWithUnavailableStock = {
+  ...mockState,
+  entities: {
+    ...mockState.entities,
+    products: {
+      ...mockState.entities.products,
+      [mockProductId]: {
+        ...mockState.entities.products[mockProductId],
+        sizes: [
+          {
+            ...mockProductSizeAdapted,
+            id: 23,
+            name: '23',
+            stock: [
+              { ...mockProductSizeAdapted.stock[0], quantity: 0 },
+            ] as SizeAdapted['stock'],
+          },
+        ],
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Description

- This adds throw statements to `handleAddUpdateBagItem` and `handleFullUpdate` functions used by the actions in `useBag` hook in order to communicate to the consumer that it was unable to perform the action. This replaces the early return strategy which would not communicate to the user that the actions were unable to perform an add/update of a bag item because there was either missing information or no stock available.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
