### PR TITLE
Fix omnitracking navigatedfrom parameter logic

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
+++ b/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
@@ -203,11 +203,6 @@ class Omnitracking extends Integration<OmnitrackingOptions> {
       }
 
       const { user } = data;
-
-      this.lastFromParameter = (data?.properties?.from || null) as
-        | string
-        | null;
-
       const userTraits = get(user, 'traits', {}) as UserTraits;
 
       precalculatedPageViewParameters.userGender = get(
@@ -239,6 +234,14 @@ class Omnitracking extends Integration<OmnitrackingOptions> {
         getClientLanguageFromCulture(culture);
       precalculatedPageViewParameters.clientCulture = culture;
     }
+
+    // Always set the `lastFromParameter` with what comes from the current event (pageview or not),
+    // so if there's a pageview being tracked right after this one,
+    // it will send the correct `navigatedFrom` parameter.
+    // Here we always set the value even if it comes `undefined` or `null`,
+    // otherwise we could end up with a stale `lastFromParameter` if some events are tracked
+    // without the `from` parameter.
+    this.lastFromParameter = (data?.properties?.from || null) as string | null;
 
     precalculatedParameters.uniqueViewId = this.currentUniqueViewId;
     precalculatedParameters.viewCurrency = currencyCode;
@@ -345,7 +348,7 @@ class Omnitracking extends Integration<OmnitrackingOptions> {
     if (!this.validateTrackingRequisites()) {
       logger.error(
         `[Omnitracking] - Event ${data.event} could not be tracked since it had no unique view id.
-         A possible cause is trying to track an event before tracking a page view. 
+         A possible cause is trying to track an event before tracking a page view.
          Make sure you are tracking events after page views are tracked.
          This event will not be tracked with Omnitracking.`,
       );


### PR DESCRIPTION
## Description

- applied same logic as main logic releated with navigated from parameter
of omnitracking.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None. 
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
