### PR TITLE
fix(redux): fix countrySourceCode in locale initial state

### DIFF
--- a/packages/redux/src/locale/serverInitialState.ts
+++ b/packages/redux/src/locale/serverInitialState.ts
@@ -24,7 +24,7 @@ const localeServerInitialState: ServerInitialState = ({ model }) => {
     currencyCode,
     currencyCultureCode,
     newsletterSubscriptionOptionDefault,
-    sourceCountryCode,
+    requestSourceCountryCode,
     subfolder,
   } = model;
   // Normalize it
@@ -49,7 +49,7 @@ const localeServerInitialState: ServerInitialState = ({ model }) => {
   return {
     locale: {
       countryCode,
-      sourceCountryCode,
+      sourceCountryCode: requestSourceCountryCode,
     },
     entities,
   };

--- a/packages/redux/src/types/model.types.ts
+++ b/packages/redux/src/types/model.types.ts
@@ -29,7 +29,7 @@ type Common = {
   currencyCultureCode: string;
   designers: Designers;
   newsletterSubscriptionOptionDefault: boolean;
-  sourceCountryCode: string;
+  requestSourceCountryCode: string;
   defaultCulture: string;
   defaultSubfolder: string;
   pageType: string;

--- a/tests/__fixtures__/locale/locale.fixtures.ts
+++ b/tests/__fixtures__/locale/locale.fixtures.ts
@@ -134,7 +134,7 @@ export const mockModel = {
   newsletterSubscriptionOptionDefault: false,
   defaultCulture: 'en-US',
   defaultSubfolder: '/en-us',
-  sourceCountryCode: 'PT',
+  requestSourceCountryCode: 'PT',
   addressType: AddressType.Any,
 };
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->
- Fix the model property being used to set the sourceCountryCode in the locale initial state

<img width="547" alt="Screenshot 2022-11-21 at 15 40 14" src="https://user-images.githubusercontent.com/10854093/203097692-a818a94c-0e1d-4148-84f1-bff615218fbb.png">


<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
