### PR TITLE
fix(core): fix omnitracking TID value for signup newsletter event

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -477,7 +477,7 @@ export const trackEventsMapper = {
     ...getCheckoutEventGenericProperties(data),
   }),
   [eventTypes.SIGNUP_NEWSLETTER]: data => ({
-    tid: 2831,
+    tid: 1040,
     gender: getGenderValueFromProperties(data),
   }),
   [eventTypes.ADDRESS_INFO_ADDED]: data => ({

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -252,7 +252,7 @@ Object {
 exports[`Omnitracking definitions \`Sign-up Newsletter\` return should match the snapshot 1`] = `
 Object {
   "gender": "Woman,Man",
-  "tid": 2831,
+  "tid": 1040,
 }
 `;
 


### PR DESCRIPTION
## Description
This PR updates a tracker ID on the omnitracking integration for the signup newsletter event.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
