### PR TITLE
chore: fix missing yes flag in lerna version

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,9 +13,9 @@ if [[ ${SOURCE_BRANCH_NAME} = main || ${SOURCE_BRANCH_NAME} = next ]]; then
         CONVENTIONAL_PRERELEASE="--conventional-prerelease"
     fi
 
-    npx lerna version --conventional-commits --message "${PUBLISH_COMMIT_MESSAGE}" ${PRE_ID} ${CONVENTIONAL_PRERELEASE}
+    npx lerna version --conventional-commits --message --yes "${PUBLISH_COMMIT_MESSAGE}" ${PRE_ID} ${CONVENTIONAL_PRERELEASE} --loglevel=verbose
 
     yarn release:build
 
-    npx lerna publish from-package --no-verify-access --yes ${CONTENTS} ${PRE_DIST_TAG} 
+    npx lerna publish from-package --no-verify-access --yes ${CONTENTS} ${PRE_DIST_TAG} --loglevel=verbose
 fi


### PR DESCRIPTION
## Description

- This fixes a bug with the release script that was not sending the --yes flag to the lerna version command which prevented the correct release of new versions and
also activated verbose logs for lerna calls.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
