### PR TITLE
fix(redux|react): fix createSelector types

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
+++ b/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
@@ -380,7 +380,7 @@ class Omnitracking extends Integration<OmnitrackingOptions> {
 
       if (!finalPayload) {
         logger.error(
-          '`transformPayload` function did not return any payload data to be sent to Omnitracking. No request will be sent for eventData: ',
+          '[Omnitracking] - `transformPayload` function did not return any payload data to be sent to Omnitracking. No request will be sent for eventData: ',
           eventData,
         );
 

--- a/packages/client/src/checkout/types/checkoutOrderMerchant.types.ts
+++ b/packages/client/src/checkout/types/checkoutOrderMerchant.types.ts
@@ -1,26 +1,8 @@
-import type { ShippingCostType } from '.';
+import type { ShippingOption } from '.';
 
 export type CheckoutOrderMerchant = {
   merchantId: number;
   merchantName: string;
   salesTax: number;
-  shipping: {
-    currency: string;
-    discount: number;
-    merchants: number[];
-    price: number;
-    formattedPrice: string;
-    shippingCostType: ShippingCostType;
-    shippingService: {
-      description: string;
-      id: number;
-      name: string;
-      type: string;
-      minEstimatedDeliveryHour: number;
-      maxEstimatedDeliveryHour: number;
-      trackingCodes: string[];
-    };
-    shippingWithoutCapped: number;
-    baseFlatRate: number;
-  };
+  shipping: ShippingOption;
 };

--- a/packages/react/src/bags/hooks/types/useBag.ts
+++ b/packages/react/src/bags/hooks/types/useBag.ts
@@ -1,6 +1,6 @@
 import type {
   BagItemActionMetadata,
-  BagItemHydrated,
+  BagItemDenormalized,
   CustomAttributesAdapted,
   ProductEntityDenormalized,
   SizeAdapted,
@@ -20,7 +20,7 @@ export type HandleAddOrUpdateItem = (
     from?: string;
     product: ProductEntityDenormalized;
     productAggregatorId?: Exclude<
-      BagItemHydrated['productAggregator'],
+      BagItemDenormalized['productAggregator'],
       null
     >['id'];
     quantity: number;

--- a/packages/react/src/bags/hooks/useBag.ts
+++ b/packages/react/src/bags/hooks/useBag.ts
@@ -4,7 +4,7 @@
 import {
   addBagItem as addBagItemAction,
   BagItemActionMetadata,
-  BagItemHydrated,
+  BagItemDenormalized,
   buildBagItem,
   fetchBag as fetchBagAction,
   generateBagItemHash,
@@ -189,7 +189,7 @@ const useBag = (options: UseBagOptions = {}) => {
 
   const handleQuantityChange = useCallback(
     (
-      bagItem: BagItemHydrated,
+      bagItem: BagItemDenormalized,
       newQuantity: number,
       metadata?: BagItemActionMetadata,
     ) => {
@@ -253,7 +253,7 @@ const useBag = (options: UseBagOptions = {}) => {
    */
   const handleSizeChange = useCallback(
     async (
-      bagItem: BagItemHydrated,
+      bagItem: BagItemDenormalized,
       newSize: SizeAdapted['id'],
       metadata?: BagItemActionMetadata,
     ) => {
@@ -365,7 +365,7 @@ const useBag = (options: UseBagOptions = {}) => {
    */
   const handleFullUpdate = useCallback(
     async (
-      bagItem: BagItemHydrated,
+      bagItem: BagItemDenormalized,
       newSizeId: number,
       newQty: number,
       metadata?: BagItemActionMetadata,

--- a/packages/react/src/wishlists/hooks/types/useWishlistSet.types.ts
+++ b/packages/react/src/wishlists/hooks/types/useWishlistSet.types.ts
@@ -4,7 +4,7 @@ import type {
   PatchWishlistSetData,
   WishlistSet,
 } from '@farfetch/blackout-client';
-import type { WishlistSetHydrated } from '@farfetch/blackout-redux';
+import type { WishlistSetDenormalized } from '@farfetch/blackout-redux';
 
 export type UseWishlistSet = (setId: WishlistSet['setId']) => {
   error: BlackoutError | null | undefined;
@@ -21,5 +21,5 @@ export type UseWishlistSet = (setId: WishlistSet['setId']) => {
     data: PatchWishlistSetData,
     config?: Config,
   ) => Promise<WishlistSet | undefined>;
-  wishlistSet: WishlistSetHydrated | undefined;
+  wishlistSet: WishlistSetDenormalized | undefined;
 };

--- a/packages/react/src/wishlists/hooks/types/useWishlistSets.types.ts
+++ b/packages/react/src/wishlists/hooks/types/useWishlistSets.types.ts
@@ -4,8 +4,8 @@ import type {
   WishlistSets,
 } from '@farfetch/blackout-client';
 import type {
+  WishlistSetsDenormalized,
   WishlistSetsErrors,
-  WishlistSetsHydrated,
   WishlistSetsState,
 } from '@farfetch/blackout-redux';
 
@@ -21,5 +21,5 @@ export type UseWishlistSets = () => {
   isAnyWishlistSetWithError: boolean;
   resetWishlistSets: () => void;
   resetWishlistSetsState: (fieldsToReset?: string[]) => void;
-  wishlistSets: WishlistSetsHydrated;
+  wishlistSets: WishlistSetsDenormalized | undefined;
 };

--- a/packages/redux/src/analytics/middlewares/__tests__/wishlist.test.ts
+++ b/packages/redux/src/analytics/middlewares/__tests__/wishlist.test.ts
@@ -18,7 +18,7 @@ import Analytics, {
 import merge from 'lodash/merge';
 import type {
   ProductEntity,
-  WishlistItemHydrated,
+  WishlistItemDenormalized,
 } from '../../../entities/types';
 import type { StoreState } from '../../../types';
 
@@ -46,7 +46,7 @@ const { name, shortDescription } = productData;
 const wishlistItem = getWishlistItem(
   wishlistMockData.state,
   wishlistMockData.wishListItemId,
-) as WishlistItemHydrated;
+) as WishlistItemDenormalized;
 
 const { price, quantity, size } = wishlistItem;
 

--- a/packages/redux/src/analytics/middlewares/wishlist.ts
+++ b/packages/redux/src/analytics/middlewares/wishlist.ts
@@ -26,8 +26,8 @@ import type {
   WishlistProductUpdateSetActionMetadata,
 } from './types';
 import type {
+  WishlistItemDenormalized,
   WishlistItemEntity,
-  WishlistItemHydrated,
 } from '../../entities/types';
 
 /**
@@ -108,7 +108,7 @@ const getWishlistItemIdFromAction = (action: AnyAction, searchMeta = true) => {
  */
 const getWishlistData = (
   action: AnyAction,
-  wishlistItem: WishlistItemHydrated | undefined,
+  wishlistItem: WishlistItemDenormalized | undefined,
 ) => {
   return {
     affiliation: get(action, 'meta.affiliation'),
@@ -134,7 +134,7 @@ const getWishlistData = (
 const getProductData = async (
   analyticsInstance: Analytics,
   state: StoreState,
-  wishlistItem: WishlistItemHydrated | undefined,
+  wishlistItem: WishlistItemDenormalized | undefined,
 ) => {
   const product = get(wishlistItem, 'product');
   const priceWithDiscount = get(wishlistItem, 'price.includingTaxes');
@@ -410,7 +410,7 @@ export function analyticsWishlistMiddleware(
 
             return getWishlistItem(state, wishlistItemId);
           })
-          .filter(Boolean) as WishlistItemHydrated[];
+          .filter(Boolean) as WishlistItemDenormalized[];
 
         await Promise.all(
           addedItems.map(async wishlistItem => {

--- a/packages/redux/src/brands/selectors.ts
+++ b/packages/redux/src/brands/selectors.ts
@@ -91,9 +91,15 @@ export const getBrand = (state: StoreState, brandId: Brand['id']) =>
  *
  * @returns Brands result with pagination.
  */
-export const getBrandsResult = createSelector(
+export const getBrandsResult: (
+  state: StoreState,
+  hash?: string | null,
+) => Brands | undefined = createSelector(
   [
-    (state: StoreState, hash = getBrandsHash(state)) => hash,
+    (
+      state: StoreState,
+      hash: string | null | undefined = getBrandsHash(state),
+    ) => hash,
     (state: StoreState) => getResult(state.brands as BrandsState),
     getBrands,
   ],
@@ -106,13 +112,12 @@ export const getBrandsResult = createSelector(
 
     return {
       ...result,
-      entries: result.entries.map((id: number) => brands?.[id]),
+      entries: result.entries
+        .map((id: number) => brands?.[id])
+        .filter(Boolean) as Brand[],
     };
   },
-  // Little workaround to "explain" to typescript the function signature, to
-  // avoid the "Expected 1 arguments, but got 2." error.
-  // https://github.com/reduxjs/reselect/issues/459#issuecomment-804335461
-) as (state: StoreState, hash?: string | null) => Brands | undefined;
+);
 
 /**
  * Retrieves if a brands result is cached by its hash.

--- a/packages/redux/src/categories/selectors/topCategories.ts
+++ b/packages/redux/src/categories/selectors/topCategories.ts
@@ -40,19 +40,22 @@ export const getTopCategoriesError = (state: StoreState) =>
  *
  * @returns - Top categories list.
  */
-export const getTopCategories = createSelector(
-  [
-    (state: StoreState) => getResult(state.categories as CategoriesState),
-    (state: StoreState) => getCategories(state),
-  ],
-  (topCategories, categories): CategoryEntity[] => {
-    if (!topCategories) {
-      return [];
-    }
+export const getTopCategories: (state: StoreState) => CategoryEntity[] =
+  createSelector(
+    [
+      (state: StoreState) => getResult(state.categories as CategoriesState),
+      (state: StoreState) => getCategories(state),
+    ],
+    (topCategories, categories): CategoryEntity[] => {
+      if (!topCategories) {
+        return [];
+      }
 
-    return topCategories.map(id => categories?.[id] as CategoryEntity);
-  },
-);
+      return topCategories
+        .map(id => categories?.[id])
+        .filter(Boolean) as CategoryEntity[];
+    },
+  );
 
 /**
  * Retrieves the loading state of top categories.

--- a/packages/redux/src/entities/schemas/order.ts
+++ b/packages/redux/src/entities/schemas/order.ts
@@ -13,6 +13,12 @@ export default new schema.Entity(
   { items: [orderItem] },
   {
     processStrategy: (order: Order | OrderLegacy) => {
+      // This is needed since the Farfetch Checkout service is merging
+      // both Address Line 2 and Address Line 3 not checking correctly if the
+      // second is empty, when the user fills the third address line but not
+      // the second it adds a space when merging the values and returns it
+      // in the second line.
+      // This only occurs in the order details not in the address book.
       const preprocessedOrder = preprocessOrder(order);
 
       if (typeof preprocessedOrder.customerType === 'number') {
@@ -25,13 +31,7 @@ export default new schema.Entity(
         }
       }
 
-      // This is needed since the Farfetch Checkout service is merging
-      // both Address Line 2 and Address Line 3 not checking correctly if the
-      // second is empty, when the user fills the third address line but not
-      // the second it adds a space when merging the values and returns it
-      // in the second line.
-      // This only occurs in the order details not in the address book.
-      return preprocessOrder(order);
+      return preprocessedOrder;
     },
   },
 );

--- a/packages/redux/src/entities/types/bagItem.types.ts
+++ b/packages/redux/src/entities/types/bagItem.types.ts
@@ -38,6 +38,6 @@ export type BagItemEntity = Omit<
   size: SizeAdapted;
 };
 
-export type BagItemHydrated = Omit<BagItemEntity, 'product'> & {
+export type BagItemDenormalized = Omit<BagItemEntity, 'product'> & {
   product: ProductEntityDenormalized | undefined;
 };

--- a/packages/redux/src/entities/types/checkoutOrder.types.ts
+++ b/packages/redux/src/entities/types/checkoutOrder.types.ts
@@ -3,8 +3,16 @@ import type {
   CheckoutOrderItem,
   CollectPoint,
 } from '@farfetch/blackout-client';
+import type { CheckoutOrderItemEntityDenormalized } from './checkoutOrderItem.types';
 
 export type CheckoutOrderEntity = Omit<CheckoutOrder, 'items'> & {
   items: Array<CheckoutOrderItem['id']>;
   collectpoints?: Array<CollectPoint>;
+};
+
+export type CheckoutOrderEntityDenormalized = Omit<
+  CheckoutOrderEntity,
+  'items'
+> & {
+  items: CheckoutOrderItemEntityDenormalized[] | undefined;
 };

--- a/packages/redux/src/entities/types/wishlistItem.types.ts
+++ b/packages/redux/src/entities/types/wishlistItem.types.ts
@@ -27,7 +27,7 @@ export type WishlistItemsEntities = Record<
   WishlistItemEntity
 >;
 
-export type WishlistItemHydrated = Omit<WishlistItemEntity, 'product'> & {
+export type WishlistItemDenormalized = Omit<WishlistItemEntity, 'product'> & {
   product: ProductEntityDenormalized | undefined;
   parentSets?: Record<'id' | 'name', string>[] | undefined;
 };

--- a/packages/redux/src/entities/types/wishlistSet.types.ts
+++ b/packages/redux/src/entities/types/wishlistSet.types.ts
@@ -10,7 +10,7 @@ export type WishlistSetEntities = Record<
   WishlistSetEntity
 >;
 
-export type WishlistSetHydrated = Omit<
+export type WishlistSetDenormalized = Omit<
   WishlistSetEntity,
   'wishlistSetItems'
 > & {
@@ -21,4 +21,6 @@ export type WishlistSetHydrated = Omit<
   >;
 };
 
-export type WishlistSetsHydrated = Array<WishlistSetHydrated> | undefined;
+export type WishlistSetsDenormalized =
+  | Array<WishlistSetDenormalized>
+  | undefined;

--- a/packages/redux/src/merchantsLocations/selectors.ts
+++ b/packages/redux/src/merchantsLocations/selectors.ts
@@ -61,7 +61,10 @@ export const getMerchantsLocations = (state: StoreState) =>
  *
  * @returns Merchants locations of the provided ids.
  */
-export const getMerchantsLocationsByIds = createSelector(
+export const getMerchantsLocationsByIds: (
+  state: StoreState,
+  merchantLocationsIds: Array<MerchantLocationEntity['id']>,
+) => MerchantLocation[] = createSelector(
   [
     state => state,
     (state: StoreState, ids: Array<MerchantLocationEntity['id']>) => ids,

--- a/packages/redux/src/products/selectors/details.ts
+++ b/packages/redux/src/products/selectors/details.ts
@@ -7,9 +7,12 @@ import {
 } from '../../bags';
 import { getError, getIsHydrated, getIsLoading } from '../reducer/details';
 import { getProduct, getProductDenormalized } from './product';
-import type { ProductEntity } from '../../entities/types';
+import type {
+  GroupedEntriesAdapted,
+  ProductEntity,
+} from '../../entities/types';
 import type { ProductsState } from '../types';
-import type { SizeAdapted } from '../../helpers/adapters';
+import type { SizeAdapted, SizesAdapted } from '../../helpers/adapters';
 import type { StoreState } from '../../types';
 
 /**
@@ -145,7 +148,10 @@ export const getProductSizeRemainingQuantity = (
  * @returns Product sizes array with updated quantity, as the difference between the total quantity of
  * product size and the respective bag quantity.
  */
-export const getAllProductSizesRemainingQuantity = createSelector(
+export const getAllProductSizesRemainingQuantity: (
+  state: StoreState,
+  productId: ProductEntity['id'],
+) => SizesAdapted = createSelector(
   [
     (state: StoreState, productId: ProductEntity['id']) =>
       getProductDenormalized(state, productId),
@@ -243,7 +249,16 @@ export const getAllProductSizesRemainingQuantity = createSelector(
  *
  * @returns Color grouping object.
  */
-export const getProductGroupedEntries = createSelector(
+export const getProductGroupedEntries: (
+  state: StoreState,
+  productId: ProductEntity['id'],
+) =>
+  | {
+      totalItems: number;
+      remaining: number;
+      entries: NonNullable<GroupedEntriesAdapted>['entries'];
+    }
+  | undefined = createSelector(
   [
     (state: StoreState, productId: ProductEntity['id']) =>
       getProduct(state, productId),

--- a/packages/redux/src/products/selectors/product.ts
+++ b/packages/redux/src/products/selectors/product.ts
@@ -10,6 +10,7 @@ import type {
   ProductEntity,
   ProductEntityDenormalized,
 } from '../../entities/types';
+import type { Label, Promotion } from '@farfetch/blackout-client';
 import type { StoreState } from '../../types';
 
 /**
@@ -103,7 +104,10 @@ export const isProductOutOfStock = (
  *
  * @returns List of product promotions for the given ID.
  */
-export const getProductPromotions = createSelector(
+export const getProductPromotions: (
+  state: StoreState,
+  productId: ProductEntity['id'],
+) => Promotion[] = createSelector(
   [
     (state: StoreState, productId: ProductEntity['id']) =>
       getProduct(state, productId),
@@ -120,7 +124,11 @@ export const getProductPromotions = createSelector(
  *
  * @returns Labels sorted by the given order.
  */
-export const getProductLabelsByPriority = createSelector(
+export const getProductLabelsByPriority: (
+  state: StoreState,
+  productId: ProductEntity['id'],
+  sortOrder?: 'asc' | 'desc',
+) => Label[] = createSelector(
   [
     (state: StoreState, productId: ProductEntity['id']) =>
       getProduct(state, productId),

--- a/packages/redux/src/products/selectors/sets.ts
+++ b/packages/redux/src/products/selectors/sets.ts
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import { getProduct } from './product';
 import type { ProductEntity } from '../../entities/types';
+import type { RelatedSet } from '@farfetch/blackout-client';
 import type { StoreState } from '../../types';
 
 /**
@@ -12,7 +13,11 @@ import type { StoreState } from '../../types';
  *
  * @returns Related sets of the given type.
  */
-export const getProductRelatedSetsIdsByType = createSelector(
+export const getProductRelatedSetsIdsByType: (
+  state: StoreState,
+  productId: ProductEntity['id'],
+  setType: RelatedSet['setType'],
+) => RelatedSet['setId'][] = createSelector(
   (state: StoreState, productId: ProductEntity['id']) =>
     getProduct(state, productId),
   (state: StoreState, productId: ProductEntity['id'], setType: number) =>

--- a/packages/redux/src/products/selectors/sizes.ts
+++ b/packages/redux/src/products/selectors/sizes.ts
@@ -3,7 +3,7 @@ import { getError, getIsLoading } from '../reducer/sizes';
 import { getProduct } from './product';
 import type { ProductEntity } from '../../entities/types';
 import type { ProductsState } from '../types';
-import type { StoreState } from '../../types';
+import type { SizeAdapted, StoreState } from '../../types';
 
 /**
  * Returns the loading product sizes condition to a specific product.
@@ -68,7 +68,10 @@ export const getProductSizes = (state: StoreState, id: ProductEntity['id']) => {
  *
  * @returns The sizes with stock for a given product id.
  */
-export const getProductSizesWithStock = createSelector(
+export const getProductSizesWithStock: (
+  state: StoreState,
+  productId: ProductEntity['id'],
+) => SizeAdapted[] | undefined = createSelector(
   (state: StoreState, id: ProductEntity['id']) => getProductSizes(state, id),
   sizes => sizes?.filter(size => !size.isOutOfStock),
 );

--- a/packages/redux/src/sharedWishlists/__tests__/selectors.test.ts
+++ b/packages/redux/src/sharedWishlists/__tests__/selectors.test.ts
@@ -59,7 +59,7 @@ describe('shared wishlists redux selectors', () => {
       ...sharedWishlistEntity,
     };
 
-    it('should return all data regarding a shared wishlist item', () => {
+    it('should return all data regarding a shared wishlist', () => {
       const spy = jest.spyOn(fromEntities, 'getEntityById');
 
       expect(
@@ -79,23 +79,20 @@ describe('shared wishlists redux selectors', () => {
   describe('getSharedWishlistItem()', () => {
     const expectedResult = {
       ...sharedWishlistItemEntity,
-      product: { ...mockProductsEntity[mockProductId] },
+      product: {
+        ...mockProductsEntity[mockProductId],
+        brand: mockSharedWishlistState.entities.brands[2450],
+        categories: [mockSharedWishlistState.entities.categories[136301]],
+      },
     };
 
     it('should return all data regarding a shared wishlist item', () => {
-      const spy = jest.spyOn(fromEntities, 'getEntityById');
-
       expect(
         selectors.getSharedWishlistItem(
           mockSharedWishlistState,
           mockSharedWishlistItemId,
         ),
       ).toEqual(expectedResult);
-      expect(spy).toHaveBeenCalledWith(
-        mockSharedWishlistState,
-        'sharedWishlistItems',
-        mockSharedWishlistItemId,
-      );
     });
   });
 
@@ -106,7 +103,11 @@ describe('shared wishlists redux selectors', () => {
           ...mockSharedWishlistState.entities.sharedWishlistItems[
             mockSharedWishlistItemId
           ],
-          product: mockSharedWishlistState.entities.products[mockProductId],
+          product: {
+            ...mockSharedWishlistState.entities.products[mockProductId],
+            brand: mockSharedWishlistState.entities.brands[2450],
+            categories: [mockSharedWishlistState.entities.categories[136301]],
+          },
         },
         {
           ...mockSharedWishlistState.entities.sharedWishlistItems[102],
@@ -115,6 +116,8 @@ describe('shared wishlists redux selectors', () => {
             ...mockProductsEntity[mockProductId],
             id: 1002,
             description: 'wide leg pant',
+            brand: mockSharedWishlistState.entities.brands[2450],
+            categories: [mockSharedWishlistState.entities.categories[136301]],
           },
           quantity: 2,
         },

--- a/packages/redux/src/sizeScales/selectors.ts
+++ b/packages/redux/src/sizeScales/selectors.ts
@@ -1,5 +1,5 @@
+import { CategoryEntity, getEntities, getEntityById } from '../entities';
 import { createSelector } from 'reselect';
-import { getEntities, getEntityById } from '../entities';
 import {
   getError,
   getIsLoading,
@@ -43,7 +43,10 @@ export const getSizeScales = (state: StoreState) =>
  *
  * @returns Size scales for the provided category id.
  */
-export const getSizeScalesByCategory = createSelector(
+export const getSizeScalesByCategory: (
+  state: StoreState,
+  categoryId: CategoryEntity['id'],
+) => SizeScale[] = createSelector(
   [
     getSizeScales,
     (state: StoreState, categoryId: Category['id']) => categoryId,

--- a/packages/redux/src/subscriptions/selectors/subscriptionPackages.ts
+++ b/packages/redux/src/subscriptions/selectors/subscriptionPackages.ts
@@ -3,6 +3,7 @@ import { getEntities } from '../../entities';
 import defaultTo from 'lodash/defaultTo';
 import get from 'lodash/get';
 import type { StoreState } from '../../types';
+import type { SubscriptionPackage } from '@farfetch/blackout-client';
 
 /*
  * @param state - Application state.
@@ -30,15 +31,18 @@ export const getSubscriptionPackagesError = (state: StoreState, hash: string) =>
  *
  * @returns Subscription package result.
  */
-export const getSubscriptionPackages = createSelector(
+export const getSubscriptionPackages: (
+  state: StoreState,
+  hash: string,
+) => SubscriptionPackage[] | null | undefined = createSelector(
   (state: StoreState, hash: string) => getContentByHash(state, hash)?.result,
   (state: StoreState) => getEntities(state, 'subscriptionPackages'),
   (subscriptionPackagesResult, subscriptionPackagesEntity) => {
     return (
       subscriptionPackagesResult &&
-      subscriptionPackagesResult.packages
+      (subscriptionPackagesResult.packages
         .map(packageId => get(subscriptionPackagesEntity, packageId))
-        .filter(Boolean)
+        .filter(Boolean) as SubscriptionPackage[])
     );
   },
 );

--- a/packages/redux/src/subscriptions/selectors/userSubscriptions.ts
+++ b/packages/redux/src/subscriptions/selectors/userSubscriptions.ts
@@ -2,7 +2,10 @@ import * as userSubscriptionReducer from '../reducer/userSubscriptions';
 import { createSelector } from 'reselect';
 import defaultTo from 'lodash/defaultTo';
 import type { StoreState } from '../../types';
-import type { SubscriptionsState } from './../types';
+import type {
+  SubscriptionsState,
+  UnsubscribeRecipientFromTopicType,
+} from './../types';
 import type { SubscriptionTopic } from '@farfetch/blackout-client';
 
 // Default user subscriptions value for the following selectors.
@@ -50,7 +53,10 @@ export const getUserSubscriptions = (state: StoreState) =>
  *
  * @returns User subscribed topics for the specified platform.
  */
-export const getUserSubscribedTopicsForPlatform = createSelector(
+export const getUserSubscribedTopicsForPlatform: (
+  state: StoreState,
+  platform: string,
+) => SubscriptionTopic[] = createSelector(
   (state: StoreState) =>
     defaultTo(getUserSubscriptions(state), DEFAULT_USER_SUBSCRIPTIONS_VALUE),
   (_: unknown, platform: string) => platform,
@@ -84,7 +90,10 @@ export const getUserSubscribedTopicsForPlatform = createSelector(
  *
  * @returns User subscribed topics for the specified address.
  */
-export const getUserSubscribedTopicsForAddress = createSelector(
+export const getUserSubscribedTopicsForAddress: (
+  state: StoreState,
+  address: string,
+) => SubscriptionTopic[] = createSelector(
   (state: StoreState) =>
     defaultTo(getUserSubscriptions(state), DEFAULT_USER_SUBSCRIPTIONS_VALUE),
   (_: unknown, address: string) => address,
@@ -172,18 +181,21 @@ export const getUnsubscribeRecipientFromTopicRequest = (
  *
  * @returns All unsubscribe recipient from topic requests state.
  */
-export const getUnsubscribeRecipientFromTopicRequests = createSelector(
-  (state: StoreState) =>
-    userSubscriptionReducer.getUnsubscribeRecipientFromTopicRequests(
-      state.subscriptions?.user,
-    ),
-  unsubscribeRecipientFromTopicRequests =>
-    Object.entries(unsubscribeRecipientFromTopicRequests || {}).map(
-      ([recipientId, unsubscribeRequestState]) => {
-        return {
-          ...unsubscribeRequestState,
-          recipientId,
-        };
-      },
-    ),
-);
+export const getUnsubscribeRecipientFromTopicRequests: (
+  state: StoreState,
+) => (UnsubscribeRecipientFromTopicType & { recipientId: string })[] =
+  createSelector(
+    (state: StoreState) =>
+      userSubscriptionReducer.getUnsubscribeRecipientFromTopicRequests(
+        state.subscriptions?.user,
+      ),
+    unsubscribeRecipientFromTopicRequests =>
+      Object.entries(unsubscribeRecipientFromTopicRequests || {}).map(
+        ([recipientId, unsubscribeRequestState]) => {
+          return {
+            ...unsubscribeRequestState,
+            recipientId,
+          };
+        },
+      ),
+  );

--- a/packages/redux/src/wishlists/actions/factories/removeWishlistItemFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/removeWishlistItemFactory.ts
@@ -15,7 +15,7 @@ import type {
   RemoveWishlistItemAction,
   WishlistItemActionMetadata,
 } from '../../types';
-import type { WishlistItemHydrated } from '../../../entities/types';
+import type { WishlistItemDenormalized } from '../../../entities/types';
 
 /**
  * Creates a thunk factory configured with the specified client to remove a
@@ -39,7 +39,7 @@ const removeWishlistItemFactory =
       getOptions = ({ productImgQueryParam }) => ({ productImgQueryParam }),
     }: GetOptionsArgument,
   ): Promise<Wishlist | undefined> => {
-    let wishlistItem: WishlistItemHydrated | undefined;
+    let wishlistItem: WishlistItemDenormalized | undefined;
     try {
       const state = getState();
       const wishlistId = getWishlistId(state);

--- a/packages/redux/src/wishlists/actions/factories/updateWishlistItemFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/updateWishlistItemFactory.ts
@@ -16,7 +16,7 @@ import type {
   UpdateWishlistItemAction,
   WishlistItemActionMetadata,
 } from '../../types';
-import type { WishlistItemHydrated } from '../../../entities/types';
+import type { WishlistItemDenormalized } from '../../../entities/types';
 
 /**
  * Creates a thunk factory configured with the specified client to update a
@@ -41,7 +41,7 @@ const updateWishlistItemFactory =
       getOptions = ({ productImgQueryParam }) => ({ productImgQueryParam }),
     }: GetOptionsArgument,
   ): Promise<Wishlist | undefined> => {
-    let wishlistItem: WishlistItemHydrated | undefined;
+    let wishlistItem: WishlistItemDenormalized | undefined;
 
     try {
       const state = getState();

--- a/packages/redux/src/wishlists/selectors/wishlistsSets.ts
+++ b/packages/redux/src/wishlists/selectors/wishlistsSets.ts
@@ -5,9 +5,9 @@ import { getProductDenormalized } from '../../products';
 import type { StoreState } from '../../types';
 import type { WishlistSet } from '@farfetch/blackout-client';
 import type {
+  WishlistSetDenormalized,
   WishlistSetEntity,
-  WishlistSetHydrated,
-  WishlistSetsHydrated,
+  WishlistSetsDenormalized,
 } from '../../entities/types';
 import type { WishlistSetsErrors } from './types/wishlistsSets.types';
 import type { WishlistsState } from '../types';
@@ -166,7 +166,7 @@ export const isWishlistSetFetched = (
 export const getWishlistSet: (
   state: StoreState,
   setId: WishlistSet['setId'],
-) => WishlistSetHydrated | undefined = createSelector(
+) => WishlistSetDenormalized | undefined = createSelector(
   [
     (state: StoreState) => getEntities(state, 'wishlistItems'),
     (
@@ -198,7 +198,7 @@ export const getWishlistSet: (
     return {
       ...wishlistSet,
       wishlistSetItems,
-    } as WishlistSetHydrated;
+    } as WishlistSetDenormalized;
   },
 );
 
@@ -218,13 +218,14 @@ export const getWishlistSet: (
  *
  * @returns List of wishlist sets.
  */
-export const getWishlistSets = createSelector(
-  [getWishlistSetsIds, state => state],
-  (wishlistSetsIds, state) =>
-    wishlistSetsIds?.map(setId =>
-      getWishlistSet(state, setId),
-    ) as WishlistSetsHydrated,
-);
+export const getWishlistSets: (state: StoreState) => WishlistSetsDenormalized =
+  createSelector(
+    [getWishlistSetsIds, state => state],
+    (wishlistSetsIds, state) =>
+      wishlistSetsIds
+        ?.map(setId => getWishlistSet(state, setId))
+        .filter(Boolean) as WishlistSetDenormalized[],
+  );
 
 /**
  * Retrieves the number of different items in the wishlist set, regardless of each
@@ -371,7 +372,9 @@ export const areWishlistSetsWithAnyError = (state: StoreState) => {
  * @returns Errors that occurred for a specific wishlist set, with the "id", "name" and "error"
  * information. Undefined if there are no errors.
  */
-export const getAllWishlistSetsErrors = createSelector(
+export const getAllWishlistSetsErrors: (
+  state: StoreState,
+) => WishlistSetsErrors | undefined = createSelector(
   [
     getWishlistSetsIds,
     state => fromWishlistSetsReducer.getSetError(state.wishlist.sets),

--- a/tests/__fixtures__/sharedWishlists/sharedWishlists.fixtures.ts
+++ b/tests/__fixtures__/sharedWishlists/sharedWishlists.fixtures.ts
@@ -1,5 +1,5 @@
+import { Gender, SharedWishlistItem } from '@farfetch/blackout-client';
 import { mockProductsEntity } from '../products';
-import type { SharedWishlistItem } from '@farfetch/blackout-client';
 
 export const mockSharedWishlistId = '3fa85f64-5717-4562-b3fc-2c963f66afa6';
 export const mockSharedWishlistItemId = 481426747;
@@ -136,6 +136,13 @@ export const mockSharedWishlistState = {
         name: 'Balenciaga',
         priceType: 0,
         slug: 'rockstud-sling-back-flats-12854475',
+      },
+    },
+    categories: {
+      136301: {
+        id: 136301,
+        name: 'Trousers',
+        gender: Gender.Man,
       },
     },
   },


### PR DESCRIPTION
## Description

- This fixes the typings of all selectors that are based on createSelector as the types generated by createSelector by default are not very understandable for the consumer.
- Changed sharedWishlistItem selectors to avoid sending a new reference even when data has not changed.
- Renamed types that contain `Hydrated` in its name to `Denormalized` to be consistent with other types.
- Fixed Omnitracking integration logging message that did not contain the
Omnitracking prefix.

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
