### PR TITLE
fix(react): fix getListingSeoMetadataParams

### DIFF
--- a/packages/react/src/contents/types/metatags.types.ts
+++ b/packages/react/src/contents/types/metatags.types.ts
@@ -74,7 +74,7 @@ export type ListingSeoMetadataParams = {
   pathname?: string;
   subPageType?: string;
   param: {
-    SetName?: string | null;
+    SetName?: string;
     TotalNumberItems?: number;
     BrandName?: string;
     CategoryName?: string;

--- a/packages/react/src/contents/utils/getListingSeoMetadataParams.ts
+++ b/packages/react/src/contents/utils/getListingSeoMetadataParams.ts
@@ -11,7 +11,7 @@ const getListingSeoMetadataParams: GetListingSeoMetadataParams = ({
   location,
   totalItems = 0,
   filterSegments = [],
-  listingName = '',
+  listingName,
   lowestProductPrice = undefined,
   countryCode,
   cultureCode,
@@ -53,7 +53,7 @@ const getListingSeoMetadataParams: GetListingSeoMetadataParams = ({
       param: {
         Country: countryName,
         CountryCode: countryCode,
-        SetName: listingName,
+        SetName: listingName || '',
       },
       subPageType: SeoSubPageType.Default,
     };


### PR DESCRIPTION
## Description

- This fixes getListingSeoMetadataParams implementation to make it take into account that the listing name might be null as well.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
