### PR TITLE
feat(core): add new get user returns endpoints

### DIFF
--- a/packages/core/src/profile/client/__fixtures__/getUserReturns.fixtures.js
+++ b/packages/core/src/profile/client/__fixtures__/getUserReturns.fixtures.js
@@ -1,0 +1,28 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+/**
+ * Response payloads.
+ */
+export default {
+  success: params => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', params.userId, '/returns'),
+      {
+        method: 'get',
+        response: params.response,
+        status: 200,
+      },
+    );
+  },
+  failure: params => {
+    moxios.stubRequest(
+      join('/api/account/v1/users', params.userId, '/returns'),
+      {
+        method: 'get',
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/core/src/profile/client/__tests__/__snapshots__/getUserReturns.test.js.snap
+++ b/packages/core/src/profile/client/__tests__/__snapshots__/getUserReturns.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getUserReturns should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/profile/client/__tests__/getUserReturns.test.js
+++ b/packages/core/src/profile/client/__tests__/getUserReturns.test.js
@@ -1,0 +1,43 @@
+import { getUserReturns } from '..';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/getUserReturns.fixtures';
+import moxios from 'moxios';
+
+describe('getUserReturns', () => {
+  const expectedConfig = undefined;
+  const userId = '123456';
+  const spy = jest.spyOn(client, 'get');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = {};
+
+    fixtures.success({ userId, response });
+
+    expect.assertions(2);
+
+    await expect(getUserReturns(userId)).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${userId}/returns`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure({ userId });
+
+    expect.assertions(2);
+    await expect(getUserReturns(userId)).rejects.toMatchSnapshot();
+    expect(spy).toHaveBeenCalledWith(
+      `/account/v1/users/${userId}/returns`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/profile/client/getUserReturns.js
+++ b/packages/core/src/profile/client/getUserReturns.js
@@ -1,0 +1,23 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * Method responsible for getting all the user returns.
+ *
+ * @function getUserReturns
+ * @memberof module:profile/client
+ *
+ * @param {number} userId - The user's id.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Promise} Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+export default (userId, config) =>
+  client
+    .get(join('/account/v1/users', userId, '/returns'), config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/profile/client/index.js
+++ b/packages/core/src/profile/client/index.js
@@ -40,3 +40,4 @@ export { default as patchPersonalId } from './patchPersonalId';
 export { default as postPersonalIdImage } from './postPersonalIdImage';
 export { default as getUserBenefits } from './getUserBenefits';
 export { default as getGuestUserBenefits } from './getGuestUserBenefits';
+export { default as getUserReturns } from './getUserReturns';

--- a/packages/core/src/profile/redux/__fixtures__/userReturns.fixtures.js
+++ b/packages/core/src/profile/redux/__fixtures__/userReturns.fixtures.js
@@ -1,0 +1,87 @@
+export const mockGetUserReturnsResponse = {
+  number: 1,
+  totalPages: 1,
+  totalItems: 1,
+  entries: [
+    {
+      id: 50057759,
+      orderId: 'YGG2Y8BK2',
+      merchantId: 9134,
+      userId: 30446182,
+      type: 'CourierPickUp',
+      status: 'InTransit',
+      numberOfBoxes: 1,
+      numberOfItems: 1,
+      userPickupAddress: {
+        firstName: 'Fabricio Baia',
+        lastName: '',
+        addressLine1: 'Rua Luciano da Silva Barros 213',
+        addressLine2: '',
+        addressLine3: null,
+        vatNumber: '',
+        city: {
+          id: 0,
+          name: 'Porto',
+          stateId: null,
+          countryId: 165,
+        },
+        state: null,
+        country: {
+          id: 165,
+          name: 'Portugal',
+          nativeName: null,
+          alpha2Code: 'PT',
+          alpha3Code: null,
+          culture: null,
+          currency: null,
+          region: null,
+          subRegion: null,
+          continentId: 0,
+        },
+        zipCode: '4470-193',
+        phone: '123456789.',
+        neighbourhood: null,
+        ddd: null,
+        continent: null,
+        addressType: 'Any',
+      },
+      maximumDateForPickup: '2022-06-24T23:59:58',
+      pickupSchedule: {
+        start: '2022-06-06T14:00:00.443',
+        end: '2022-06-06T17:00:00.443',
+      },
+      merchantLocationId: null,
+      items: [
+        {
+          id: 1323,
+          orderItemId: 2195153,
+          reason: null,
+          description: null,
+          status: 'Created',
+          itemStatus: {
+            code: 'Open',
+          },
+        },
+      ],
+      createdDate: '2022-06-02T16:37:54.213',
+      awbUrl: '/v1/returns/50057759/AWB',
+      invoiceUrl: '/v1/returns/50057759/Invoice',
+      references: [
+        {
+          name: 'ReturnCustomerRequestedAWB',
+          url: '/v1/returns/50057759/ReturnCustomerRequestedAWB',
+        },
+        {
+          name: 'ReturnNote',
+          url: '/v1/returns/50057759/ReturnNote',
+        },
+      ],
+      refundPreference: {
+        paymentType: 'Default',
+      },
+      returnStatus: {
+        code: 'InTransit',
+      },
+    },
+  ],
+};

--- a/packages/core/src/profile/redux/actionTypes.js
+++ b/packages/core/src/profile/redux/actionTypes.js
@@ -336,3 +336,13 @@ export const GET_GUEST_USER_BENEFITS_REQUEST =
 /** Action type dispatched when the get guest user benefits request succeeds. */
 export const GET_GUEST_USER_BENEFITS_SUCCESS =
   '@farfetch/blackout-core/GET_GUEST_USER_BENEFITS_SUCCESS';
+
+/** Action type dispatched when the get user returns request fails. */
+export const GET_USER_RETURNS_FAILURE =
+  '@farfetch/blackout-core/GET_USER_RETURNS_FAILURE';
+/** Action type dispatched when the get user returns request starts. */
+export const GET_USER_RETURNS_REQUEST =
+  '@farfetch/blackout-core/GET_USER_RETURNS_REQUEST';
+/** Action type dispatched when the get user returns request succeeds. */
+export const GET_USER_RETURNS_SUCCESS =
+  '@farfetch/blackout-core/GET_USER_RETURNS_SUCCESS';

--- a/packages/core/src/profile/redux/actions/__tests__/__snapshots__/doGetUserReturns.test.js.snap
+++ b/packages/core/src/profile/redux/actions/__tests__/__snapshots__/doGetUserReturns.test.js.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doGetUserReturns action creator should create the correct actions for when the get user returns procedure is successful: get guest user success payload 1`] = `
+Object {
+  "payload": Object {
+    "entries": Array [
+      Object {
+        "awbUrl": "/v1/returns/50057759/AWB",
+        "createdDate": "2022-06-02T16:37:54.213",
+        "id": 50057759,
+        "invoiceUrl": "/v1/returns/50057759/Invoice",
+        "items": Array [
+          Object {
+            "description": null,
+            "id": 1323,
+            "itemStatus": Object {
+              "code": "Open",
+            },
+            "orderItemId": 2195153,
+            "reason": null,
+            "status": "Created",
+          },
+        ],
+        "maximumDateForPickup": "2022-06-24T23:59:58",
+        "merchantId": 9134,
+        "merchantLocationId": null,
+        "numberOfBoxes": 1,
+        "numberOfItems": 1,
+        "orderId": "YGG2Y8BK2",
+        "pickupSchedule": Object {
+          "end": "2022-06-06T17:00:00.443",
+          "start": "2022-06-06T14:00:00.443",
+        },
+        "references": Array [
+          Object {
+            "name": "ReturnCustomerRequestedAWB",
+            "url": "/v1/returns/50057759/ReturnCustomerRequestedAWB",
+          },
+          Object {
+            "name": "ReturnNote",
+            "url": "/v1/returns/50057759/ReturnNote",
+          },
+        ],
+        "refundPreference": Object {
+          "paymentType": "Default",
+        },
+        "returnStatus": Object {
+          "code": "InTransit",
+        },
+        "status": "InTransit",
+        "type": "CourierPickUp",
+        "userId": 30446182,
+        "userPickupAddress": Object {
+          "addressLine1": "Rua Luciano da Silva Barros 213",
+          "addressLine2": "",
+          "addressLine3": null,
+          "addressType": "Any",
+          "city": Object {
+            "countryId": 165,
+            "id": 0,
+            "name": "Porto",
+            "stateId": null,
+          },
+          "continent": null,
+          "country": Object {
+            "alpha2Code": "PT",
+            "alpha3Code": null,
+            "continentId": 0,
+            "culture": null,
+            "currency": null,
+            "id": 165,
+            "name": "Portugal",
+            "nativeName": null,
+            "region": null,
+            "subRegion": null,
+          },
+          "ddd": null,
+          "firstName": "Fabricio Baia",
+          "lastName": "",
+          "neighbourhood": null,
+          "phone": "123456789.",
+          "state": null,
+          "vatNumber": "",
+          "zipCode": "4470-193",
+        },
+      },
+    ],
+    "number": 1,
+    "totalItems": 1,
+    "totalPages": 1,
+  },
+  "type": "@farfetch/blackout-core/GET_USER_RETURNS_SUCCESS",
+}
+`;

--- a/packages/core/src/profile/redux/actions/__tests__/doGetUserReturns.test.js
+++ b/packages/core/src/profile/redux/actions/__tests__/doGetUserReturns.test.js
@@ -1,0 +1,68 @@
+import { doGetUserReturns } from '../';
+import { mockGetUserReturnsResponse } from '../../__fixtures__/userReturns.fixtures';
+import { mockStore } from '../../../../../tests';
+import find from 'lodash/find';
+import reducer, { actionTypes } from '../../';
+
+const profileMockStore = (state = {}) =>
+  mockStore({ profile: reducer() }, state);
+
+describe('doGetUserReturns action creator', () => {
+  let store;
+  const getUserReturns = jest.fn();
+  const action = doGetUserReturns(getUserReturns);
+  const userId = 123456789;
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = profileMockStore();
+  });
+
+  it('should create the correct actions for when the get user returns procedure fails', async () => {
+    const expectedError = new Error('get user returns error');
+
+    getUserReturns.mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(userId));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(getUserReturns).toHaveBeenCalledTimes(1);
+      expect(getUserReturns).toHaveBeenCalledWith(userId, expectedConfig);
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: actionTypes.GET_USER_RETURNS_REQUEST },
+          {
+            type: actionTypes.GET_USER_RETURNS_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the get user returns procedure is successful', async () => {
+    getUserReturns.mockResolvedValueOnce(mockGetUserReturnsResponse);
+
+    await store.dispatch(action(userId));
+
+    const actionResults = store.getActions();
+
+    expect(getUserReturns).toHaveBeenCalledTimes(1);
+    expect(getUserReturns).toHaveBeenCalledWith(userId, expectedConfig);
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.GET_USER_RETURNS_REQUEST },
+      {
+        payload: mockGetUserReturnsResponse,
+        type: actionTypes.GET_USER_RETURNS_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.GET_USER_RETURNS_SUCCESS,
+      }),
+    ).toMatchSnapshot('get guest user success payload');
+  });
+});

--- a/packages/core/src/profile/redux/actions/doGetUserReturns.js
+++ b/packages/core/src/profile/redux/actions/doGetUserReturns.js
@@ -1,0 +1,48 @@
+import {
+  GET_USER_RETURNS_FAILURE,
+  GET_USER_RETURNS_REQUEST,
+  GET_USER_RETURNS_SUCCESS,
+} from '../actionTypes';
+
+/**
+ * @callback GetUserReturnsThunkFactory
+ * @param {string} id - The user's id.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Get user returns from user.
+ *
+ * @function doGetUserReturns
+ * @memberof module:profile/actions
+ *
+ * @param {Function} getUserReturns - Get user returns client.
+ *
+ * @returns {GetUserReturnsThunkFactory} Thunk factory.
+ */
+export default getUserReturns => (id, config) => async dispatch => {
+  dispatch({
+    type: GET_USER_RETURNS_REQUEST,
+  });
+
+  try {
+    const result = await getUserReturns(id, config);
+
+    dispatch({
+      payload: result,
+      type: GET_USER_RETURNS_SUCCESS,
+    });
+
+    return result;
+  } catch (error) {
+    dispatch({
+      payload: { error },
+      type: GET_USER_RETURNS_FAILURE,
+    });
+
+    throw error;
+  }
+};

--- a/packages/core/src/profile/redux/actions/index.js
+++ b/packages/core/src/profile/redux/actions/index.js
@@ -40,3 +40,4 @@ export { default as doDeletePersonalId } from './doDeletePersonalId';
 export { default as doPostPersonalIdImage } from './doPostPersonalIdImage';
 export { default as doGetUserBenefits } from './doGetUserBenefits';
 export { default as doGetGuestUserBenefits } from './doGetGuestUserBenefits';
+export { default as doGetUserReturns } from './doGetUserReturns';


### PR DESCRIPTION
## Description

This adds the new get user returns endpoint that is used to fetch all of an authenticated user returns with pagination.

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
