### PR TITLE
fix(core): add query to get user returns

### DIFF
--- a/packages/core/src/returns/client/__fixtures__/getUserReturns.fixtures.js
+++ b/packages/core/src/returns/client/__fixtures__/getUserReturns.fixtures.js
@@ -1,3 +1,4 @@
+import get from 'lodash/get';
 import join from 'proper-url-join';
 import moxios from 'moxios';
 
@@ -7,7 +8,9 @@ import moxios from 'moxios';
 export default {
   success: params => {
     moxios.stubRequest(
-      join('/api/account/v1/users', params.userId, '/returns'),
+      join('/api/account/v1/users', params.userId, '/returns', {
+        query: get(params, 'query'),
+      }),
       {
         method: 'get',
         response: params.response,
@@ -17,7 +20,9 @@ export default {
   },
   failure: params => {
     moxios.stubRequest(
-      join('/api/account/v1/users', params.userId, '/returns'),
+      join('/api/account/v1/users', params.userId, '/returns', {
+        query: get(params, 'query'),
+      }),
       {
         method: 'get',
         response: 'stub error',

--- a/packages/core/src/returns/client/__tests__/getUserReturns.test.js
+++ b/packages/core/src/returns/client/__tests__/getUserReturns.test.js
@@ -7,6 +7,7 @@ describe('getUserReturns', () => {
   const expectedConfig = undefined;
   const userId = '123456';
   const spy = jest.spyOn(client, 'get');
+  const query = { page: 1 };
 
   beforeEach(() => {
     moxios.install(client);
@@ -18,25 +19,25 @@ describe('getUserReturns', () => {
   it('should handle a client request successfully', async () => {
     const response = {};
 
-    fixtures.success({ userId, response });
+    fixtures.success({ userId, response, query });
 
     expect.assertions(2);
 
-    await expect(getUserReturns(userId)).resolves.toBe(response);
+    await expect(getUserReturns(userId, query)).resolves.toBe(response);
 
     expect(spy).toHaveBeenCalledWith(
-      `/account/v1/users/${userId}/returns`,
+      `/account/v1/users/${userId}/returns?page=${query.page}`,
       expectedConfig,
     );
   });
 
   it('should receive a client request error', async () => {
-    fixtures.failure({ userId });
+    fixtures.failure({ userId, query });
 
     expect.assertions(2);
-    await expect(getUserReturns(userId)).rejects.toMatchSnapshot();
+    await expect(getUserReturns(userId, query)).rejects.toMatchSnapshot();
     expect(spy).toHaveBeenCalledWith(
-      `/account/v1/users/${userId}/returns`,
+      `/account/v1/users/${userId}/returns?page=${query.page}`,
       expectedConfig,
     );
   });

--- a/packages/core/src/returns/client/getUserReturns.js
+++ b/packages/core/src/returns/client/getUserReturns.js
@@ -2,21 +2,34 @@ import client, { adaptError } from '../../helpers/client';
 import join from 'proper-url-join';
 
 /**
+ * @typedef {object} GetUserReturnQuery
+ *
+ * @alias GetUserReturnQuery
+ * @memberof module:returns/client
+ *
+ * @property {number} [page] - Number of the page to get, starting at 1. The default is 1.
+ * @property {number} [pageSize] - Size of each page, as a number between 1 and 180. The default is 60.
+ * @property {string} [sort] - Comma separated list of sort criteria of the results. Possible values:
+ * createdAt:asc, createdAt:desc.
+ */
+
+/**
  * Method responsible for getting all the user returns.
  *
  * @function getUserReturns
  * @memberof module:profile/client
  *
  * @param {number} userId - The user's id.
+ * @param {GetUserReturnQuery} [query] - Query parameters.
  * @param {object} [config] - Custom configurations to send to the client
  * instance (axios).
  *
  * @returns {Promise} Promise that will resolve when the call to
  * the endpoint finishes.
  */
-export default (userId, config) =>
+export default (userId, query, config) =>
   client
-    .get(join('/account/v1/users', userId, '/returns'), config)
+    .get(join('/account/v1/users', userId, '/returns', { query }), config)
     .then(response => response.data)
     .catch(error => {
       throw adaptError(error);

--- a/packages/core/src/returns/redux/actions/__tests__/doGetUserReturns.test.js
+++ b/packages/core/src/returns/redux/actions/__tests__/doGetUserReturns.test.js
@@ -16,6 +16,7 @@ describe('doGetUserReturns action creator', () => {
   const action = doGetUserReturns(getUserReturns);
   const userId = 123456789;
   const expectedConfig = undefined;
+  const query = {};
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -29,11 +30,15 @@ describe('doGetUserReturns action creator', () => {
     expect.assertions(4);
 
     try {
-      await store.dispatch(action(userId));
+      await store.dispatch(action(userId, query));
     } catch (error) {
       expect(error).toBe(expectedError);
       expect(getUserReturns).toHaveBeenCalledTimes(1);
-      expect(getUserReturns).toHaveBeenCalledWith(userId, expectedConfig);
+      expect(getUserReturns).toHaveBeenCalledWith(
+        userId,
+        query,
+        expectedConfig,
+      );
       expect(store.getActions()).toEqual(
         expect.arrayContaining([
           { type: actionTypes.GET_USER_RETURNS_REQUEST },
@@ -49,12 +54,12 @@ describe('doGetUserReturns action creator', () => {
   it('should create the correct actions for when the get user returns procedure is successful', async () => {
     getUserReturns.mockResolvedValueOnce(responses.getUserReturns.get.success);
 
-    await store.dispatch(action(userId));
+    await store.dispatch(action(userId, query));
 
     const actionResults = store.getActions();
 
     expect(getUserReturns).toHaveBeenCalledTimes(1);
-    expect(getUserReturns).toHaveBeenCalledWith(userId, expectedConfig);
+    expect(getUserReturns).toHaveBeenCalledWith(userId, query, expectedConfig);
     expect(actionResults).toMatchObject([
       { type: actionTypes.GET_USER_RETURNS_REQUEST },
       {

--- a/packages/core/src/returns/redux/actions/doGetUserReturns.js
+++ b/packages/core/src/returns/redux/actions/doGetUserReturns.js
@@ -7,8 +7,21 @@ import { normalize } from 'normalizr';
 import returnSchema from '../../../entities/schemas/return';
 
 /**
+ * @typedef {object} GetUserReturnQuery
+ *
+ * @alias GetUserReturnQuery
+ * @memberof module:returns/client
+ *
+ * @property {number} [page] - Number of the page to get, starting at 1. The default is 1.
+ * @property {number} [pageSize] - Size of each page, as a number between 1 and 180. The default is 60.
+ * @property {string} [sort] - Comma separated list of sort criteria of the results. Possible values:
+ * createdAt:asc, createdAt:desc.
+ */
+
+/**
  * @callback GetUserReturnsThunkFactory
  * @param {string} id - The user's id.
+ * @param {GetUserReturnQuery} [query] - Query parameters.
  * @param {object} [config] - Custom configurations to send to the client
  * instance (axios).
  *
@@ -25,13 +38,13 @@ import returnSchema from '../../../entities/schemas/return';
  *
  * @returns {GetUserReturnsThunkFactory} Thunk factory.
  */
-export default getUserReturns => (id, config) => async dispatch => {
+export default getUserReturns => (id, query, config) => async dispatch => {
   dispatch({
     type: GET_USER_RETURNS_REQUEST,
   });
 
   try {
-    const result = await getUserReturns(id, config);
+    const result = await getUserReturns(id, query, config);
     const normalizedReturns = normalize(result, {
       entries: [returnSchema],
     });


### PR DESCRIPTION
## Description

- Added missing query parameter to getUserReturns endpoint.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
