### PR TITLE
feat(analytics|react): normalize property of productId on Analytics for next

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -986,7 +986,7 @@ Object {
 
 exports[`Omnitracking track events definitions \`product-details\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":12122479,\\"itemPromotion\\":1,\\"designerName\\":\\"Saint Laurent\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":2,\\"sizeID\\":\\"20\\",\\"itemQuantity\\":13,\\"promoCode\\":\\"EASTER2022\\",\\"storeID\\":20000}]",
+  "lineItems": "[{\\"productId\\":\\"12122479\\",\\"itemPromotion\\":1,\\"designerName\\":\\"Saint Laurent\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":2,\\"sizeID\\":\\"20\\",\\"itemQuantity\\":13,\\"promoCode\\":\\"EASTER2022\\",\\"storeID\\":20000}]",
   "viewSubType": "Product",
   "viewType": "Product",
 }

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
@@ -4,7 +4,6 @@ import {
   getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
   getGenderValueFromProperties,
-  getOmnitrackingProductId,
   getPageEventFromLocation,
   getPlatformSpecificParameters,
   getProductLineItemsQuantity,
@@ -169,41 +168,6 @@ describe('getCommonCheckoutStepTrackingData', () => {
         '{"deliveryType":"sample_delivery","courierType":"sample_shipping"}',
       interactionType: 'click',
     });
-  });
-});
-
-describe('getOmnitrackingProductId', () => {
-  it('should return product id over id', () => {
-    const data = {
-      properties: {
-        productId: 123,
-        id: 432,
-      } as Record<string, unknown>,
-    } as EventData<TrackTypesValues>;
-
-    expect(getOmnitrackingProductId(data)).toEqual(123);
-  });
-
-  it('should return id without product id', () => {
-    const data = {
-      properties: {
-        productId: undefined,
-        id: 432,
-      } as Record<string, unknown>,
-    } as EventData<TrackTypesValues>;
-
-    expect(getOmnitrackingProductId(data)).toEqual(432);
-  });
-
-  it('should return undefined instead of id property if method has been called with true on useOnlyProductIdField parameter', () => {
-    const data = {
-      properties: {
-        productId: undefined,
-        id: 432,
-      } as Record<string, unknown>,
-    } as EventData<TrackTypesValues>;
-
-    expect(getOmnitrackingProductId(data, true)).toEqual(undefined);
   });
 });
 describe('getGenderValueFromProperties', () => {

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -3,11 +3,10 @@ import {
   getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
   getGenderValueFromProperties,
-  getOmnitrackingProductId,
   getProductLineItems,
   getProductLineItemsQuantity,
 } from './omnitracking-helper';
-import { logger } from '../../utils';
+import { getProductId, logger } from '../../utils';
 import eventTypes from '../../types/eventTypes';
 import interactionTypes from '../../types/interactionTypes';
 import pageTypes from '../../types/pageTypes';
@@ -19,7 +18,6 @@ import type {
 } from './types/Omnitracking.types';
 
 export const PRODUCT_ID_PARAMETER = 'productId';
-export const PRODUCT_ID_PARAMETER_FROM_BAG_WISHLIST = 'id';
 
 /**
  * Common parameters to any event. This list is extended by each page event
@@ -495,7 +493,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
   [eventTypes.SHARE]: data => ({
     tid: 1205,
     actionArea: data.properties?.from,
-    productId: getOmnitrackingProductId(data),
+    productId: getProductId(data.properties),
   }),
   [eventTypes.LOGIN]: data => ({
     tid: 2924,
@@ -508,7 +506,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
   [eventTypes.PRODUCT_CLICKED]: data => ({
     tid: 2926,
     actionArea: data.properties?.from,
-    productId: getOmnitrackingProductId(data),
+    productId: getProductId(data.properties),
     lineItems: getProductLineItems(data),
   }),
   [eventTypes.PRODUCT_ADDED_TO_CART]: data => ({
@@ -542,7 +540,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
       contentType: properties?.contentType,
       interactionType: properties?.interactionType,
       val: properties?.id,
-      productId: getOmnitrackingProductId(data, true),
+      productId: properties?.productId,
     } as OmnitrackingTrackEventParameters;
   },
   [eventTypes.FILTERS_APPLIED]: (data: EventData<TrackTypesValues>) => ({
@@ -603,7 +601,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
       eventList.push({
         ...additionalParameters,
         tid: 2098,
-        productId: properties?.id,
+        productId: getProductId(properties),
         actionArea: properties?.from,
       });
     }
@@ -639,7 +637,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
       eventList.push({
         ...additionalParameters,
         tid: 2920,
-        productId: properties?.id,
+        productId: getProductId(properties),
         actionArea: properties?.from,
       });
     }
@@ -652,7 +650,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
 
       eventList.push({
         tid: 2919,
-        productId: properties?.id,
+        productId: getProductId(properties),
         actionArea: properties?.from,
         itemQuantity: properties?.quantity,
       });

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -12,7 +12,7 @@ import {
   DEFAULT_CLIENT_LANGUAGE,
   DEFAULT_SEARCH_QUERY_PARAMETERS,
 } from './constants';
-import { getCustomerIdFromUser, logger } from '../../utils';
+import { getCustomerIdFromUser, getProductId, logger } from '../../utils';
 import { isPageEventType, isScreenEventType } from '../../utils/typePredicates';
 import {
   pageActionEventTypes,
@@ -549,24 +549,6 @@ export const getClientLanguageFromCulture = (culture = '') => {
 };
 
 /**
- * Obtain product Id omnitracking parameter.
- *
- * @param data - The event tracking data.
- * @param useOnlyProductIdField - Should be true when it's only to use productId field.
- *
- * @returns The product id.
- */
-export const getOmnitrackingProductId = (
-  data: EventData<TrackTypesValues>,
-  useOnlyProductIdField = false,
-) => {
-  return (
-    data?.properties?.productId ||
-    (useOnlyProductIdField ? undefined : data?.properties?.id)
-  );
-};
-
-/**
  * Transforms the products list payload into `lineItems` omnitracking parameter.
  *
  * @param data - The event tracking data.
@@ -576,11 +558,11 @@ export const getOmnitrackingProductId = (
 export const getProductLineItems = (data: EventData<TrackTypesValues>) => {
   const properties = data?.properties || {};
   const productsList = properties.products;
-  const productId = getOmnitrackingProductId(data);
+  const productId = getProductId(properties);
 
   if (productsList && productsList.length) {
     const mappedProductList = productsList.map(product => ({
-      productId: product.id,
+      productId: getProductId(product),
       itemPromotion: product.discountValue,
       designerName: product.brand,
       category: (product.category || '').split('/')[0],
@@ -629,7 +611,7 @@ export const getCheckoutEventGenericProperties = (
   if (!validOrderCode) {
     logger.warn(
       `[Omnitracking] - Event ${data.event} property orderId should be an alphanumeric value.
-                        If you send the internal orderId, please use 'orderId' (e.g.: 5H5QYB) 
+                        If you send the internal orderId, please use 'orderId' (e.g.: 5H5QYB)
                         and 'checkoutOrderId' (e.g.:123123123)`,
     );
   }

--- a/packages/analytics/src/utils/getters.ts
+++ b/packages/analytics/src/utils/getters.ts
@@ -3,6 +3,8 @@ import type {
   AnalyticsProduct,
   EventData,
   EventProperties,
+  LoadIntegrationEventData,
+  SetUserEventData,
   TrackTypesValues,
 } from '../types/analytics.types';
 import type URLParse from 'url-parse';
@@ -99,7 +101,10 @@ export const getProductName = (unmappedProduct: AnalyticsProduct): string => {
 };
 
 export const getLocation = (
-  data: EventData<TrackTypesValues>,
+  data:
+    | EventData<TrackTypesValues>
+    | SetUserEventData
+    | LoadIntegrationEventData,
 ): URLParse<Record<string, string | undefined>> => {
   return get(data, 'context.web.window.location', {});
 };

--- a/packages/analytics/src/utils/getters.ts
+++ b/packages/analytics/src/utils/getters.ts
@@ -82,10 +82,14 @@ export const getCheckoutProperties = (
   };
 };
 
-export const getProductId = (unmappedProduct: AnalyticsProduct): string => {
+export const getProductId = (
+  unmappedProduct: AnalyticsProduct,
+): string | undefined => {
   // Validation of event properties are done before this function is called
   // so the cast is acceptable here.
-  return unmappedProduct.id as string;
+  const productId = unmappedProduct.productId || unmappedProduct.id;
+
+  return productId ? `${productId}` : undefined;
 };
 
 export const getProductName = (unmappedProduct: AnalyticsProduct): string => {

--- a/packages/react/src/analytics/integrations/GA/commands.ts
+++ b/packages/react/src/analytics/integrations/GA/commands.ts
@@ -327,7 +327,7 @@ const commands = {
         EVENT_CATEGORY_ECOMMERCE,
         eventTypes.PRODUCT_ADDED_TO_CART,
         getProductEventLabel(
-          utils.getProductId(productData),
+          utils.getProductId(productData) as string,
           utils.getProductName(productData),
         ),
       ),
@@ -360,7 +360,7 @@ const commands = {
         EVENT_CATEGORY_ECOMMERCE,
         eventTypes.PRODUCT_REMOVED_FROM_CART,
         getProductEventLabel(
-          utils.getProductId(productData),
+          utils.getProductId(productData) as string,
           utils.getProductName(productData),
         ),
       ),
@@ -377,7 +377,7 @@ const commands = {
         EVENT_CATEGORY_ECOMMERCE,
         `${eventTypes.PRODUCT_ADDED_TO_WISHLIST} - ${utils.getList(data)}`,
         getProductEventLabel(
-          utils.getProductId(productData),
+          utils.getProductId(productData) as string,
           utils.getProductName(productData),
         ),
       ),
@@ -394,7 +394,7 @@ const commands = {
         EVENT_CATEGORY_ECOMMERCE,
         `${eventTypes.PRODUCT_REMOVED_FROM_WISHLIST} - ${utils.getList(data)}`,
         getProductEventLabel(
-          utils.getProductId(productData),
+          utils.getProductId(productData) as string,
           utils.getProductName(productData),
         ),
       ),
@@ -411,7 +411,7 @@ const commands = {
         EVENT_CATEGORY_ECOMMERCE,
         utils.getList(data),
         getProductEventLabel(
-          utils.getProductId(productData),
+          utils.getProductId(productData) as string,
           utils.getProductName(productData),
         ),
       ),
@@ -438,7 +438,7 @@ const commands = {
         EVENT_CATEGORY_ECOMMERCE,
         eventTypes.PRODUCT_CLICKED,
         getProductEventLabel(
-          utils.getProductId(productData),
+          utils.getProductId(productData) as string,
           utils.getProductName(productData),
         ),
       ),
@@ -470,7 +470,7 @@ const commands = {
         EVENT_CATEGORY_ECOMMERCE,
         eventTypes.PRODUCT_VIEWED,
         getProductEventLabel(
-          utils.getProductId(productData),
+          utils.getProductId(productData) as string,
           utils.getProductName(productData),
         ),
       ),

--- a/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.ts
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.ts
@@ -1465,13 +1465,15 @@ describe('GA4 Integration', () => {
                 trackEventsData[eventTypes.INTERACT_CONTENT],
               );
 
-              expect(ga4Spy).toHaveBeenCalledWith('event', 'interact_content', {
-                content_type: 'biz',
-                some_other_property: 12312312,
-                interaction_type: interactionTypes.CLICK,
-                __blackoutAnalyticsEventId: expect.any(String),
-                state: 'dummy',
-              });
+              expect(ga4Spy).toHaveBeenCalledWith(
+                'event',
+                'interact_content',
+                expect.objectContaining({
+                  content_type: 'biz',
+                  some_other_property: 12312312,
+                  interaction_type: interactionTypes.CLICK,
+                }),
+              );
             });
           });
         });

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -7,7 +7,9 @@ Array [
     "scroll",
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
-      "percent_scrolled": "25%",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
+      "percent_scrolled": 25,
     },
   ],
 ]
@@ -21,6 +23,8 @@ Array [
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "newsletter_gender": "Woman,Man",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
   Array [
@@ -29,6 +33,8 @@ Array [
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "newsletter_gender": "WOMAN,MAN",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
   Array [
@@ -37,6 +43,8 @@ Array [
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "newsletter_gender": "Woman,Man",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -50,6 +58,8 @@ Array [
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "newsletter_gender": "Woman",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -88,6 +98,8 @@ Array [
           "size": "L",
         },
       ],
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "value": 13,
       "wishlist_id": undefined,
       "wishlist_name": undefined,
@@ -112,6 +124,8 @@ Array [
     "search",
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "search_term": "shoes",
     },
   ],
@@ -134,6 +148,8 @@ Array [
     "view_wishlist",
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "wishlist_id": "d3618128-5aa9-4caa-a452-1dd1377a6190",
     },
   ],
@@ -167,6 +183,8 @@ Array [
   "search",
   Object {
     "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
+    "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+    "path_clean": "/en-pt/",
     "search_term": "term",
   },
 ]
@@ -178,6 +196,8 @@ Array [
   "search",
   Object {
     "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
+    "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+    "path_clean": "/en-pt/",
     "search_term": "query",
   },
 ]
@@ -195,6 +215,8 @@ Array [
       "currency": "USD",
       "delivery_type": "Standard/Standard",
       "packaging_type": undefined,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "shipping_tier": "Next Day",
       "value": 24.64,
     },
@@ -211,6 +233,8 @@ Array [
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "coupon": "ACME2019",
       "currency": "USD",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "value": 24.64,
     },
   ],
@@ -248,6 +272,8 @@ Array [
           "size": "L",
         },
       ],
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "value": 24.64,
     },
   ],
@@ -262,6 +288,8 @@ Array [
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "checkout_step": 1,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -275,6 +303,8 @@ Array [
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "filters": "{\\"brands\\":[2765,4062],\\"categories\\":[135973],\\"colors\\":[1],\\"discount\\":[0],\\"gender\\":[0],\\"price\\":[0,1950],\\"sizes\\":[16]}",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -288,6 +318,8 @@ Array [
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "filters": "{\\"brands\\":[2765,4062],\\"categories\\":[135973],\\"colors\\":[1],\\"discount\\":[0],\\"gender\\":[0],\\"price\\":[0,1950],\\"sizes\\":[16]}",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -302,6 +334,8 @@ Array [
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "content_type": "biz",
       "interaction_type": "Click",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "some_other_property": 12312312,
       "state": "dummy",
     },
@@ -317,6 +351,8 @@ Array [
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "method": "Acme",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -354,6 +390,8 @@ Array [
           "size": "L",
         },
       ],
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "shipping": 3.6,
       "tax": 2.04,
       "transaction_id": "ABC12",
@@ -395,6 +433,8 @@ Array [
           "size": "L",
         },
       ],
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "shipping": undefined,
       "tax": undefined,
       "transaction_id": "50314b8e9bcf000000000000",
@@ -435,6 +475,8 @@ Array [
           "size": "L",
         },
       ],
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "payment_type": "credit card",
       "value": 24.64,
     },
@@ -452,6 +494,8 @@ Array [
       "affiliation": undefined,
       "coupon": "ACME2019",
       "currency": "USD",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "shipping": 3.6,
       "tax": 2.04,
       "transaction_id": "50314b8e9bcf000000000000",
@@ -492,6 +536,8 @@ Array [
           "size": "L",
         },
       ],
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "value": 19,
       "wishlist_id": undefined,
       "wishlist_name": undefined,
@@ -531,6 +577,8 @@ Array [
           "size": undefined,
         },
       ],
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "value": 19,
       "wishlist_id": "d3618128-5aa9-4caa-a452-1dd1377a6190",
       "wishlist_name": undefined,
@@ -566,6 +614,8 @@ Array [
           "size": undefined,
         },
       ],
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -620,6 +670,8 @@ Array [
         },
       ],
       "non_interaction": true,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "sort_option": undefined,
     },
   ],
@@ -649,6 +701,8 @@ Array [
       "item_name": "Gareth McConnell Dreamscape T-Shirt",
       "item_variant": "Black",
       "location_id": undefined,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "price": 25,
       "quantity": undefined,
       "size": undefined,
@@ -691,6 +745,8 @@ Array [
           "size": "L",
         },
       ],
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "value": 19,
       "wishlist_id": undefined,
       "wishlist_name": undefined,
@@ -730,6 +786,8 @@ Array [
         },
       ],
       "non_interaction": true,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "value": 19,
     },
   ],
@@ -748,6 +806,8 @@ Array [
       "currency": "USD",
       "delivery_type": undefined,
       "packaging_type": undefined,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "shipping_tier": "Next Day",
       "value": 24.64,
     },
@@ -764,6 +824,8 @@ Array [
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "content_type": "biz",
       "item_id": 12312312,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -779,6 +841,8 @@ Array [
       "content_type": "image",
       "item_id": "123456",
       "method": "Facebook",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -818,6 +882,8 @@ Array [
         },
       ],
       "packaging_type": undefined,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "shipping_tier": "Next Day",
       "value": 24.64,
     },
@@ -837,6 +903,8 @@ Array [
       "currency": "USD",
       "delivery_type": "Standard/Standard",
       "packaging_type": undefined,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "shipping_tier": "Next Day",
       "value": 24.64,
     },
@@ -852,6 +920,8 @@ Array [
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "method": "Acme",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -865,6 +935,8 @@ Array [
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "newsletter_gender": "Woman",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -882,6 +954,8 @@ Array [
       "item_id": "507f1f77bcf86cd799439011",
       "item_name": "Gareth McConnell Dreamscape T-Shirt",
       "old_colour": "black",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -898,6 +972,8 @@ Array [
       "item_id": "507f1f77bcf86cd799439011",
       "item_name": "Gareth McConnell Dreamscape T-Shirt",
       "old_quantity": 2,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "quantity": 1,
     },
   ],
@@ -915,6 +991,8 @@ Array [
       "item_id": "507f1f77bcf86cd799439011",
       "item_name": "Gareth McConnell Dreamscape T-Shirt",
       "old_quantity": 2,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "quantity": 1,
     },
   ],
@@ -927,6 +1005,8 @@ Array [
       "item_id": "507f1f77bcf86cd799439011",
       "item_name": "Gareth McConnell Dreamscape T-Shirt",
       "old_size": "S",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "size": "L",
     },
   ],
@@ -940,6 +1020,8 @@ Array [
       "item_id": "507f1f77bcf86cd799439011",
       "item_name": "Gareth McConnell Dreamscape T-Shirt",
       "old_colour": "black",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]
@@ -956,6 +1038,8 @@ Array [
       "item_id": "507f1f77bcf86cd799439011",
       "item_name": "Gareth McConnell Dreamscape T-Shirt",
       "old_quantity": 2,
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
       "quantity": 1,
     },
   ],
@@ -969,6 +1053,8 @@ Array [
       "item_id": "507f1f77bcf86cd799439011",
       "item_name": "Gareth McConnell Dreamscape T-Shirt",
       "old_colour": "black",
+      "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/en-pt/",
     },
   ],
 ]

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.ts
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.ts
@@ -674,7 +674,7 @@ const getSignupNewsletterParametersFromEvent = (
  */
 const getScrollParametersFromEvent = (eventProperties: EventProperties) => {
   return {
-    percent_scrolled: `${eventProperties.percentageScrolled}%`,
+    percent_scrolled: eventProperties.percentageScrolled,
   };
 };
 

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.ts
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.ts
@@ -633,7 +633,7 @@ const getCheckoutStepEditingParametersFromEvent = (
 const getShareParametersFromEvent = (eventProperties: EventProperties) => ({
   method: eventProperties.method,
   content_type: eventProperties.contentType,
-  item_id: eventProperties.id,
+  item_id: utils.getProductId(eventProperties),
 });
 
 /**

--- a/packages/react/src/analytics/integrations/GA4/types/index.ts
+++ b/packages/react/src/analytics/integrations/GA4/types/index.ts
@@ -1,9 +1,11 @@
 import type {
+  EventData,
   IntegrationOptions,
   LoadIntegrationEventData,
   PageviewEventData,
   SetUserEventData,
   TrackEventData,
+  TrackTypesValues,
 } from '@farfetch/blackout-analytics';
 import type {
   OPTION_DATA_LAYER_NAME,
@@ -41,8 +43,7 @@ export type NonInteractionEvents = Record<string, boolean>;
 export type OnPreProcessCommandsHandler = (
   commandList: GA4CommandList,
   data:
-    | TrackEventData
-    | PageviewEventData
+    | EventData<TrackTypesValues>
     | SetUserEventData
     | LoadIntegrationEventData,
 ) => GA4CommandList;


### PR DESCRIPTION
## Description

- Normalize mapping of property productId on Omnitracking and GA4 integrations.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
