### PR TITLE
fix(react|redux): fix wishlist and bag selectors

### DIFF
--- a/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
@@ -137,10 +137,7 @@ describe('useBag', () => {
   it('should render as empty', () => {
     const {
       result: {
-        current: {
-          isFetched,
-          data: { isEmpty },
-        },
+        current: { isFetched, data },
       },
     } = renderHook(() => useBag(), {
       wrapper: withStore({
@@ -159,6 +156,8 @@ describe('useBag', () => {
         },
       }),
     });
+
+    const isEmpty = data?.isEmpty;
 
     expect(isEmpty).toBe(true);
     expect(isFetched).toBe(true);

--- a/packages/react/src/bags/hooks/useBag.ts
+++ b/packages/react/src/bags/hooks/useBag.ts
@@ -26,7 +26,7 @@ import {
   ProductError,
   SizeError,
 } from './errors';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useSelector, useStore } from 'react-redux';
 import useAction from '../../helpers/useAction';
 import type { HandleAddOrUpdateItem, UseBagOptions } from './types';
@@ -480,6 +480,19 @@ const useBag = (options: UseBagOptions = {}) => {
     [handleFullUpdate, handleQuantityChange, handleSizeChange, items],
   );
 
+  const data = useMemo(() => {
+    if (!bag) {
+      return undefined;
+    }
+
+    return {
+      ...bag,
+      count,
+      isEmpty,
+      items,
+    };
+  }, [bag, count, isEmpty, items]);
+
   return {
     isLoading,
     error,
@@ -491,12 +504,7 @@ const useBag = (options: UseBagOptions = {}) => {
       updateItem,
       removeItem,
     },
-    data: {
-      ...bag,
-      count,
-      isEmpty,
-      items,
-    },
+    data,
   };
 };
 

--- a/packages/react/src/contents/components/base/contentList/ContentList.tsx
+++ b/packages/react/src/contents/components/base/contentList/ContentList.tsx
@@ -42,7 +42,10 @@ const ContentList = ({
   return contentType && contentType.entries.length > 0 ? (
     <>
       {sortContentType(contentType.entries, orderOption.value).map(content => {
-        const component = renderContent(content, location, viewportBreakpoint);
+        const component = renderContent(content, {
+          location,
+          viewportBreakpoint,
+        });
 
         if (component.type === React.Fragment) {
           return component.props.children;

--- a/packages/react/src/contents/helpers/__tests__/renderContent.test.tsx
+++ b/packages/react/src/contents/helpers/__tests__/renderContent.test.tsx
@@ -23,7 +23,7 @@ describe('renderContent', () => {
 
   it('should render a component element with legacy data', () => {
     const { getByTestId } = render(
-      renderContent(mockLegacyData, location, 'lg'),
+      renderContent(mockLegacyData, { location, viewportBreakpoint: 'lg' }),
     );
     const element = getByTestId('textElement');
 

--- a/packages/react/src/contents/helpers/renderContent.tsx
+++ b/packages/react/src/contents/helpers/renderContent.tsx
@@ -1,37 +1,25 @@
 import { Component } from '../components';
 import map from 'lodash/map';
 import React, { ReactElement } from 'react';
+import type { ComponentProps } from '../types';
 import type { ContentEntry } from '@farfetch/blackout-client';
-import type { DefaultMedia } from '../types';
 
 /**
  * Render an Editorial Content. Renders Editorial Content by going through all it's
  * components and rendering them using the Editorial Component.
  *
  * @param data - Data to render.
- * @param location - Router location object.
- * @param viewportBreakpoint - Screen size (Xs | Sm | Md | Lg) .
- * @param media - Media breakpoint sizes (xs: '400px', md...);
+ * @param componentProps - Props to be passed to the registered components.
  *
  * @returns Rendered components.
  */
 const renderContent = (
   { components }: { components: ContentEntry['components'] },
-  location: {
-    query?: Record<string, string>;
-  },
-  viewportBreakpoint: string,
-  media?: DefaultMedia,
+  componentProps?: Omit<ComponentProps, 'component'> & Record<string, unknown>,
 ): ReactElement => (
   <>
     {map(components, (component, key) => (
-      <Component
-        component={component}
-        location={location}
-        viewportBreakpoint={viewportBreakpoint}
-        media={media}
-        key={key}
-      />
+      <Component component={component} key={key} {...componentProps} />
     ))}
   </>
 );

--- a/packages/react/src/contents/types/component.types.ts
+++ b/packages/react/src/contents/types/component.types.ts
@@ -3,10 +3,10 @@ import type { DefaultMedia } from './base.types';
 
 export interface ComponentProps {
   component: ComponentType;
-  location: {
+  location?: {
     query?: Record<string, string>;
   };
-  viewportBreakpoint: string;
+  viewportBreakpoint?: string;
   media?: DefaultMedia;
   children?: React.ReactNode;
 }

--- a/packages/react/src/contents/types/metatags.types.ts
+++ b/packages/react/src/contents/types/metatags.types.ts
@@ -74,7 +74,7 @@ export type ListingSeoMetadataParams = {
   pathname?: string;
   subPageType?: string;
   param: {
-    SetName?: string;
+    SetName?: string | null;
     TotalNumberItems?: number;
     BrandName?: string;
     CategoryName?: string;
@@ -88,7 +88,7 @@ export type GetListingSeoMetadataParams = (args: {
   location: { pathname: string; search: string };
   totalItems?: number;
   filterSegments?: FilterSegment[];
-  listingName?: string;
+  listingName?: string | null;
   lowestProductPrice?: number;
   countryName: string;
   countryCode: string;

--- a/packages/react/src/wishlists/hooks/__tests__/useWishlist.test.tsx
+++ b/packages/react/src/wishlists/hooks/__tests__/useWishlist.test.tsx
@@ -128,10 +128,7 @@ describe('useWishlist', () => {
   it('should return correctly if empty', () => {
     const {
       result: {
-        current: {
-          isFetched,
-          data: { isEmpty },
-        },
+        current: { isFetched, data },
       },
     } = renderHook(() => useWishlist(), {
       wrapper: withStore({
@@ -150,6 +147,8 @@ describe('useWishlist', () => {
         },
       }),
     });
+
+    const isEmpty = data?.isEmpty;
 
     expect(isEmpty).toBe(true);
     expect(isFetched).toBe(true);

--- a/packages/react/src/wishlists/hooks/useWishlist.ts
+++ b/packages/react/src/wishlists/hooks/useWishlist.ts
@@ -15,7 +15,7 @@ import {
   resetWishlist,
   updateWishlistItem,
 } from '@farfetch/blackout-redux';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import useAction from '../../helpers/useAction';
 // Types
@@ -52,6 +52,19 @@ const useWishlist = (options: UseWishlistOptions = {}) => {
     }
   }, [enableAutoFetch, error, fetch, fetchConfig, isLoading, userWishlistId]);
 
+  const data = useMemo(() => {
+    if (!wishlist) {
+      return undefined;
+    }
+
+    return {
+      ...wishlist,
+      count,
+      isEmpty,
+      items,
+    };
+  }, [count, isEmpty, items, wishlist]);
+
   return {
     isLoading,
     error,
@@ -63,12 +76,7 @@ const useWishlist = (options: UseWishlistOptions = {}) => {
       updateItem,
       removeItem,
     },
-    data: {
-      ...wishlist,
-      count,
-      isEmpty,
-      items,
-    },
+    data,
   };
 };
 

--- a/packages/redux/src/analytics/middlewares/__tests__/bag.test.ts
+++ b/packages/redux/src/analytics/middlewares/__tests__/bag.test.ts
@@ -38,7 +38,7 @@ const productData = getProduct(
 const { name, shortDescription, sku } = productData;
 const sizes = bagMockData.mockSizes;
 const bagItem = getBagItem(bagMockData.mockState, bagMockData.mockBagItemId);
-const { price, quantity } = bagItem;
+const { price, quantity } = bagItem!;
 const {
   includingTaxes: priceWithDiscount,
   includingTaxesWithoutDiscount: priceWithoutDiscount,

--- a/packages/redux/src/analytics/middlewares/bag.ts
+++ b/packages/redux/src/analytics/middlewares/bag.ts
@@ -8,7 +8,11 @@ import {
   getVariant,
 } from './helpers';
 import { getProductDenormalized } from '../../products';
-import Analytics, { eventTypes, utils } from '@farfetch/blackout-analytics';
+import Analytics, {
+  EventProperties,
+  eventTypes,
+  utils,
+} from '@farfetch/blackout-analytics';
 import get from 'lodash/get';
 import isNil from 'lodash/isNil';
 import type { AnyAction, Dispatch, Middleware } from 'redux';
@@ -297,7 +301,7 @@ export function analyticsBagMiddleware(
         analyticsInstance.track(eventTypes.PRODUCT_UPDATED, { ...data });
 
         if (data.oldSize && data.oldSize !== data.size) {
-          const removedProductData = { ...data };
+          const removedProductData: EventProperties = { ...data };
           removedProductData.size = data.oldSize;
           removedProductData.quantity = data.oldQuantity;
 

--- a/packages/redux/src/bags/__tests__/selectors.test.ts
+++ b/packages/redux/src/bags/__tests__/selectors.test.ts
@@ -1,5 +1,4 @@
 import * as fromBag from '../reducer';
-import * as fromEntities from '../../entities/selectors/entity';
 import * as selectors from '../selectors';
 import {
   mockBagId,
@@ -94,12 +93,9 @@ describe('bags redux selectors', () => {
     };
 
     it('should return all data regarding a bag item', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntityById');
-
       expect(selectors.getBagItem(mockState, mockBagItemId)).toEqual(
         expectedResult,
       );
-      expect(spy).toHaveBeenCalledWith(mockState, 'bagItems', mockBagItemId);
     });
   });
 

--- a/packages/redux/src/entities/types/wishlistItem.types.ts
+++ b/packages/redux/src/entities/types/wishlistItem.types.ts
@@ -23,7 +23,7 @@ export type WishlistItemsEntities = Record<
   WishlistItemEntity
 >;
 
-export type WishlistItemHydrated = WishlistItemEntity & {
+export type WishlistItemHydrated = Omit<WishlistItemEntity, 'product'> & {
   product: ProductEntityDenormalized | undefined;
-  parentSets: Record<'id' | 'name', string>[] | undefined;
+  parentSets?: Record<'id' | 'name', string>[] | undefined;
 };

--- a/packages/redux/src/products/selectors/product.ts
+++ b/packages/redux/src/products/selectors/product.ts
@@ -6,6 +6,7 @@ import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import orderBy from 'lodash/orderBy';
 import type {
+  CategoryEntity,
   ProductEntity,
   ProductEntityDenormalized,
 } from '../../entities/types';
@@ -44,7 +45,10 @@ export const getProductDenormalized = (
   const categories = getCategories(state);
   const brand = brands?.[product.brand];
   const productCategories =
-    categories && product.categories?.map(id => categories[id]);
+    categories &&
+    (product.categories
+      ?.map(id => categories[id])
+      .filter(Boolean) as CategoryEntity[]);
 
   return {
     ...product,

--- a/packages/redux/src/wishlists/selectors/__tests__/wishlists.test.ts
+++ b/packages/redux/src/wishlists/selectors/__tests__/wishlists.test.ts
@@ -1,4 +1,3 @@
-import * as fromEntities from '../../../entities/selectors/entity';
 import * as fromWishlist from '../../reducer/wishlists';
 import * as selectors from '..';
 import {
@@ -109,16 +108,9 @@ describe('wishlists redux selectors', () => {
     };
 
     it('should return all data regarding a wishlist item', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntityById');
-
       expect(
         selectors.getWishlistItem(mockWishlistState, mockWishlistItemId),
       ).toEqual(expectedResult);
-      expect(spy).toHaveBeenCalledWith(
-        mockWishlistState,
-        'wishlistItems',
-        mockWishlistItemId,
-      );
     });
 
     it('should return the wishlist item data with parent sets information', () => {


### PR DESCRIPTION
## Description

- This fixes `getWishlistItems` selector that was recalculating its value unnecessarily every time the state changed even though it was using `createSelector` because of an incorrect function input to createSelector that was selecting the whole state.
- Changed `getBagItemAvailableSizes` selector to not use `getBagItem` in its implementation as it would invalidate the cached result created by createSelector as it would change the bag item id parameter.
- Refactored `getBagItems`, `getBagItem`, `getWishlistItems` and `getWishlistItem` selectors to use a common denormalize function.
- Changed `useWishlist` and `useBag` hooks to returned undefined when the wishlist and bag are undefined respectively. This is to avoid generating a new object reference when the data has not changed.
- Changed `renderContent` function to accept only 2 arguments instead
of multiple arguments and made the 2nd argument optional to avoid type
errors when the components registered do not use the same props as the
ones provided by the package.
- Added a `.filter(Boolean)` call in getProductDenormalized selector
for the categories property calculation to avoid receiving an array with
undefined values.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
