### PR TITLE
fix: remove environmentCode query

### DIFF
--- a/packages/react/src/content/hooks/useContentType.js
+++ b/packages/react/src/content/hooks/useContentType.js
@@ -33,8 +33,7 @@ export default (codes, contentTypeCode, params, pageSize) => {
   const query = {
     ...(codes && { codes }),
     contentTypeCode,
-    environmentCode:
-      params?.environmentcode || process.env.WEB_APP_CONTENT_ENV || '',
+    environmentCode: params?.environmentcode || 'live',
     'target.country': params?.countryCode,
     'target.language': params?.cultureCode,
     'target.benefits': params?.benefits,


### PR DESCRIPTION
## Description

Fix the environmentCode: avoiding sending request with the environmentCode empty when there is no value either on props or `WEB_APP_CONTENT_ENV`. Change to default: "live"

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
