### PR TITLE
fix(redux): Fix action promocode reset in checkout

### DIFF
--- a/packages/core/src/checkout/redux/__tests__/reducer.test.js
+++ b/packages/core/src/checkout/redux/__tests__/reducer.test.js
@@ -175,6 +175,20 @@ describe('checkout reducer', () => {
       ).toBe(expectedResult);
     });
 
+    it('should handle SET_PROMOCODE_RESET action type', () => {
+      const currentState = {
+        promoCode: {
+          error: 'foo',
+          isLoading: true,
+        },
+      };
+      expect(
+        reducer(currentState, {
+          type: actionTypes.SET_PROMOCODE_RESET,
+        }).promocode,
+      ).toBe(initialState.promocode);
+    });
+
     it('should handle SET_TAGS_SUCCESS action type', () => {
       const expectedResult = 'foo';
 

--- a/packages/core/src/checkout/redux/actionTypes.js
+++ b/packages/core/src/checkout/redux/actionTypes.js
@@ -177,6 +177,9 @@ export const SET_PROMOCODE_REQUEST =
 export const SET_PROMOCODE_SUCCESS =
   '@farfetch/blackout-core/SET_PROMOCODE_SUCCESS';
 
+/** Action type dispatched when reseting the promocode. */
+export const SET_PROMOCODE_RESET =
+  '@farfetch/blackout-core/SET_PROMOCODE_RESET';
 /** Action type dispatched when the set tags request fails. */
 export const SET_TAGS_FAILURE = '@farfetch/blackout-core/SET_TAGS_FAILURE';
 /** Action type dispatched when the set tags request starts. */

--- a/packages/core/src/checkout/redux/actions/__tests__/resetPromocode.test.js
+++ b/packages/core/src/checkout/redux/actions/__tests__/resetPromocode.test.js
@@ -1,0 +1,25 @@
+import { mockStore } from '../../../../../tests';
+import reducer, { actionTypes } from '../..';
+import resetPromocode from '../resetPromocode';
+
+describe('resetPromocode() action creator', () => {
+  const checkoutMockStore = (state = {}) =>
+    mockStore({ checkout: reducer() }, state);
+  let store;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = checkoutMockStore();
+  });
+
+  it('should dispatch the correct action for when the reset promocode is called', () => {
+    store.dispatch(resetPromocode());
+    const actionResults = store.getActions();
+
+    expect(actionResults).toMatchObject([
+      {
+        type: actionTypes.SET_PROMOCODE_RESET,
+      },
+    ]);
+  });
+});

--- a/packages/core/src/checkout/redux/actions/index.js
+++ b/packages/core/src/checkout/redux/actions/index.js
@@ -27,3 +27,4 @@ export { default as doUpdateDeliveryBundleUpgrades } from './doUpdateDeliveryBun
 export { default as doUpdateGiftMessage } from './doUpdateGiftMessage';
 export { default as doUpdateOrderItem } from './doUpdateOrderItem';
 export { default as reset } from './reset';
+export { default as resetPromocode } from './resetPromocode';

--- a/packages/core/src/checkout/redux/actions/resetPromocode.js
+++ b/packages/core/src/checkout/redux/actions/resetPromocode.js
@@ -1,0 +1,15 @@
+import { SET_PROMOCODE_RESET } from '../actionTypes';
+
+/**
+ * Method responsible for resetting the promocode.
+ *
+ * @function reset
+ * @memberof module:checkout/actions
+ *
+ * @returns {Function} - Thunk.
+ */
+export default () => dispatch => {
+  dispatch({
+    type: SET_PROMOCODE_RESET,
+  });
+};


### PR DESCRIPTION
## Description

- This PR makes possible to reset the promo code in the blackout core;
- In blackout, there is no action responsible for changing properties to the inital state of the promocode, and with this PR, it becomes quite simplified, because in some situation at checkout it may be necessary to reset these values to the initial ones;
- A new action was then added with the name SET_PROMOCODE_RESET able to respond to what was intended;
- Finally, all the logic responsible for processing this action is already developed in the checkout reducer;
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
