### PR TITLE
chore: fix release step of the pipeline

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,9 +5,7 @@ git remote set-url origin "https://${GITHUB_TOKEN}@github.com/Farfetch/blackout.
 SOURCE_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 CONTENTS="--contents dist"
 
-if [[ ${SOURCE_BRANCH_NAME} = main || ${SOURCE_BRANCH_NAME} = next ]]; then
-    yarn release:build
-
+if [[ ${SOURCE_BRANCH_NAME} = main || ${SOURCE_BRANCH_NAME} = next ]]; then    
     if [[ ${SOURCE_BRANCH_NAME} = next ]]; then
         PRE_ID_NAME='next'
         PRE_ID="--preid ${PRE_ID_NAME}"
@@ -15,5 +13,9 @@ if [[ ${SOURCE_BRANCH_NAME} = main || ${SOURCE_BRANCH_NAME} = next ]]; then
         CONVENTIONAL_PRERELEASE="--conventional-prerelease"
     fi
 
-    npx lerna publish --conventional-commits --message "${PUBLISH_COMMIT_MESSAGE}" --no-verify-access --yes ${CONTENTS} ${PRE_ID} ${PRE_DIST_TAG} ${CONVENTIONAL_PRERELEASE}
+    npx lerna version --conventional-commits --message "${PUBLISH_COMMIT_MESSAGE}" ${PRE_ID} ${CONVENTIONAL_PRERELEASE}
+
+    yarn release:build
+
+    npx lerna publish from-package --no-verify-access --yes ${CONTENTS} ${PRE_DIST_TAG} 
 fi


### PR DESCRIPTION
## Description

- This fixes the release step of the pipeline by running `lerna version` before running the build script in order to have the package.json files updated so that the babel transformer will pick the correct package version when transforming the imports that read the version from package.json files. Currently, new releases of the analytics package will have the incorrect version inserted by the babel transformer inside the `constants.ts` file which was being used in error/warning messages, which would confuse the consumer of the
package as it would be displaying the incorrect version that was installed.

Example:
Package version: `1.0.0-next.92`.
Version inserted in `constants.ts` by babel transformer: `1.0.0-next.91`.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
