### PR TITLE
fix: fix error handling

### DIFF
--- a/packages/client/src/addresses/__tests__/__snapshots__/getAddressPredictionDetails.test.ts.snap
+++ b/packages/client/src/addresses/__tests__/__snapshots__/getAddressPredictionDetails.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getAddressPredictionDetails with query params should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],
@@ -11,7 +11,7 @@ Object {
 
 exports[`getAddressPredictionDetails without query params should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/addresses/__tests__/__snapshots__/getAddressPredictions.test.ts.snap
+++ b/packages/client/src/addresses/__tests__/__snapshots__/getAddressPredictions.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPredictions should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/bags/__tests__/__snapshots__/deleteBagItem.test.ts.snap
+++ b/packages/client/src/bags/__tests__/__snapshots__/deleteBagItem.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteBagItem should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/bags/__tests__/__snapshots__/getBag.test.ts.snap
+++ b/packages/client/src/bags/__tests__/__snapshots__/getBag.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getBag should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/bags/__tests__/__snapshots__/patchBagItem.test.ts.snap
+++ b/packages/client/src/bags/__tests__/__snapshots__/patchBagItem.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`patchBagItem should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/bags/__tests__/__snapshots__/postBagItem.test.ts.snap
+++ b/packages/client/src/bags/__tests__/__snapshots__/postBagItem.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postBagItem should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/brands/__tests__/__snapshots__/getBrand.test.ts.snap
+++ b/packages/client/src/brands/__tests__/__snapshots__/getBrand.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`brands client getBrand() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/brands/__tests__/__snapshots__/getBrands.test.ts.snap
+++ b/packages/client/src/brands/__tests__/__snapshots__/getBrands.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`brands client getBrands() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/categories/__tests__/__snapshots__/getCategories.test.ts.snap
+++ b/packages/client/src/categories/__tests__/__snapshots__/getCategories.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getCategories() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/categories/__tests__/__snapshots__/getCategory.test.ts.snap
+++ b/packages/client/src/categories/__tests__/__snapshots__/getCategory.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getCategory() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/categories/__tests__/__snapshots__/getTopCategories.test.ts.snap
+++ b/packages/client/src/categories/__tests__/__snapshots__/getTopCategories.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getTopCategories() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/deleteCheckoutOrderItem.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/deleteCheckoutOrderItem.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client deleteCheckoutOrderItem should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrder.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrder.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client getCheckoutOrder should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderCharge.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderCharge.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client getCheckoutOrderCharge should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderDeliveryBundleProvisioning.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderDeliveryBundleProvisioning.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getCheckoutOrderDeliveryBundleProvisioning should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderDeliveryBundleUpgradeProvisioning.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderDeliveryBundleUpgradeProvisioning.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getCheckoutOrderDeliveryBundleUpgradeProvisioning should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderDeliveryBundleUpgrades.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderDeliveryBundleUpgrades.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getCheckoutOrderDeliveryBundleUpgrades should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderDetails.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderDetails.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client getCheckoutOrderDetails should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderOperation.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderOperation.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client getCheckoutOrderOperation should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderOperations.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderOperations.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client getCheckoutOrderOperations should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderPaymentMethods.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/getCheckoutOrderPaymentMethods.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getCheckoutOrderPaymentMethods should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/getCollectPoints.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/getCollectPoints.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client getCollectPoints should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/patchCheckoutOrder.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/patchCheckoutOrder.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client patchCheckoutOrder should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/patchCheckoutOrderDeliveryBundleUpgrades.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/patchCheckoutOrderDeliveryBundleUpgrades.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`patchCheckoutOrderDeliveryBundleUpgrades should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/patchCheckoutOrderItem.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/patchCheckoutOrderItem.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client patchCheckoutOrderItem should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/patchCheckoutOrderItems.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/patchCheckoutOrderItems.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client patchCheckoutOrderItems should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/postCheckoutOrder.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/postCheckoutOrder.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client postCheckoutOrder should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/postCheckoutOrderCharge.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/postCheckoutOrderCharge.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client postCheckoutOrderCharges should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/putCheckoutOrderItemTags.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/putCheckoutOrderItemTags.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client putCheckoutOrderItemTags should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/putCheckoutOrderPromocode.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/putCheckoutOrderPromocode.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client putCheckoutOrderPromocode should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/checkout/__tests__/__snapshots__/putCheckoutOrderTags.test.ts.snap
+++ b/packages/client/src/checkout/__tests__/__snapshots__/putCheckoutOrderTags.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`checkout client putCheckoutOrderTags should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/contents/__tests__/__snapshots__/getCommercePages.test.ts.snap
+++ b/packages/client/src/contents/__tests__/__snapshots__/getCommercePages.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getCommercePages() should handle a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/contents/__tests__/__snapshots__/getContentPage.test.ts.snap
+++ b/packages/client/src/contents/__tests__/__snapshots__/getContentPage.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getContentPage() should handle a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/contents/__tests__/__snapshots__/getContentTypes.test.ts.snap
+++ b/packages/client/src/contents/__tests__/__snapshots__/getContentTypes.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getContentTypes() should handle a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/contents/__tests__/__snapshots__/getSEOMetadata.test.ts.snap
+++ b/packages/client/src/contents/__tests__/__snapshots__/getSEOMetadata.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`SEO client getSEOMetadata() should handle a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/contents/__tests__/__snapshots__/getSearchContents.test.ts.snap
+++ b/packages/client/src/contents/__tests__/__snapshots__/getSearchContents.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`contents client getSearchContents() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/forms/__tests__/__snapshots__/getFormSchema.test.ts.snap
+++ b/packages/client/src/forms/__tests__/__snapshots__/getFormSchema.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`schemas client getFormSchema() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/forms/__tests__/__snapshots__/postFormData.test.ts.snap
+++ b/packages/client/src/forms/__tests__/__snapshots__/postFormData.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`schemas client postFormData() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/helpers/client/__fixtures__/errors.fixtures.ts
+++ b/packages/client/src/helpers/client/__fixtures__/errors.fixtures.ts
@@ -65,7 +65,7 @@ const mockAxiosApiError = (
 
 export const legacyApiErrorData = mockAxiosApiError({
   success: false,
-  errorCode: 14,
+  errorCode: '14',
   errorMessage: 'Could not authenticate',
   errorData: {
     key: 'value',
@@ -75,7 +75,7 @@ export const legacyApiErrorData = mockAxiosApiError({
 
 export const ApiErrorData = mockAxiosApiError({
   message: 'Could not authenticate',
-  code: 14,
+  code: '14',
   developerMessage: 'Could not authenticate',
   moreInformation: 'more information',
   exception: {},
@@ -83,7 +83,7 @@ export const ApiErrorData = mockAxiosApiError({
 
 export const ApiErrorDataNoMessage = mockAxiosApiError({
   message: null,
-  code: 14,
+  code: '14',
   developerMessage: 'Could not authenticate',
   moreInformation: 'more information',
   exception: {},
@@ -91,7 +91,7 @@ export const ApiErrorDataNoMessage = mockAxiosApiError({
 
 export const ApiErrorDataNoMessageNorDeveloperMessage = mockAxiosApiError({
   message: null,
-  code: 14,
+  code: '14',
   developerMessage: null,
   moreInformation: 'more information',
   exception: {},
@@ -103,14 +103,14 @@ export const APIListErrorData = mockAxiosApiError({
   errors: [
     {
       message: 'Could not authenticate',
-      code: 14,
+      code: '14',
       developerMessage: 'Could not authenticate',
       moreInformation: 'more information',
       exception: {},
     },
     {
       message: 'Could not authenticate',
-      code: 18,
+      code: '18',
       developerMessage: 'This is another error',
       moreInformation: 'More information on this new error',
       exception: {},

--- a/packages/client/src/helpers/client/__tests__/__snapshots__/formatError.test.ts.snap
+++ b/packages/client/src/helpers/client/__tests__/__snapshots__/formatError.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`formatError() should format the error properly when the api returns a LIST with errors 1`] = `
 Object {
-  "code": 14,
+  "code": "14",
   "exception": Object {},
   "message": "Could not authenticate",
   "moreInformation": "more information",
@@ -12,7 +12,7 @@ Object {
 
 exports[`formatError() should format the error properly when the api returns an OBJECT with the error  1`] = `
 Object {
-  "code": 14,
+  "code": "14",
   "exception": Object {},
   "message": "Could not authenticate",
   "moreInformation": "more information",
@@ -22,7 +22,7 @@ Object {
 
 exports[`formatError() should format the error properly when the api returns the error (legacy) 1`] = `
 Object {
-  "code": 14,
+  "code": "14",
   "errorData": Object {
     "key": "value",
     "productId": "13981125",
@@ -35,7 +35,7 @@ Object {
 
 exports[`formatError() should format the error properly when the request has no description 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "Request failed with status code 404",
   "status": 404,
 }
@@ -43,7 +43,7 @@ Object {
 
 exports[`formatError() should format the error properly when the request has no response 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "description": "i am error",
   "message": "i am error",
   "status": 400,

--- a/packages/client/src/helpers/client/formatError.ts
+++ b/packages/client/src/helpers/client/formatError.ts
@@ -4,7 +4,7 @@ import type { BlackoutError } from '../../types';
 import type { DefaultErrorAdapterData, LegacyErrorAdapterData } from './types';
 
 export const defaultError = {
-  code: -1,
+  code: '-1',
   message: 'Unexpected error',
 };
 
@@ -24,7 +24,7 @@ export const legacyErrorAdapter = (
     ...rest
   }: LegacyErrorAdapterData,
   status: number,
-): { code: number } & Record<string, unknown> => ({
+): { code: string } & Record<string, unknown> => ({
   code: errorCode,
   message: errorMessage,
   status,
@@ -48,7 +48,7 @@ export const defaultErrorAdapter = (
     ...rest
   }: DefaultErrorAdapterData,
   status: number,
-): { code: number } & Record<string, unknown> => ({
+): { code: string } & Record<string, unknown> => ({
   code,
   message: message || developerMessage || defaultError.message,
   status,

--- a/packages/client/src/helpers/client/types/formatError.types.ts
+++ b/packages/client/src/helpers/client/types/formatError.types.ts
@@ -2,7 +2,7 @@ export type DefaultErrorAdapterData = {
   // Error message received.
   message: string | null;
   // Error code received.
-  code: number;
+  code: string;
   // Developer message received.
   developerMessage: string | null;
   moreInformation: string;
@@ -12,7 +12,7 @@ export type LegacyErrorAdapterData = {
   // Error message received.
   errorMessage: string;
   // Error code received.
-  errorCode: number;
+  errorCode: string;
   success: boolean;
 } & { [name: string]: unknown };
 

--- a/packages/client/src/language/__tests__/__snapshots__/getTranslations.test.ts.snap
+++ b/packages/client/src/language/__tests__/__snapshots__/getTranslations.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getTranslations should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/locale/__tests__/__snapshots__/getCountries.test.ts.snap
+++ b/packages/client/src/locale/__tests__/__snapshots__/getCountries.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`locale client getCountries() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/locale/__tests__/__snapshots__/getCountry.test.ts.snap
+++ b/packages/client/src/locale/__tests__/__snapshots__/getCountry.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`locale client getCountry() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/locale/__tests__/__snapshots__/getCountryAddressSchemas.test.ts.snap
+++ b/packages/client/src/locale/__tests__/__snapshots__/getCountryAddressSchemas.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getCountryAddressSchemas getSchema should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/locale/__tests__/__snapshots__/getCountryCurrencies.test.ts.snap
+++ b/packages/client/src/locale/__tests__/__snapshots__/getCountryCurrencies.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`locale client getCountryCurrencies() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/locale/__tests__/__snapshots__/getCountryStateCities.test.ts.snap
+++ b/packages/client/src/locale/__tests__/__snapshots__/getCountryStateCities.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`locale client getCountryStateCities() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/locale/__tests__/__snapshots__/getCountryStates.test.ts.snap
+++ b/packages/client/src/locale/__tests__/__snapshots__/getCountryStates.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`locale client getCountryStates() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/loyalty/__tests__/__snapshots__/getProgramMembershipStatements.test.ts.snap
+++ b/packages/client/src/loyalty/__tests__/__snapshots__/getProgramMembershipStatements.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProgramMembershipStatements should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/loyalty/__tests__/__snapshots__/getProgramUsersMembership.test.ts.snap
+++ b/packages/client/src/loyalty/__tests__/__snapshots__/getProgramUsersMembership.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`program users client getProgramUsersMembership should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/loyalty/__tests__/__snapshots__/getPrograms.test.ts.snap
+++ b/packages/client/src/loyalty/__tests__/__snapshots__/getPrograms.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`programs client getPrograms should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/loyalty/__tests__/__snapshots__/postProgramMembership.test.ts.snap
+++ b/packages/client/src/loyalty/__tests__/__snapshots__/postProgramMembership.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postProgramMembership should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/loyalty/__tests__/__snapshots__/postProgramMembershipConvert.test.ts.snap
+++ b/packages/client/src/loyalty/__tests__/__snapshots__/postProgramMembershipConvert.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postProgramMembershipConvert should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/loyalty/__tests__/__snapshots__/postProgramMembershipReplacement.test.ts.snap
+++ b/packages/client/src/loyalty/__tests__/__snapshots__/postProgramMembershipReplacement.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postProgramMembershipReplacement should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/merchantsLocations/__tests__/__snapshots__/getMerchantsLocations.test.ts.snap
+++ b/packages/client/src/merchantsLocations/__tests__/__snapshots__/getMerchantsLocations.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getMerchantsLocations should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/omnitracking/__tests__/__snapshots__/postBatchTrackings.test.ts.snap
+++ b/packages/client/src/omnitracking/__tests__/__snapshots__/postBatchTrackings.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postBatchTrackings() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/omnitracking/__tests__/__snapshots__/postTracking.test.ts.snap
+++ b/packages/client/src/omnitracking/__tests__/__snapshots__/postTracking.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postTracking() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/getGuestOrderLegacy.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/getGuestOrderLegacy.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getGuestOrderLegacy should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/getGuestOrders.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/getGuestOrders.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getGuestOrders should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/getOrder.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/getOrder.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getOrder should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/getOrderAvailableItemsActivities.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/getOrderAvailableItemsActivities.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getOrderAvailableItemsActivities should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/getOrderDocument.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/getOrderDocument.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getOrderDocument should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/getOrderDocuments.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/getOrderDocuments.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getOrderDocuments should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/getOrderItemAvailableActivities.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/getOrderItemAvailableActivities.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getOrderItemAvailableActivities should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/getOrderReturnOptions.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/getOrderReturnOptions.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getOrderReturnOptions should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/getOrderReturns.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/getOrderReturns.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getOrderReturns should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/getShipmentTrackings.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/getShipmentTrackings.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getShipmentTrackings should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/getUserOrders.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/getUserOrders.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserOrders should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/postOrderDocument.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/postOrderDocument.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postOrderDocument should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/orders/__tests__/__snapshots__/postOrderItemActivity.test.ts.snap
+++ b/packages/client/src/orders/__tests__/__snapshots__/postOrderItemActivity.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postOrderItemActivity should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/deletePaymentIntentInstrument.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/deletePaymentIntentInstrument.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deletePaymentIntentInstrument should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/deletePaymentToken.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/deletePaymentToken.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deletePaymentToken should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/getGiftCardBalance.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/getGiftCardBalance.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getGiftCardBalance should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/getPaymentIntent.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/getPaymentIntent.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPaymentIntent should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/getPaymentIntentCharge.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/getPaymentIntentCharge.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPaymentIntentCharge should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/getPaymentIntentInstrument.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/getPaymentIntentInstrument.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPaymentIntentInstrument should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/getPaymentIntentInstruments.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/getPaymentIntentInstruments.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPaymentIntentInstruments should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/getPaymentMethodsByCountryAndCurrency.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/getPaymentMethodsByCountryAndCurrency.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPaymentMethodsByCountryAndCurrency should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/getPaymentMethodsByIntent.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/getPaymentMethodsByIntent.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPaymentMethodsByIntent should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/getPaymentTokens.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/getPaymentTokens.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPaymentTokens should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/getUserCreditBalance.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/getUserCreditBalance.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserCreditBalance should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/postPaymentIntentCharge.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/postPaymentIntentCharge.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postPaymentIntentCharge should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/postPaymentIntentInstrument.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/postPaymentIntentInstrument.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postPaymentIntentInstrument should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/payments/__tests__/__snapshots__/putPaymentIntentInstrument.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/putPaymentIntentInstrument.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`putPaymentIntentInstrument should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/deleteRecentlyViewedProduct.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/deleteRecentlyViewedProduct.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteRecentlyViewedProduct should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProduct.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProduct.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProduct should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProductAttributes.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductAttributes.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProductAttributes should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProductFittings.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductFittings.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProductFittings should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProductGrouping.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductGrouping.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProductGrouping should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProductGroupingProperties.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductGroupingProperties.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProductGroupingProperties should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProductListing.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductListing.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProductListing should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProductRecommendedSet.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductRecommendedSet.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`recommended sets client getProductRecommendedSet() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProductSet.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductSet.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProductSet should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProductSizeGuides.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductSizeGuides.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProductSizeGuides should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProductSizes.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductSizes.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProductSizes should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProductVariantMerchantsLocations.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductVariantMerchantsLocations.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProductVariantsMerchantsLocations should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getProductVariantsMeasurements.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getProductVariantsMeasurements.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProductVariantsMeasurements should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getRecentlyViewedProducts.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getRecentlyViewedProducts.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getRecentlyViewedProducts should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/products/__tests__/__snapshots__/getRecommendedProducts.test.ts.snap
+++ b/packages/client/src/products/__tests__/__snapshots__/getRecommendedProducts.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getRecommendedProducts should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/promotionEvaluations/__tests__/__snapshots__/getPromotionEvaluationItems.test.ts.snap
+++ b/packages/client/src/promotionEvaluations/__tests__/__snapshots__/getPromotionEvaluationItems.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPromotionEvaluationItems() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/returns/__tests__/__snapshots__/getReturn.test.ts.snap
+++ b/packages/client/src/returns/__tests__/__snapshots__/getReturn.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getReturn should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/returns/__tests__/__snapshots__/getReturnPickupCapability.test.ts.snap
+++ b/packages/client/src/returns/__tests__/__snapshots__/getReturnPickupCapability.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getReturnPickupCapability should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/returns/__tests__/__snapshots__/getReturnPickupRescheduleRequest.test.ts.snap
+++ b/packages/client/src/returns/__tests__/__snapshots__/getReturnPickupRescheduleRequest.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getReturnPickupRescheduleRequest should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/returns/__tests__/__snapshots__/getReturnPickupRescheduleRequests.test.ts.snap
+++ b/packages/client/src/returns/__tests__/__snapshots__/getReturnPickupRescheduleRequests.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getReturnPickupRescheduleRequests should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/returns/__tests__/__snapshots__/patchReturn.test.ts.snap
+++ b/packages/client/src/returns/__tests__/__snapshots__/patchReturn.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`patchReturn should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/returns/__tests__/__snapshots__/postReturn.test.ts.snap
+++ b/packages/client/src/returns/__tests__/__snapshots__/postReturn.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postReturn() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/returns/__tests__/__snapshots__/postReturnPickupRescheduleRequest.test.ts.snap
+++ b/packages/client/src/returns/__tests__/__snapshots__/postReturnPickupRescheduleRequest.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postReturnPickupRescheduleRequests() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/search/__tests__/__snapshots__/getSearchDidYouMean.test.ts.snap
+++ b/packages/client/src/search/__tests__/__snapshots__/getSearchDidYouMean.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`search did you mean client getSearchDidYouMean should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/search/__tests__/__snapshots__/getSearchIntents.test.ts.snap
+++ b/packages/client/src/search/__tests__/__snapshots__/getSearchIntents.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`search intents client getSearchIntents should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/search/__tests__/__snapshots__/getSearchSuggestions.test.ts.snap
+++ b/packages/client/src/search/__tests__/__snapshots__/getSearchSuggestions.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`search suggestions client getSearchSuggestions should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/settings/__tests__/__snapshots__/getConfiguration.test.ts.snap
+++ b/packages/client/src/settings/__tests__/__snapshots__/getConfiguration.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getConfiguration should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/settings/__tests__/__snapshots__/getConfigurations.test.ts.snap
+++ b/packages/client/src/settings/__tests__/__snapshots__/getConfigurations.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getConfigurations should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/sharedWishlists/__tests__/__snapshots__/deleteSharedWishlist.test.ts.snap
+++ b/packages/client/src/sharedWishlists/__tests__/__snapshots__/deleteSharedWishlist.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteSharedWishlist should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/sharedWishlists/__tests__/__snapshots__/getSharedWishlist.test.ts.snap
+++ b/packages/client/src/sharedWishlists/__tests__/__snapshots__/getSharedWishlist.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getSharedWishlist should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/sharedWishlists/__tests__/__snapshots__/postSharedWishlist.test.ts.snap
+++ b/packages/client/src/sharedWishlists/__tests__/__snapshots__/postSharedWishlist.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postSharedWishlist should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/sharedWishlists/__tests__/__snapshots__/putSharedWishlist.test.ts.snap
+++ b/packages/client/src/sharedWishlists/__tests__/__snapshots__/putSharedWishlist.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`putSharedWishlist should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/sizeGuides/__tests__/__snapshots__/getSizeGuides.test.ts.snap
+++ b/packages/client/src/sizeGuides/__tests__/__snapshots__/getSizeGuides.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getProductSizeGuides should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/sizeScales/__tests__/__snapshots__/getSizeScale.test.ts.snap
+++ b/packages/client/src/sizeScales/__tests__/__snapshots__/getSizeScale.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`sizeScales client getSizeScale() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/sizeScales/__tests__/__snapshots__/getSizeScales.test.ts.snap
+++ b/packages/client/src/sizeScales/__tests__/__snapshots__/getSizeScales.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`sizeScales client getSizeScales() should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/staffMembers/__tests__/__snapshots__/getStaffMember.test.ts.snap
+++ b/packages/client/src/staffMembers/__tests__/__snapshots__/getStaffMember.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getStaffMember should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/subscriptions/__tests__/__snapshots__/deleteSubscription.test.ts.snap
+++ b/packages/client/src/subscriptions/__tests__/__snapshots__/deleteSubscription.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteSubscription should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/subscriptions/__tests__/__snapshots__/deleteSubscriptionTopicRecipient.test.ts.snap
+++ b/packages/client/src/subscriptions/__tests__/__snapshots__/deleteSubscriptionTopicRecipient.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteSubscriptionTopicRecipient should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/subscriptions/__tests__/__snapshots__/getSubscriptionPackages.test.ts.snap
+++ b/packages/client/src/subscriptions/__tests__/__snapshots__/getSubscriptionPackages.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getSubscriptionPackages should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/subscriptions/__tests__/__snapshots__/getSubscriptions.test.ts.snap
+++ b/packages/client/src/subscriptions/__tests__/__snapshots__/getSubscriptions.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getSubscriptions should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/subscriptions/__tests__/__snapshots__/putSubscriptions.test.ts.snap
+++ b/packages/client/src/subscriptions/__tests__/__snapshots__/putSubscriptions.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`putSubscriptions should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/types/error/blackoutError.ts
+++ b/packages/client/src/types/error/blackoutError.ts
@@ -1,5 +1,5 @@
 export type BlackoutError = Error & {
-  code: number;
+  code: string;
   developerMessage?: string;
   exception?: Record<string, string | number>;
   moreInformation?: string;

--- a/packages/client/src/users/addresses/__tests__/__snapshots__/deleteUserAddress.test.ts.snap
+++ b/packages/client/src/users/addresses/__tests__/__snapshots__/deleteUserAddress.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteUserAddress deleteUserAddress should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/addresses/__tests__/__snapshots__/getUserAddress.test.ts.snap
+++ b/packages/client/src/users/addresses/__tests__/__snapshots__/getUserAddress.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserAddress getUserAddress should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/addresses/__tests__/__snapshots__/getUserAddresses.test.ts.snap
+++ b/packages/client/src/users/addresses/__tests__/__snapshots__/getUserAddresses.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserAddresses should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/addresses/__tests__/__snapshots__/postUserAddress.test.ts.snap
+++ b/packages/client/src/users/addresses/__tests__/__snapshots__/postUserAddress.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postUserAddress should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/addresses/__tests__/__snapshots__/putUserAddress.test.ts.snap
+++ b/packages/client/src/users/addresses/__tests__/__snapshots__/putUserAddress.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`putUserAddress should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/addresses/__tests__/__snapshots__/putUserDefaultBillingAddress.test.ts.snap
+++ b/packages/client/src/users/addresses/__tests__/__snapshots__/putUserDefaultBillingAddress.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`putUserDefaultBillingAddress should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/addresses/__tests__/__snapshots__/putUserDefaultShippingAddress.test.ts.snap
+++ b/packages/client/src/users/addresses/__tests__/__snapshots__/putUserDefaultShippingAddress.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`putUserDefaultShippingAddress putUserDefaultShippingAddress should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/attributes/__tests__/__snapshots__/deleteUserAttribute.test.ts.snap
+++ b/packages/client/src/users/attributes/__tests__/__snapshots__/deleteUserAttribute.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteUserAttribute should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/attributes/__tests__/__snapshots__/getUserAttribute.test.ts.snap
+++ b/packages/client/src/users/attributes/__tests__/__snapshots__/getUserAttribute.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserAttribute should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/attributes/__tests__/__snapshots__/getUserAttributes.test.ts.snap
+++ b/packages/client/src/users/attributes/__tests__/__snapshots__/getUserAttributes.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserAttributes should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/attributes/__tests__/__snapshots__/patchUserAttribute.test.ts.snap
+++ b/packages/client/src/users/attributes/__tests__/__snapshots__/patchUserAttribute.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`patchUserAttribute should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/attributes/__tests__/__snapshots__/postUserAttribute.test.ts.snap
+++ b/packages/client/src/users/attributes/__tests__/__snapshots__/postUserAttribute.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postUserAttribute should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/attributes/__tests__/__snapshots__/putUserAttribute.test.ts.snap
+++ b/packages/client/src/users/attributes/__tests__/__snapshots__/putUserAttribute.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`putUserAttribute should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/deleteGuestToken.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/deleteGuestToken.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteGuestToken should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/deleteToken.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/deleteToken.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteToken should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/getGuestUser.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/getGuestUser.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getGuestUser should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/getUser.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/getUser.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUser should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postGuestToken.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postGuestToken.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postGuestToken Create a valid guest user token should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postGuestUser.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postGuestUser.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postGuestUser should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postLogin.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postLogin.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postLogin should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postLogout.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postLogout.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postLogout should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postPasswordChange.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postPasswordChange.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postPasswordChange should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postPasswordRecover.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postPasswordRecover.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postPasswordRecover should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postPasswordReset.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postPasswordReset.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postPasswordReset should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postPhoneNumberValidation.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postPhoneNumberValidation.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postPhoneNumberValidation should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postPhoneToken.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postPhoneToken.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postPhoneToken should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postPhoneTokenValidation.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postPhoneTokenValidation.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postPhoneTokenValidation should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postRefreshEmailToken.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postRefreshEmailToken.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postRefreshEmailToken should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postToken.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postToken.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postToken Create a valid guest user token should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postUser.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postUser.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postUser should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/postValidateEmail.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/postValidateEmail.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postEmailTokenValidate should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/authentication/__tests__/__snapshots__/putUser.test.ts.snap
+++ b/packages/client/src/users/authentication/__tests__/__snapshots__/putUser.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`putUser should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/benefits/__tests__/__snapshots__/getUserBenefits.test.ts.snap
+++ b/packages/client/src/users/benefits/__tests__/__snapshots__/getUserBenefits.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserBenefits should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/contacts/__tests__/__snapshots__/deleteUserContact.test.ts.snap
+++ b/packages/client/src/users/contacts/__tests__/__snapshots__/deleteUserContact.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteUserContact should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/contacts/__tests__/__snapshots__/getUserContact.test.ts.snap
+++ b/packages/client/src/users/contacts/__tests__/__snapshots__/getUserContact.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserContact should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/contacts/__tests__/__snapshots__/getUserContacts.test.ts.snap
+++ b/packages/client/src/users/contacts/__tests__/__snapshots__/getUserContacts.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserContacts should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/contacts/__tests__/__snapshots__/patchUserContact.test.ts.snap
+++ b/packages/client/src/users/contacts/__tests__/__snapshots__/patchUserContact.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`patchUserContact should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/contacts/__tests__/__snapshots__/postUserContact.test.ts.snap
+++ b/packages/client/src/users/contacts/__tests__/__snapshots__/postUserContact.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postUserContact should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/credits/__tests__/__snapshots__/getUserCreditMovements.test.ts.snap
+++ b/packages/client/src/users/credits/__tests__/__snapshots__/getUserCreditMovements.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserCreditMovements should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/credits/__tests__/__snapshots__/getUserCredits.test.ts.snap
+++ b/packages/client/src/users/credits/__tests__/__snapshots__/getUserCredits.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserCredits should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/personalIds/__tests__/__snapshots__/deleteUserPersonalId.test.ts.snap
+++ b/packages/client/src/users/personalIds/__tests__/__snapshots__/deleteUserPersonalId.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteUserPersonalId should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/personalIds/__tests__/__snapshots__/getUserDefaultPersonalId.test.ts.snap
+++ b/packages/client/src/users/personalIds/__tests__/__snapshots__/getUserDefaultPersonalId.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserDefaultPersonalId should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/personalIds/__tests__/__snapshots__/getUserPersonalId.test.ts.snap
+++ b/packages/client/src/users/personalIds/__tests__/__snapshots__/getUserPersonalId.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPersonalId should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/personalIds/__tests__/__snapshots__/getUserPersonalIds.test.ts.snap
+++ b/packages/client/src/users/personalIds/__tests__/__snapshots__/getUserPersonalIds.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPersonalIds should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/personalIds/__tests__/__snapshots__/patchUserPersonalId.test.ts.snap
+++ b/packages/client/src/users/personalIds/__tests__/__snapshots__/patchUserPersonalId.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`patchPersonalId should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/personalIds/__tests__/__snapshots__/postUserPersonalId.test.ts.snap
+++ b/packages/client/src/users/personalIds/__tests__/__snapshots__/postUserPersonalId.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postUserPersonalId should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/personalIds/__tests__/__snapshots__/postUserPersonalIdImage.test.ts.snap
+++ b/packages/client/src/users/personalIds/__tests__/__snapshots__/postUserPersonalIdImage.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postPersonalIdImage should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/personalIds/__tests__/__snapshots__/putUserDefaultPersonalId.test.ts.snap
+++ b/packages/client/src/users/personalIds/__tests__/__snapshots__/putUserDefaultPersonalId.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`putDefaultPersonalId should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/preferences/__tests__/__snapshots__/getPreferences.test.ts.snap
+++ b/packages/client/src/users/preferences/__tests__/__snapshots__/getPreferences.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getPreferences should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],
@@ -11,7 +11,7 @@ Object {
 
 exports[`getPreferences should receive a client request error when filtered by code 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/preferences/__tests__/__snapshots__/putPreferences.test.ts.snap
+++ b/packages/client/src/users/preferences/__tests__/__snapshots__/putPreferences.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`putPreferences should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/returns/__tests__/__snapshots__/getUserReturns.test.ts.snap
+++ b/packages/client/src/users/returns/__tests__/__snapshots__/getUserReturns.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getUserReturns should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/users/titles/__tests__/__snapshots__/getUserTitles.test.ts.snap
+++ b/packages/client/src/users/titles/__tests__/__snapshots__/getUserTitles.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getTitles should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/wishlists/__tests__/__snapshots__/deleteWishlistItem.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/deleteWishlistItem.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteWishlistItem should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/wishlists/__tests__/__snapshots__/deleteWishlistSet.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/deleteWishlistSet.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`deleteWishlistSet should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/wishlists/__tests__/__snapshots__/getWishlist.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/getWishlist.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getWishlist should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/wishlists/__tests__/__snapshots__/getWishlistSet.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/getWishlistSet.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getWishlistSet should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/wishlists/__tests__/__snapshots__/getWishlistSets.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/getWishlistSets.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getWishlistSets should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/wishlists/__tests__/__snapshots__/patchWishlistItem.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/patchWishlistItem.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`patchWishlistItem should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/wishlists/__tests__/__snapshots__/patchWishlistSet.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/patchWishlistSet.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`patchWishlistSet should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/wishlists/__tests__/__snapshots__/postWishlistItem.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/postWishlistItem.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postWishlistItem should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/client/src/wishlists/__tests__/__snapshots__/postWishlistSet.test.ts.snap
+++ b/packages/client/src/wishlists/__tests__/__snapshots__/postWishlistSet.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postWishlistSet should receive a client request error 1`] = `
 Object {
-  "code": -1,
+  "code": "-1",
   "message": "stub error",
   "status": 404,
   "toJSON": [Function],

--- a/packages/react/src/locale/hooks/__tests__/useCountries.test.tsx
+++ b/packages/react/src/locale/hooks/__tests__/useCountries.test.tsx
@@ -63,7 +63,7 @@ describe('useCountries', () => {
     const mockError = {
       message: 'This is an error message',
       name: 'error',
-      code: 500,
+      code: '500',
     };
 
     const {

--- a/packages/react/src/locale/hooks/__tests__/useCountryAddressSchemas.test.tsx
+++ b/packages/react/src/locale/hooks/__tests__/useCountryAddressSchemas.test.tsx
@@ -64,7 +64,7 @@ describe('useCountryAddressSchemas', () => {
     const mockError = {
       message: 'This is an error message',
       name: 'error',
-      code: 500,
+      code: '500',
     };
 
     const {

--- a/packages/react/src/locale/hooks/__tests__/useCountryStateCities.test.tsx
+++ b/packages/react/src/locale/hooks/__tests__/useCountryStateCities.test.tsx
@@ -67,7 +67,7 @@ describe('useCountryStateCities', () => {
     const mockError = {
       message: 'This is an error message',
       name: 'error',
-      code: 500,
+      code: '500',
     };
 
     const {

--- a/packages/react/src/locale/hooks/__tests__/useCountryStates.test.tsx
+++ b/packages/react/src/locale/hooks/__tests__/useCountryStates.test.tsx
@@ -61,7 +61,7 @@ describe('useCountryStates', () => {
     const mockError = {
       message: 'This is an error message',
       name: 'error',
-      code: 500,
+      code: '500',
     };
 
     const {

--- a/packages/react/src/subscriptions/hooks/__tests__/useSubscriptionPackages.test.tsx
+++ b/packages/react/src/subscriptions/hooks/__tests__/useSubscriptionPackages.test.tsx
@@ -70,7 +70,7 @@ describe('useSubscriptionPackages', () => {
     const errorData = {
       message: 'An awesome, fascinating and incredible error',
       name: 'error',
-      code: 400,
+      code: '400',
     };
     const {
       result: {

--- a/packages/react/src/subscriptions/hooks/__tests__/useUserSubscriptions.test.tsx
+++ b/packages/react/src/subscriptions/hooks/__tests__/useUserSubscriptions.test.tsx
@@ -76,7 +76,7 @@ describe('useUserSubscriptions', () => {
     const errorData = {
       message: 'An awesome, fascinating and incredible error',
       name: 'error',
-      code: 400,
+      code: '400',
     };
     const {
       result: {

--- a/packages/redux/src/addresses/actions/factories/fetchAddressPredictionDetailsFactory.ts
+++ b/packages/redux/src/addresses/actions/factories/fetchAddressPredictionDetailsFactory.ts
@@ -41,12 +41,14 @@ const fetchAddressPredictionDetailsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_ADDRESS_PREDICTION_DETAILS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/addresses/actions/factories/fetchAddressPredictionsFactory.ts
+++ b/packages/redux/src/addresses/actions/factories/fetchAddressPredictionsFactory.ts
@@ -36,12 +36,14 @@ const fetchAddressPredictionsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_ADDRESS_PREDICTIONS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/bags/actions/factories/addBagItemFactory.ts
+++ b/packages/redux/src/bags/actions/factories/addBagItemFactory.ts
@@ -78,8 +78,10 @@ const addBagItemFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.ADD_BAG_ITEM_FAILURE,
         meta: {
           ...metadata,
@@ -88,7 +90,7 @@ const addBagItemFactory =
         },
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/bags/actions/factories/fetchBagFactory.ts
+++ b/packages/redux/src/bags/actions/factories/fetchBagFactory.ts
@@ -50,12 +50,14 @@ const fetchBagFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_BAG_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/bags/actions/factories/removeBagItemFactory.ts
+++ b/packages/redux/src/bags/actions/factories/removeBagItemFactory.ts
@@ -73,13 +73,15 @@ const removeBagItemFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         meta: { ...metadata, bagId, bagItemId },
         type: actionTypes.REMOVE_BAG_ITEM_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/bags/actions/factories/updateBagItemFactory.ts
+++ b/packages/redux/src/bags/actions/factories/updateBagItemFactory.ts
@@ -78,8 +78,10 @@ const updateBagItemFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         meta: {
           ...metadata,
           ...data,
@@ -89,7 +91,7 @@ const updateBagItemFactory =
         type: actionTypes.UPDATE_BAG_ITEM_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/brands/actions/factories/fetchBrandFactory.ts
+++ b/packages/redux/src/brands/actions/factories/fetchBrandFactory.ts
@@ -38,13 +38,15 @@ const fetchBrandFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { brandId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_BRAND_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/brands/actions/factories/fetchBrandsFactory.ts
+++ b/packages/redux/src/brands/actions/factories/fetchBrandsFactory.ts
@@ -84,13 +84,15 @@ const fetchBrandsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { hash: hash as string, query },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_BRANDS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/categories/actions/factories/fetchCategoriesFactory.ts
+++ b/packages/redux/src/categories/actions/factories/fetchCategoriesFactory.ts
@@ -36,12 +36,14 @@ const fetchCategoriesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CATEGORIES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/categories/actions/factories/fetchCategoryFactory.ts
+++ b/packages/redux/src/categories/actions/factories/fetchCategoryFactory.ts
@@ -38,13 +38,15 @@ const fetchCategoryFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { id },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CATEGORY_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/categories/actions/factories/fetchTopCategoriesFactory.ts
+++ b/packages/redux/src/categories/actions/factories/fetchTopCategoriesFactory.ts
@@ -36,12 +36,14 @@ const fetchTopCategoriesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_TOP_CATEGORIES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/createCheckoutOrderChargeFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/createCheckoutOrderChargeFactory.ts
@@ -43,12 +43,14 @@ const createCheckoutOrderChargeFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_CHECKOUT_ORDER_CHARGE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/createCheckoutOrderFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/createCheckoutOrderFactory.ts
@@ -69,12 +69,14 @@ const createCheckoutOrderFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_CHECKOUT_ORDER_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderChargeFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderChargeFactory.ts
@@ -44,12 +44,14 @@ const fetchCheckoutOrderChargeFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CHECKOUT_ORDER_CHARGE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderDeliveryBundleProvisioningFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderDeliveryBundleProvisioningFactory.ts
@@ -46,12 +46,14 @@ const fetchCheckoutOrderDeliveryBundleProvisioning =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CHECKOUT_ORDER_DELIVERY_BUNDLE_PROVISIONING_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderDeliveryBundleUpgradeProvisioningFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderDeliveryBundleUpgradeProvisioningFactory.ts
@@ -49,12 +49,14 @@ const fetchCheckoutOrderDeliveryBundleUpgradeProvisioning =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CHECKOUT_ORDER_DELIVERY_BUNDLE_UPGRADE_PROVISIONING_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderDeliveryBundleUpgradesFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderDeliveryBundleUpgradesFactory.ts
@@ -53,12 +53,14 @@ const fetchCheckoutOrderDeliveryBundleUpgrades =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CHECKOUT_ORDER_DELIVERY_BUNDLE_UPGRADES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderDetailsFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderDetailsFactory.ts
@@ -37,12 +37,14 @@ const fetchCheckoutOrderDetailsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CHECKOUT_ORDER_DETAILS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderFactory.ts
@@ -66,12 +66,14 @@ const fetchCheckoutOrderFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CHECKOUT_ORDER_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 export default fetchCheckoutOrderFactory;

--- a/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderOperationFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderOperationFactory.ts
@@ -1,12 +1,13 @@
 import * as actionTypes from '../../actionTypes';
-import { normalize } from 'normalizr';
-import checkoutOrderOperation from '../../../entities/schemas/checkoutOrderOperation';
-import type {
+import {
   CheckoutOrder,
   CheckoutOrderOperation,
   Config,
   GetCheckoutOrderOperation,
+  toBlackoutError,
 } from '@farfetch/blackout-client';
+import { normalize } from 'normalizr';
+import checkoutOrderOperation from '../../../entities/schemas/checkoutOrderOperation';
 import type { Dispatch } from 'redux';
 
 /**
@@ -42,12 +43,14 @@ const fetchCheckoutOrderOperationFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CHECKOUT_ORDER_OPERATION_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderOperationsFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderOperationsFactory.ts
@@ -1,13 +1,14 @@
 import * as actionTypes from '../../actionTypes';
-import { normalize } from 'normalizr';
-import checkoutOrderOperation from '../../../entities/schemas/checkoutOrderOperation';
-import type {
+import {
   CheckoutOrder,
   CheckoutOrderOperations,
   Config,
   GetCheckoutOrderOperations,
   GetCheckoutOrderOperationsQuery,
+  toBlackoutError,
 } from '@farfetch/blackout-client';
+import { normalize } from 'normalizr';
+import checkoutOrderOperation from '../../../entities/schemas/checkoutOrderOperation';
 import type { Dispatch } from 'redux';
 
 /**
@@ -43,12 +44,14 @@ const fetchCheckoutOrderOperationsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CHECKOUT_ORDER_OPERATIONS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderPaymentMethodsFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/fetchCheckoutOrderPaymentMethodsFactory.ts
@@ -48,12 +48,14 @@ const fetchCheckoutOrderPaymentMethodsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CHECKOUT_ORDER_PAYMENT_METHODS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/fetchCollectPointsFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/fetchCollectPointsFactory.ts
@@ -38,12 +38,14 @@ const fetchCollectPointsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_COLLECT_POINTS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/removeCheckoutOrderItemFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/removeCheckoutOrderItemFactory.ts
@@ -1,9 +1,10 @@
 import * as actionTypes from '../../actionTypes';
-import type {
+import {
   CheckoutOrder,
   CheckoutOrderItem,
   Config,
   DeleteCheckoutOrderItem,
+  toBlackoutError,
 } from '@farfetch/blackout-client';
 import type { Dispatch } from 'redux';
 
@@ -39,12 +40,14 @@ const removeCheckoutOrderItemFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_CHECKOUT_ORDER_ITEM_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/setCheckoutOrderItemTagsFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/setCheckoutOrderItemTagsFactory.ts
@@ -72,12 +72,14 @@ const setCheckoutOrderItemTagsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.SET_CHECKOUT_ORDER_ITEM_TAGS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/setCheckoutOrderPromocodeFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/setCheckoutOrderPromocodeFactory.ts
@@ -70,12 +70,14 @@ const setCheckoutOrderPromocodeFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.SET_CHECKOUT_ORDER_PROMOCODE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/setCheckoutOrderTagsFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/setCheckoutOrderTagsFactory.ts
@@ -61,12 +61,14 @@ const setCheckoutOrderTagsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.SET_CHECKOUT_ORDER_TAGS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/updateCheckoutOrderDeliveryBundleUpgradesFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/updateCheckoutOrderDeliveryBundleUpgradesFactory.ts
@@ -44,12 +44,14 @@ const updateCheckoutOrderDeliveryBundleUpgradesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_CHECKOUT_ORDER_DELIVERY_BUNDLE_UPGRADES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/updateCheckoutOrderFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/updateCheckoutOrderFactory.ts
@@ -68,12 +68,14 @@ const updateCheckoutOrderFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_CHECKOUT_ORDER_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/updateCheckoutOrderItemFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/updateCheckoutOrderItemFactory.ts
@@ -1,10 +1,11 @@
 import * as actionTypes from '../../actionTypes';
-import type {
+import {
   CheckoutOrder,
   CheckoutOrderItem,
   Config,
   PatchCheckoutOrderItem,
   PatchCheckoutOrderItemData,
+  toBlackoutError,
 } from '@farfetch/blackout-client';
 import type { Dispatch } from 'redux';
 
@@ -42,12 +43,14 @@ const updateCheckoutOrderItemFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_CHECKOUT_ORDER_ITEM_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/checkout/actions/factories/updateCheckoutOrderItemsFactory.ts
+++ b/packages/redux/src/checkout/actions/factories/updateCheckoutOrderItemsFactory.ts
@@ -41,12 +41,14 @@ const updateCheckoutOrderItemsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_CHECKOUT_ORDER_ITEMS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/contents/actions/factories/fetchCommercePagesFactory.ts
+++ b/packages/redux/src/contents/actions/factories/fetchCommercePagesFactory.ts
@@ -55,12 +55,14 @@ const fetchCommercePagesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error), hash: hash as string },
+        payload: { error: errorAsBlackoutError, hash: hash as string },
         type: actionTypes.FETCH_COMMERCE_PAGES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/contents/actions/factories/fetchContentPageFactory.ts
+++ b/packages/redux/src/contents/actions/factories/fetchContentPageFactory.ts
@@ -53,12 +53,14 @@ const fetchContentPageFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error), hash },
+        payload: { error: errorAsBlackoutError, hash },
         type: actionTypes.FETCH_CONTENT_PAGES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/contents/actions/factories/fetchContentTypesFactory.ts
+++ b/packages/redux/src/contents/actions/factories/fetchContentTypesFactory.ts
@@ -33,12 +33,14 @@ const fetchContentTypesFactory =
 
       return contentTypes;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CONTENT_TYPES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/contents/actions/factories/fetchContentsFactory.ts
+++ b/packages/redux/src/contents/actions/factories/fetchContentsFactory.ts
@@ -46,12 +46,14 @@ const fetchContentsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error), hash: hash as string },
+        payload: { error: errorAsBlackoutError, hash: hash as string },
         type: actionTypes.FETCH_CONTENTS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/contents/actions/factories/fetchSEOMetadataFactory.ts
+++ b/packages/redux/src/contents/actions/factories/fetchSEOMetadataFactory.ts
@@ -40,15 +40,17 @@ const fetchSEOMetadataFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         payload: {
-          error: toBlackoutError(error),
+          error: errorAsBlackoutError,
           pathname,
         },
         type: actionTypes.FETCH_SEO_METADATA_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/forms/__tests__/reducer.test.ts
+++ b/packages/redux/src/forms/__tests__/reducer.test.ts
@@ -52,7 +52,7 @@ describe('forms redux reducer', () => {
       const errorCode = 'foo-biz';
       const state: FormsState = {
         ...initialState,
-        error: { [errorCode]: { code: -1, name: 'Error', message: 'error' } },
+        error: { [errorCode]: { code: '-1', name: 'Error', message: 'error' } },
       };
 
       expect(formsReducer(state, randomAction).error).toEqual(state.error);

--- a/packages/redux/src/forms/actions/factories/fetchFormSchemaFactory.ts
+++ b/packages/redux/src/forms/actions/factories/fetchFormSchemaFactory.ts
@@ -36,13 +36,15 @@ const fetchFormSchemaFactory: FetchFormSchemaFactory<GetFormSchema> =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { schemaCode },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_FORM_SCHEMA_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/forms/actions/factories/submitFormDataFactory.ts
+++ b/packages/redux/src/forms/actions/factories/submitFormDataFactory.ts
@@ -37,13 +37,15 @@ const submitFormDataFactory: SubmitFormDataFactory<PostFormData> =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { schemaCode, data },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.SUBMIT_FORM_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/locale/actions/factories/fetchCountriesFactory.ts
+++ b/packages/redux/src/locale/actions/factories/fetchCountriesFactory.ts
@@ -36,12 +36,14 @@ const fetchCountriesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_COUNTRIES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/locale/actions/factories/fetchCountryAddressSchemasFactory.ts
+++ b/packages/redux/src/locale/actions/factories/fetchCountryAddressSchemasFactory.ts
@@ -44,12 +44,14 @@ const fetchCountryAddressSchemasFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_COUNTRY_ADDRESS_SCHEMA_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/locale/actions/factories/fetchCountryCurrenciesFactory.ts
+++ b/packages/redux/src/locale/actions/factories/fetchCountryCurrenciesFactory.ts
@@ -42,13 +42,15 @@ const fetchCountryCurrenciesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { countryCode },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_COUNTRY_CURRENCIES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/locale/actions/factories/fetchCountryFactory.ts
+++ b/packages/redux/src/locale/actions/factories/fetchCountryFactory.ts
@@ -38,13 +38,15 @@ const fetchCountryFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { countryCode },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_COUNTRY_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/locale/actions/factories/fetchCountryStateCitiesFactory.ts
+++ b/packages/redux/src/locale/actions/factories/fetchCountryStateCitiesFactory.ts
@@ -48,16 +48,18 @@ const fetchCountryStateCitiesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: {
           countryCode,
           stateId,
         },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_COUNTRY_STATE_CITIES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/locale/actions/factories/fetchCountryStatesFactory.ts
+++ b/packages/redux/src/locale/actions/factories/fetchCountryStatesFactory.ts
@@ -42,13 +42,15 @@ const fetchCountryStatesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { countryCode },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_COUNTRY_STATES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/loyalty/actions/factories/createProgramMembershipConvertFactory.ts
+++ b/packages/redux/src/loyalty/actions/factories/createProgramMembershipConvertFactory.ts
@@ -48,12 +48,14 @@ const createProgramMembershipConvertFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_PROGRAM_MEMBERSHIP_CONVERT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/loyalty/actions/factories/createProgramMembershipFactory.ts
+++ b/packages/redux/src/loyalty/actions/factories/createProgramMembershipFactory.ts
@@ -39,12 +39,14 @@ const createProgramMembershipFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_PROGRAM_MEMBERSHIP_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/loyalty/actions/factories/createProgramMembershipReplacementFactory.ts
+++ b/packages/redux/src/loyalty/actions/factories/createProgramMembershipReplacementFactory.ts
@@ -50,12 +50,14 @@ const createProgramMembershipReplacementFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_PROGRAM_MEMBERSHIP_REPLACEMENT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/loyalty/actions/factories/fetchProgramMembershipStatementsFactory.ts
+++ b/packages/redux/src/loyalty/actions/factories/fetchProgramMembershipStatementsFactory.ts
@@ -50,12 +50,14 @@ const fetchProgramMembershipStatementsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PROGRAM_MEMBERSHIP_STATEMENTS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/loyalty/actions/factories/fetchProgramUsersMembershipFactory.ts
+++ b/packages/redux/src/loyalty/actions/factories/fetchProgramUsersMembershipFactory.ts
@@ -39,12 +39,14 @@ const fetchProgramUsersMembershipFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PROGRAM_USERS_MEMBERSHIP_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/loyalty/actions/factories/fetchProgramsFactory.ts
+++ b/packages/redux/src/loyalty/actions/factories/fetchProgramsFactory.ts
@@ -36,12 +36,14 @@ const fetchProgramsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PROGRAMS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/merchantsLocations/actions/factories/fetchMerchantsLocationsFactory.ts
+++ b/packages/redux/src/merchantsLocations/actions/factories/fetchMerchantsLocationsFactory.ts
@@ -49,12 +49,14 @@ const fetchMerchantsLocationsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_MERCHANTS_LOCATIONS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/__tests__/selectors.test.ts
+++ b/packages/redux/src/orders/__tests__/selectors.test.ts
@@ -620,7 +620,7 @@ describe('orders redux selectors', () => {
             isLoading: { [orderId]: false },
           },
           trackings: {
-            error: { name: '', message: 'Error', code: 123 },
+            error: { name: '', message: 'Error', code: '123' },
             isLoading: false,
           },
           documents: {

--- a/packages/redux/src/orders/actions/factories/addOrderDocumentFactory.ts
+++ b/packages/redux/src/orders/actions/factories/addOrderDocumentFactory.ts
@@ -32,12 +32,14 @@ const addOrderDocumentFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.ADD_ORDER_DOCUMENT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/addOrderItemActivityFactory.ts
+++ b/packages/redux/src/orders/actions/factories/addOrderItemActivityFactory.ts
@@ -39,12 +39,14 @@ const addOrderItemActivityFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.ADD_ORDER_ITEM_ACTIVITY_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/fetchGuestOrderLegacyFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchGuestOrderLegacyFactory.ts
@@ -48,13 +48,15 @@ const fetchGuestOrderLegacyFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { orderId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_ORDER_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/fetchGuestOrdersFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchGuestOrdersFactory.ts
@@ -68,12 +68,14 @@ const fetchGuestOrdersFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_GUEST_ORDERS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/fetchOrderAvailableItemsActivitiesFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchOrderAvailableItemsActivitiesFactory.ts
@@ -31,12 +31,14 @@ const fetchOrderAvailableItemsActivities =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_ORDER_AVAILABLE_ITEMS_ACTIVITIES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/fetchOrderDocumentFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchOrderDocumentFactory.ts
@@ -31,12 +31,14 @@ const fetchOrderDocumentFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_ORDER_DOCUMENT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/fetchOrderDocumentsFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchOrderDocumentsFactory.ts
@@ -36,12 +36,14 @@ const fetchOrderDocumentsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_ORDER_DOCUMENTS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/fetchOrderFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchOrderFactory.ts
@@ -48,13 +48,15 @@ const fetchOrderFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { orderId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_ORDER_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/fetchOrderItemAvailableActivitiesFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchOrderItemAvailableActivitiesFactory.ts
@@ -37,12 +37,14 @@ const fetchOrderItemAvailableActivities =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_ORDER_ITEM_AVAILABLE_ACTIVITIES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/fetchOrderReturnOptionsFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchOrderReturnOptionsFactory.ts
@@ -39,13 +39,15 @@ const fetchOrderReturnOptionsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { orderId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_ORDER_RETURN_OPTIONS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/fetchOrderReturnsFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchOrderReturnsFactory.ts
@@ -36,13 +36,15 @@ const fetchOrderReturnsFactory =
       });
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { orderId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_ORDER_RETURNS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/fetchShipmentTrackingsFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchShipmentTrackingsFactory.ts
@@ -39,12 +39,14 @@ const fetchShipmentTrackingsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_SHIPMENT_TRACKINGS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/orders/actions/factories/fetchUserOrdersFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchUserOrdersFactory.ts
@@ -36,12 +36,14 @@ const fetchUserOrdersFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_ORDERS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/__tests__/selectors.test.ts
+++ b/packages/redux/src/payments/__tests__/selectors.test.ts
@@ -96,7 +96,7 @@ describe('Payments redux selectors', () => {
         const mockError = {
           message: 'This is an error message',
           name: 'error',
-          code: 500,
+          code: '500',
         };
 
         expect(

--- a/packages/redux/src/payments/actions/factories/createPaymentIntentChargeFactory.ts
+++ b/packages/redux/src/payments/actions/factories/createPaymentIntentChargeFactory.ts
@@ -44,12 +44,14 @@ const createPaymentIntentChargeFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_PAYMENT_INTENT_CHARGE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/createPaymentIntentInstrumentFactory.ts
+++ b/packages/redux/src/payments/actions/factories/createPaymentIntentInstrumentFactory.ts
@@ -44,12 +44,14 @@ const createPaymentIntentInstrumentFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_PAYMENT_INTENT_INSTRUMENT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/fetchGiftCardBalanceFactory.ts
+++ b/packages/redux/src/payments/actions/factories/fetchGiftCardBalanceFactory.ts
@@ -34,12 +34,14 @@ const fetchGiftCardBalanceFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_GIFT_CARD_BALANCE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/fetchPaymentIntentChargeFactory.ts
+++ b/packages/redux/src/payments/actions/factories/fetchPaymentIntentChargeFactory.ts
@@ -37,12 +37,14 @@ const fetchPaymentIntentChargeFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PAYMENT_INTENT_CHARGE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/fetchPaymentIntentFactory.ts
+++ b/packages/redux/src/payments/actions/factories/fetchPaymentIntentFactory.ts
@@ -35,12 +35,14 @@ const fetchPaymentIntentFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PAYMENT_INTENT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/fetchPaymentIntentInstrumentFactory.ts
+++ b/packages/redux/src/payments/actions/factories/fetchPaymentIntentInstrumentFactory.ts
@@ -46,12 +46,14 @@ const fetchPaymentIntentInstrumentFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PAYMENT_INTENT_INSTRUMENT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/fetchPaymentIntentInstrumentsFactory.ts
+++ b/packages/redux/src/payments/actions/factories/fetchPaymentIntentInstrumentsFactory.ts
@@ -38,12 +38,14 @@ const fetchPaymentIntentInstrumentsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PAYMENT_INTENT_INSTRUMENTS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/fetchPaymentMethodsByCountryAndCurrencyFactory.ts
+++ b/packages/redux/src/payments/actions/factories/fetchPaymentMethodsByCountryAndCurrencyFactory.ts
@@ -38,12 +38,14 @@ const fetchPaymentMethodsByCountryAndCurrencyFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PAYMENT_METHODS_BY_COUNTRY_AND_CURRENCY_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/fetchPaymentMethodsByIntentFactory.ts
+++ b/packages/redux/src/payments/actions/factories/fetchPaymentMethodsByIntentFactory.ts
@@ -36,12 +36,14 @@ const fetchPaymentMethodsByIntentFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PAYMENT_METHODS_BY_INTENT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/fetchPaymentTokensFactory.ts
+++ b/packages/redux/src/payments/actions/factories/fetchPaymentTokensFactory.ts
@@ -39,12 +39,14 @@ const fetchPaymentTokensFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PAYMENT_TOKENS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/fetchUserCreditBalanceFactory.ts
+++ b/packages/redux/src/payments/actions/factories/fetchUserCreditBalanceFactory.ts
@@ -36,12 +36,14 @@ const fetchUserCreditBalanceFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_CREDIT_BALANCE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/removePaymentIntentInstrumentFactory.ts
+++ b/packages/redux/src/payments/actions/factories/removePaymentIntentInstrumentFactory.ts
@@ -44,12 +44,14 @@ const removePaymentIntentInstrumentFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_PAYMENT_INTENT_INSTRUMENT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/removePaymentTokenFactory.ts
+++ b/packages/redux/src/payments/actions/factories/removePaymentTokenFactory.ts
@@ -34,12 +34,14 @@ const removePaymentTokenFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_PAYMENT_TOKEN_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/payments/actions/factories/updatePaymentIntentInstrumentFactory.ts
+++ b/packages/redux/src/payments/actions/factories/updatePaymentIntentInstrumentFactory.ts
@@ -46,12 +46,14 @@ const updatePaymentIntentInstrumentFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_PAYMENT_INTENT_INSTRUMENT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchProductAttributesFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchProductAttributesFactory.ts
@@ -42,13 +42,15 @@ const fetchProductAttributesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { productId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PRODUCT_ATTRIBUTES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchProductDetailsFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchProductDetailsFactory.ts
@@ -80,13 +80,15 @@ const fetchProductDetailsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { productId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PRODUCT_DETAILS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchProductFittingsFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchProductFittingsFactory.ts
@@ -42,13 +42,15 @@ const fetchProductFittingsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { productId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PRODUCT_FITTINGS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchProductGroupingFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchProductGroupingFactory.ts
@@ -59,13 +59,15 @@ const fetchProductGroupingFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { productId },
-        payload: { error: toBlackoutError(error), hash },
+        payload: { error: errorAsBlackoutError, hash },
         type: FETCH_PRODUCT_GROUPING_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchProductGroupingPropertiesFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchProductGroupingPropertiesFactory.ts
@@ -62,13 +62,15 @@ const fetchProductGroupingFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { productId },
-        payload: { error: toBlackoutError(error), hash },
+        payload: { error: errorAsBlackoutError, hash },
         type: FETCH_PRODUCT_GROUPING_PROPERTIES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchProductMeasurementsFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchProductMeasurementsFactory.ts
@@ -42,13 +42,15 @@ const fetchProductMeasurementsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { productId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PRODUCT_MEASUREMENTS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchProductSizeGuidesFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchProductSizeGuidesFactory.ts
@@ -45,13 +45,15 @@ const fetchProductSizeGuidesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { productId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PRODUCT_SIZEGUIDES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchProductSizesFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchProductSizesFactory.ts
@@ -47,13 +47,15 @@ const fetchProductSizesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { productId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PRODUCT_SIZES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchProductVariantsByMerchantsLocationsFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchProductVariantsByMerchantsLocationsFactory.ts
@@ -69,13 +69,15 @@ const fetchProductVariantsByMerchantsLocationsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { productId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PRODUCT_MERCHANTS_LOCATIONS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchProductsListFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchProductsListFactory.ts
@@ -118,13 +118,15 @@ const fetchProductsListFactory = async (
 
     return result;
   } catch (error) {
+    const errorAsBlackoutError = toBlackoutError(error);
+
     dispatch({
       meta: { hash: hash as string },
-      payload: { error: toBlackoutError(error) },
+      payload: { error: errorAsBlackoutError },
       type: actionTypes.FETCH_PRODUCTS_LIST_FAILURE,
     });
 
-    throw error;
+    throw errorAsBlackoutError;
   }
 };
 

--- a/packages/redux/src/products/actions/factories/fetchRecentlyViewedProductsFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchRecentlyViewedProductsFactory.ts
@@ -50,12 +50,14 @@ const fetchRecentlyViewedProductsFactory: FetchRecentlyViewedProductsFactory<
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         type: actionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_FAILURE,
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchRecommendedProductsFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchRecommendedProductsFactory.ts
@@ -49,13 +49,15 @@ const fetchRecommendedProductsFactory: FetchRecommendedProductsFactory<
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         type: actionTypes.FETCH_RECOMMENDED_PRODUCTS_FAILURE,
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         meta: { strategyName },
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/fetchRecommendedSetFactory.ts
+++ b/packages/redux/src/products/actions/factories/fetchRecommendedSetFactory.ts
@@ -38,13 +38,15 @@ const fetchRecommendedSetFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { recommendedSetId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_RECOMMENDED_SET_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/actions/factories/removeRecentlyViewedProductFactory.ts
+++ b/packages/redux/src/products/actions/factories/removeRecentlyViewedProductFactory.ts
@@ -38,13 +38,15 @@ const removeRecentlyViewedProductFactory: RemoveRecentlyViewedProductFactory<
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { productId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/products/reducer/__tests__/recentlyViewed.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/recentlyViewed.test.ts
@@ -22,7 +22,7 @@ describe('Recently Viewed reducer', () => {
     const expectedError = {
       message: 'An error occurred',
       name: 'error',
-      code: -1,
+      code: '-1',
     };
 
     it('should return the initial state', () => {
@@ -216,7 +216,7 @@ describe('Recently Viewed reducer', () => {
     it('should return the `recentlyViewed.error` property from a given state', () => {
       const state = {
         ...initialState,
-        error: { message: 'This is an error', name: 'error', code: -1 },
+        error: { message: 'This is an error', name: 'error', code: '-1' },
       };
 
       expect(getError(state)).toEqual(state.error);

--- a/packages/redux/src/promotionEvaluations/actions/factories/fetchPromotionEvaluationItemsFactory.ts
+++ b/packages/redux/src/promotionEvaluations/actions/factories/fetchPromotionEvaluationItemsFactory.ts
@@ -42,13 +42,15 @@ const fetchPromotionEvaluationItemsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { promotionEvaluationId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_PROMOTION_EVALUATION_ITEMS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/returns/actions/factories/createReturnPickupRescheduleRequestFactory.ts
+++ b/packages/redux/src/returns/actions/factories/createReturnPickupRescheduleRequestFactory.ts
@@ -37,12 +37,14 @@ const createReturnPickupRescheduleRequestFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_RETURN_PICKUP_RESCHEDULE_REQUEST_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/returns/actions/factories/fetchReturnFactory.ts
+++ b/packages/redux/src/returns/actions/factories/fetchReturnFactory.ts
@@ -36,13 +36,15 @@ const fetchReturnFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         type: actionTypes.FETCH_RETURN_FAILURE,
         meta: { returnId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/returns/actions/factories/fetchReturnPickupCapabilityFactory.ts
+++ b/packages/redux/src/returns/actions/factories/fetchReturnPickupCapabilityFactory.ts
@@ -56,13 +56,15 @@ const fetchReturnPickupCapabilityFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { hash },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_RETURN_PICKUP_CAPABILITY_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/returns/actions/factories/fetchReturnPickupRescheduleRequestFactory.ts
+++ b/packages/redux/src/returns/actions/factories/fetchReturnPickupRescheduleRequestFactory.ts
@@ -37,12 +37,14 @@ const fetchReturnPickupRescheduleRequestFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_RETURN_PICKUP_RESCHEDULE_REQUEST_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/returns/actions/factories/fetchReturnPickupRescheduleRequestsFactory.ts
+++ b/packages/redux/src/returns/actions/factories/fetchReturnPickupRescheduleRequestsFactory.ts
@@ -33,12 +33,14 @@ const fetchReturnPickupRescheduleRequestsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_RETURN_PICKUP_RESCHEDULE_REQUESTS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/returns/actions/factories/updateReturnFactory.ts
+++ b/packages/redux/src/returns/actions/factories/updateReturnFactory.ts
@@ -44,13 +44,15 @@ const updateReturnFactory =
         type: actionTypes.UPDATE_RETURN_SUCCESS,
       });
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { returnId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_RETURN_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/search/actions/factories/fetchSearchDidYouMeanFactory.ts
+++ b/packages/redux/src/search/actions/factories/fetchSearchDidYouMeanFactory.ts
@@ -42,13 +42,15 @@ const fetchSearchDidYouMeanFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { query, hash },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_SEARCH_DID_YOU_MEAN_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/search/actions/factories/fetchSearchIntentsFactory.ts
+++ b/packages/redux/src/search/actions/factories/fetchSearchIntentsFactory.ts
@@ -44,13 +44,15 @@ const fetchSearchIntentsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { query, hash },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_SEARCH_INTENTS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/search/actions/factories/fetchSearchSuggestionsFactory.ts
+++ b/packages/redux/src/search/actions/factories/fetchSearchSuggestionsFactory.ts
@@ -42,13 +42,15 @@ const fetchSearchSuggestionsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { query, hash },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_SEARCH_SUGGESTIONS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/settings/actions/factories/fetchConfigurationFactory.ts
+++ b/packages/redux/src/settings/actions/factories/fetchConfigurationFactory.ts
@@ -41,13 +41,15 @@ const fetchConfigurationFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { code },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_CONFIGURATION_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/settings/actions/factories/fetchConfigurationsFactory.ts
+++ b/packages/redux/src/settings/actions/factories/fetchConfigurationsFactory.ts
@@ -38,11 +38,13 @@ const fetchConfigurationsFactory =
       });
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         type: actionTypes.FETCH_CONFIGURATIONS_FAILURE,
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
       });
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/sharedWishlists/actions/factories/createSharedWishlistFactory.ts
+++ b/packages/redux/src/sharedWishlists/actions/factories/createSharedWishlistFactory.ts
@@ -52,12 +52,14 @@ const createSharedWishlistFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_SHARED_WISHLIST_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/sharedWishlists/actions/factories/fetchSharedWishlistFactory.ts
+++ b/packages/redux/src/sharedWishlists/actions/factories/fetchSharedWishlistFactory.ts
@@ -51,12 +51,14 @@ const fetchWishlistFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_SHARED_WISHLIST_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/sharedWishlists/actions/factories/removeSharedWishlistFactory.ts
+++ b/packages/redux/src/sharedWishlists/actions/factories/removeSharedWishlistFactory.ts
@@ -33,12 +33,14 @@ const removeSharedWishlistFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_SHARED_WISHLIST_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/sharedWishlists/actions/factories/updateSharedWishlistFactory.ts
+++ b/packages/redux/src/sharedWishlists/actions/factories/updateSharedWishlistFactory.ts
@@ -51,12 +51,14 @@ const updateWishlistSetFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_SHARED_WISHLIST_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/sizeGuides/actions/factories/fetchSizeGuidesFactory.ts
+++ b/packages/redux/src/sizeGuides/actions/factories/fetchSizeGuidesFactory.ts
@@ -42,13 +42,15 @@ const fetchSizeGuidesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { query },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_SIZE_GUIDES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/sizeScales/actions/factories/fetchSizeScaleFactory.ts
+++ b/packages/redux/src/sizeScales/actions/factories/fetchSizeScaleFactory.ts
@@ -38,13 +38,15 @@ const fetchSizeScaleFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { sizeScaleId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_SIZE_SCALE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/sizeScales/actions/factories/fetchSizeScalesFactory.ts
+++ b/packages/redux/src/sizeScales/actions/factories/fetchSizeScalesFactory.ts
@@ -39,13 +39,15 @@ const fetchSizeScalesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { query },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_SIZE_SCALES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/staffMembers/actions/factories/fetchStaffMemberFactory.ts
+++ b/packages/redux/src/staffMembers/actions/factories/fetchStaffMemberFactory.ts
@@ -36,13 +36,15 @@ const fetchStaffMemberFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         type: actionTypes.FETCH_STAFF_MEMBER_FAILURE,
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         meta: { id },
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/subscriptions/actions/factories/fetchSubscriptionPackagesFactory.ts
+++ b/packages/redux/src/subscriptions/actions/factories/fetchSubscriptionPackagesFactory.ts
@@ -35,13 +35,15 @@ const fetchSubscriptionPackagesFactory: FetchSubscriptionPackagesFactory<
     });
     return result;
   } catch (error) {
+    const errorAsBlackoutError = toBlackoutError(error);
+
     dispatch({
       meta: { hash },
-      payload: { error: toBlackoutError(error) },
+      payload: { error: errorAsBlackoutError },
       type: actionTypes.FETCH_SUBSCRIPTION_PACKAGES_FAILURE,
     });
 
-    throw error;
+    throw errorAsBlackoutError;
   }
 };
 

--- a/packages/redux/src/subscriptions/actions/factories/fetchUserSubscriptionsFactory.ts
+++ b/packages/redux/src/subscriptions/actions/factories/fetchUserSubscriptionsFactory.ts
@@ -25,12 +25,14 @@ const fetchUserSubscriptionsFactory: FetchUserSubscriptionsFactory<
     });
     return result;
   } catch (error) {
+    const errorAsBlackoutError = toBlackoutError(error);
+
     dispatch({
-      payload: { error: toBlackoutError(error) },
+      payload: { error: errorAsBlackoutError },
       type: actionTypes.FETCH_USER_SUBSCRIPTIONS_FAILURE,
     });
 
-    throw error;
+    throw errorAsBlackoutError;
   }
 };
 

--- a/packages/redux/src/subscriptions/actions/factories/unsubscribeSubscriptionFactory.ts
+++ b/packages/redux/src/subscriptions/actions/factories/unsubscribeSubscriptionFactory.ts
@@ -25,12 +25,14 @@ const unsubscribeSubscriptionFactory: UnsubscribeSubscriptionFactory<
 
     return result;
   } catch (error) {
+    const errorAsBlackoutError = toBlackoutError(error);
+
     dispatch({
-      payload: { error: toBlackoutError(error) },
+      payload: { error: errorAsBlackoutError },
       type: actionTypes.UNSUBSCRIBE_SUBSCRIPTION_FAILURE,
     });
 
-    throw error;
+    throw errorAsBlackoutError;
   }
 };
 

--- a/packages/redux/src/subscriptions/actions/factories/unsubscribeSubscriptionTopicRecipientFactory.ts
+++ b/packages/redux/src/subscriptions/actions/factories/unsubscribeSubscriptionTopicRecipientFactory.ts
@@ -45,12 +45,14 @@ const unsubscribeSubscriptionTopicRecipient: UnsubscribeSubscriptionTopicRecipie
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { recipientId, error: toBlackoutError(error) },
+        payload: { recipientId, error: errorAsBlackoutError },
         type: actionTypes.UNSUBSCRIBE_SUBSCRIPTION_TOPIC_RECIPIENT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/subscriptions/actions/factories/updateUserSubscriptionsFactory.ts
+++ b/packages/redux/src/subscriptions/actions/factories/updateUserSubscriptionsFactory.ts
@@ -23,12 +23,14 @@ const updateUserSubscriptionsFactory: UpdateUserSubscriptionsFactory<
       type: actionTypes.UPDATE_USER_SUBSCRIPTIONS_SUCCESS,
     });
   } catch (error) {
+    const errorAsBlackoutError = toBlackoutError(error);
+
     dispatch({
-      payload: { error: toBlackoutError(error) },
+      payload: { error: errorAsBlackoutError },
       type: actionTypes.UPDATE_USER_SUBSCRIPTIONS_FAILURE,
     });
 
-    throw error;
+    throw errorAsBlackoutError;
   }
 };
 

--- a/packages/redux/src/subscriptions/reducer/__tests__/userSubscriptions.test.ts
+++ b/packages/redux/src/subscriptions/reducer/__tests__/userSubscriptions.test.ts
@@ -77,7 +77,7 @@ describe('userSubscriptions reducer', () => {
 
     it('should handle other actions by returning the previous state', () => {
       const state: SubscriptionsState['user'] = {
-        error: { message: 'foo', name: 'error', code: -1 },
+        error: { message: 'foo', name: 'error', code: '-1' },
         isLoading: false,
         result: [],
         unsubscribeRecipientFromTopicRequests: {},
@@ -112,7 +112,7 @@ describe('userSubscriptions reducer', () => {
     it('should handle other actions by returning the previous state', () => {
       const state: SubscriptionsState['user'] = {
         ...mockUserSubscriptionsState,
-        updateSubscriptionsError: { code: -1, name: 'foo', message: 'bar' },
+        updateSubscriptionsError: { code: '-1', name: 'foo', message: 'bar' },
       };
 
       expect(reducer(state, randomAction).updateSubscriptionsError).toEqual(
@@ -506,7 +506,7 @@ describe('userSubscriptions reducer', () => {
 
   describe('getSubscriptionsError() selector', () => {
     it('should return the error state', () => {
-      const error = { message: 'This is an error', name: 'error', code: -1 };
+      const error = { message: 'This is an error', name: 'error', code: '-1' };
 
       expect(getUserSubscriptionsError({ ...initialState, error })).toBe(error);
     });
@@ -552,7 +552,7 @@ describe('userSubscriptions reducer', () => {
       const updateSubscriptionsError: BlackoutError = {
         name: 'error',
         message: 'foo',
-        code: -1,
+        code: '-1',
       };
 
       expect(

--- a/packages/redux/src/users/addresses/actions/factories/createUserAddressFactory.ts
+++ b/packages/redux/src/users/addresses/actions/factories/createUserAddressFactory.ts
@@ -37,12 +37,14 @@ const createUserAddressFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_USER_ADDRESS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/addresses/actions/factories/fetchUserAddressFactory.ts
+++ b/packages/redux/src/users/addresses/actions/factories/fetchUserAddressFactory.ts
@@ -37,13 +37,15 @@ const fetchUserAddressFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { addressId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_ADDRESS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/addresses/actions/factories/fetchUserAddressesFactory.ts
+++ b/packages/redux/src/users/addresses/actions/factories/fetchUserAddressesFactory.ts
@@ -37,12 +37,14 @@ const fetchUserAddressesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_ADDRESSES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/addresses/actions/factories/fetchUserDefaultContactAddressFactory.ts
+++ b/packages/redux/src/users/addresses/actions/factories/fetchUserDefaultContactAddressFactory.ts
@@ -36,12 +36,14 @@ const fetchUserDefaultContactAddressFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_DEFAULT_CONTACT_ADDRESS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/addresses/actions/factories/removeUserAddressFactory.ts
+++ b/packages/redux/src/users/addresses/actions/factories/removeUserAddressFactory.ts
@@ -35,13 +35,15 @@ const removeUserAddressFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { addressId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_USER_ADDRESS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/addresses/actions/factories/removeUserDefaultContactAddressFactory.ts
+++ b/packages/redux/src/users/addresses/actions/factories/removeUserDefaultContactAddressFactory.ts
@@ -37,13 +37,15 @@ const removeUserDefaultContactAddressFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { userId, addressId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_USER_DEFAULT_CONTACT_ADDRESS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/addresses/actions/factories/setUserDefaultBillingAddressFactory.ts
+++ b/packages/redux/src/users/addresses/actions/factories/setUserDefaultBillingAddressFactory.ts
@@ -40,13 +40,15 @@ const setUserDefaultBillingAddressFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { addressId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.SET_USER_DEFAULT_BILLING_ADDRESS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/addresses/actions/factories/setUserDefaultContactAddressFactory.ts
+++ b/packages/redux/src/users/addresses/actions/factories/setUserDefaultContactAddressFactory.ts
@@ -41,13 +41,15 @@ const setUserDefaultContactAddressFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { addressId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.SET_USER_DEFAULT_CONTACT_ADDRESS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/addresses/actions/factories/setUserDefaultShippingAddressFactory.ts
+++ b/packages/redux/src/users/addresses/actions/factories/setUserDefaultShippingAddressFactory.ts
@@ -40,13 +40,15 @@ const setUserDefaultShippingAddressFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { addressId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.SET_USER_DEFAULT_SHIPPING_ADDRESS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/addresses/actions/factories/updateUserAddressFactory.ts
+++ b/packages/redux/src/users/addresses/actions/factories/updateUserAddressFactory.ts
@@ -44,13 +44,15 @@ const updateUserAddressFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { addressId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_USER_ADDRESS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/attributes/actions/factories/createUserAttributesFactory.ts
+++ b/packages/redux/src/users/attributes/actions/factories/createUserAttributesFactory.ts
@@ -32,12 +32,14 @@ const createUserAttributesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_USER_ATTRIBUTES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/attributes/actions/factories/fetchUserAttributeFactory.ts
+++ b/packages/redux/src/users/attributes/actions/factories/fetchUserAttributeFactory.ts
@@ -32,12 +32,14 @@ const fetchUserAttributeFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_ATTRIBUTE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/attributes/actions/factories/fetchUserAttributesFactory.ts
+++ b/packages/redux/src/users/attributes/actions/factories/fetchUserAttributesFactory.ts
@@ -33,12 +33,14 @@ const fetchUserAttributesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_ATTRIBUTES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/attributes/actions/factories/removeUserAttributeFactory.ts
+++ b/packages/redux/src/users/attributes/actions/factories/removeUserAttributeFactory.ts
@@ -31,12 +31,14 @@ const removeUserAttributeFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_USER_ATTRIBUTE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/attributes/actions/factories/setUserAttributeFactory.ts
+++ b/packages/redux/src/users/attributes/actions/factories/setUserAttributeFactory.ts
@@ -37,12 +37,14 @@ const setUserAttributeFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.SET_USER_ATTRIBUTE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/attributes/actions/factories/updateUserAttributeFactory.ts
+++ b/packages/redux/src/users/attributes/actions/factories/updateUserAttributeFactory.ts
@@ -42,12 +42,14 @@ const updateUserAttributeFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_USER_ATTRIBUTE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/changePasswordFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/changePasswordFactory.ts
@@ -30,12 +30,14 @@ const changePasswordFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.PASSWORD_CHANGE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/createClientCredentialsTokenFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/createClientCredentialsTokenFactory.ts
@@ -29,12 +29,14 @@ const createClientCredentialsTokenFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_CLIENT_CREDENTIALS_TOKEN_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/createGuestUserFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/createGuestUserFactory.ts
@@ -36,12 +36,14 @@ const createGuestUserFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_GUEST_USER_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/createPhoneNumberValidationsFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/createPhoneNumberValidationsFactory.ts
@@ -32,12 +32,14 @@ const createPhoneNumberValidationsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_PHONE_NUMBER_VALIDATIONS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/createPhoneTokenValidationsFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/createPhoneTokenValidationsFactory.ts
@@ -32,12 +32,14 @@ const createPhoneTokenValidationsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_PHONE_TOKEN_VALIDATIONS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/createPhoneTokensFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/createPhoneTokensFactory.ts
@@ -32,12 +32,14 @@ const createPhoneTokensFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_PHONE_TOKEN_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/createUserTokenFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/createUserTokenFactory.ts
@@ -34,12 +34,14 @@ const createUserTokenFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_USER_TOKEN_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/fetchGuestUserFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/fetchGuestUserFactory.ts
@@ -36,12 +36,14 @@ const fetchGuestUserFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_GUEST_USER_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/fetchUserFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/fetchUserFactory.ts
@@ -33,12 +33,14 @@ const fetchUserFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/loginFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/loginFactory.ts
@@ -43,12 +43,14 @@ const loginFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.LOGIN_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/logoutFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/logoutFactory.ts
@@ -25,12 +25,14 @@ const logoutFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.LOGOUT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/recoverPasswordFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/recoverPasswordFactory.ts
@@ -30,12 +30,14 @@ const recoverPasswordFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.PASSWORD_RECOVER_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/refreshEmailTokenFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/refreshEmailTokenFactory.ts
@@ -32,12 +32,14 @@ const refreshEmailTokenFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REFRESH_EMAIL_TOKEN_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/refreshTokenFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/refreshTokenFactory.ts
@@ -29,12 +29,14 @@ const refreshTokenFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REFRESH_USER_TOKEN_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/registerFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/registerFactory.ts
@@ -46,12 +46,14 @@ const registerFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REGISTER_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/removeUserTokenFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/removeUserTokenFactory.ts
@@ -30,12 +30,14 @@ const removeUserTokenFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.DELETE_USER_TOKEN_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/resetPasswordFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/resetPasswordFactory.ts
@@ -30,12 +30,14 @@ const resetPasswordFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.PASSWORD_RESET_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/setUserFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/setUserFactory.ts
@@ -38,12 +38,14 @@ const setUserFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_USER_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/authentication/actions/factories/validateEmailFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/validateEmailFactory.ts
@@ -30,12 +30,14 @@ const validateEmailFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.VALIDATE_EMAIL_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/benefits/actions/factories/fetchUserBenefitsFactory.ts
+++ b/packages/redux/src/users/benefits/actions/factories/fetchUserBenefitsFactory.ts
@@ -35,12 +35,14 @@ const fetchUserBenefitsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_BENEFITS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/contacts/actions/factories/createUserContactFactory.ts
+++ b/packages/redux/src/users/contacts/actions/factories/createUserContactFactory.ts
@@ -34,12 +34,14 @@ const createUserContactFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_USER_CONTACT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/contacts/actions/factories/fetchUserContactFactory.ts
+++ b/packages/redux/src/users/contacts/actions/factories/fetchUserContactFactory.ts
@@ -33,12 +33,14 @@ const fetchUserContactFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_CONTACT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/contacts/actions/factories/fetchUserContactsFactory.ts
+++ b/packages/redux/src/users/contacts/actions/factories/fetchUserContactsFactory.ts
@@ -33,12 +33,14 @@ const fetchUserContactsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_CONTACTS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/contacts/actions/factories/removeUserContactFactory.ts
+++ b/packages/redux/src/users/contacts/actions/factories/removeUserContactFactory.ts
@@ -30,12 +30,14 @@ const removeUserContactFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_USER_CONTACT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/contacts/actions/factories/updateUserContactFactory.ts
+++ b/packages/redux/src/users/contacts/actions/factories/updateUserContactFactory.ts
@@ -37,12 +37,14 @@ const updateUserContactFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_USER_CONTACT_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/credits/actions/factories/fetchUserCreditMovementsFactory.ts
+++ b/packages/redux/src/users/credits/actions/factories/fetchUserCreditMovementsFactory.ts
@@ -33,12 +33,14 @@ const fetchUserCreditMovementsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_CREDIT_MOVEMENTS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/credits/actions/factories/fetchUserCreditsFactory.ts
+++ b/packages/redux/src/users/credits/actions/factories/fetchUserCreditsFactory.ts
@@ -40,12 +40,14 @@ const fetchUserCreditsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_CREDITS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/personalIds/__tests__/reducer.test.ts
+++ b/packages/redux/src/users/personalIds/__tests__/reducer.test.ts
@@ -218,7 +218,7 @@ describe('personalIds reducers', () => {
     it('should handle other actions by returning the previous state', () => {
       const state = {
         ...initialState,
-        error: { code: 123, name: 'error', message: 'error' },
+        error: { code: '123', name: 'error', message: 'error' },
       };
 
       const randomActionWithError = {

--- a/packages/redux/src/users/personalIds/actions/factories/createUserPersonalIdFactory.ts
+++ b/packages/redux/src/users/personalIds/actions/factories/createUserPersonalIdFactory.ts
@@ -36,12 +36,14 @@ const createUserPersonalIdsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_USER_PERSONAL_ID_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/personalIds/actions/factories/createUserPersonalIdImageFactory.ts
+++ b/packages/redux/src/users/personalIds/actions/factories/createUserPersonalIdImageFactory.ts
@@ -33,12 +33,14 @@ const createUserPersonalIdImageFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.CREATE_USER_PERSONAL_ID_IMAGE_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/personalIds/actions/factories/fetchUserDefaultPersonalIdFactory.ts
+++ b/packages/redux/src/users/personalIds/actions/factories/fetchUserDefaultPersonalIdFactory.ts
@@ -32,12 +32,14 @@ const fetchUserDefaultPersonalIdFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_DEFAULT_PERSONAL_ID_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/personalIds/actions/factories/fetchUserPersonalIdFactory.ts
+++ b/packages/redux/src/users/personalIds/actions/factories/fetchUserPersonalIdFactory.ts
@@ -32,12 +32,14 @@ const fetchUserPersonalIdFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_PERSONAL_ID_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/personalIds/actions/factories/fetchUserPersonalIdsFactory.ts
+++ b/packages/redux/src/users/personalIds/actions/factories/fetchUserPersonalIdsFactory.ts
@@ -32,12 +32,14 @@ const fetchUserPersonalIdsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_PERSONAL_IDS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/personalIds/actions/factories/removeUserPersonalIdFactory.ts
+++ b/packages/redux/src/users/personalIds/actions/factories/removeUserPersonalIdFactory.ts
@@ -31,12 +31,14 @@ const removeUserPersonalIdFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_USER_PERSONAL_ID_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/personalIds/actions/factories/setUserDefaultPersonalIdFactory.ts
+++ b/packages/redux/src/users/personalIds/actions/factories/setUserDefaultPersonalIdFactory.ts
@@ -32,12 +32,14 @@ const setUserDefaultPersonalIdFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.SET_USER_DEFAULT_PERSONAL_ID_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/personalIds/actions/factories/updateUserPersonalIdFactory.ts
+++ b/packages/redux/src/users/personalIds/actions/factories/updateUserPersonalIdFactory.ts
@@ -43,12 +43,14 @@ const updateUserPersonalIdFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_USER_PERSONAL_ID_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/preferences/actions/factories/fetchUserPreferencesFactory.ts
+++ b/packages/redux/src/users/preferences/actions/factories/fetchUserPreferencesFactory.ts
@@ -33,12 +33,14 @@ const fetchUserPreferencesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_PREFERENCES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/preferences/actions/factories/setUserPreferencesFactory.ts
+++ b/packages/redux/src/users/preferences/actions/factories/setUserPreferencesFactory.ts
@@ -34,12 +34,14 @@ const setUserPreferencesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_USER_PREFERENCES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/users/titles/actions/factories/fetchUserTitlesFactory.ts
+++ b/packages/redux/src/users/titles/actions/factories/fetchUserTitlesFactory.ts
@@ -35,12 +35,14 @@ const fetchUserTitlesFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_USER_TITLES_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/wishlists/actions/__tests__/removeWishlistItem.test.ts
+++ b/packages/redux/src/wishlists/actions/__tests__/removeWishlistItem.test.ts
@@ -62,7 +62,7 @@ describe('removeWishlistItem() action creator', () => {
           payload: {
             error: expect.objectContaining({
               message: 'No wishlist id is set',
-              code: -1,
+              code: '-1',
             }),
           },
         }),

--- a/packages/redux/src/wishlists/actions/__tests__/updateWishlistItem.test.ts
+++ b/packages/redux/src/wishlists/actions/__tests__/updateWishlistItem.test.ts
@@ -63,7 +63,7 @@ describe('updateWishlistItem()', () => {
           payload: {
             error: expect.objectContaining({
               message: 'No wishlist id is set',
-              code: -1,
+              code: '-1',
             }),
           },
         }),

--- a/packages/redux/src/wishlists/actions/factories/addWishlistItemFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/addWishlistItemFactory.ts
@@ -70,13 +70,15 @@ const addWishlistItemFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { ...metadata, productId: data.productId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.ADD_WISHLIST_ITEM_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/wishlists/actions/factories/addWishlistSetFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/addWishlistSetFactory.ts
@@ -50,12 +50,14 @@ const addWishlistSetFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.ADD_WISHLIST_SET_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/wishlists/actions/factories/fetchWishlistFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/fetchWishlistFactory.ts
@@ -51,12 +51,14 @@ const fetchWishlistFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_WISHLIST_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/wishlists/actions/factories/fetchWishlistSetFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/fetchWishlistSetFactory.ts
@@ -54,13 +54,15 @@ const fetchWishlistSetFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { wishlistSetId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_WISHLIST_SET_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/wishlists/actions/factories/fetchWishlistSetsFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/fetchWishlistSetsFactory.ts
@@ -48,12 +48,14 @@ const fetchWishlistSetsFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.FETCH_WISHLIST_SETS_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/wishlists/actions/factories/removeWishlistItemFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/removeWishlistItemFactory.ts
@@ -87,17 +87,19 @@ const removeWishlistItemFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: {
           ...metadata,
           productId: wishlistItem?.product?.id,
           wishlistItemId,
         },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_WISHLIST_ITEM_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/wishlists/actions/factories/removeWishlistSetFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/removeWishlistSetFactory.ts
@@ -47,13 +47,15 @@ const removeWishlistSetFactory =
 
       return;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { wishlistSetId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.REMOVE_WISHLIST_SET_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/wishlists/actions/factories/updateWishlistItemFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/updateWishlistItemFactory.ts
@@ -90,17 +90,19 @@ const updateWishlistItemFactory =
 
       return result;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: {
           ...metadata,
           productId: wishlistItem?.product?.id,
           wishlistItemId,
         },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_WISHLIST_ITEM_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/packages/redux/src/wishlists/actions/factories/updateWishlistSetFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/updateWishlistSetFactory.ts
@@ -70,13 +70,15 @@ const updateWishlistSetFactory =
 
       return updatedResult;
     } catch (error) {
+      const errorAsBlackoutError = toBlackoutError(error);
+
       dispatch({
         meta: { wishlistSetId },
-        payload: { error: toBlackoutError(error) },
+        payload: { error: errorAsBlackoutError },
         type: actionTypes.UPDATE_WISHLIST_SET_FAILURE,
       });
 
-      throw error;
+      throw errorAsBlackoutError;
     }
   };
 

--- a/tests/__fixtures__/settings/configurations.fixtures.ts
+++ b/tests/__fixtures__/settings/configurations.fixtures.ts
@@ -119,7 +119,7 @@ export const mockConfigurationsErrorState = {
       error: {
         message: 'An awesome, fascinating and incredible error',
         name: 'Error name',
-        code: 501,
+        code: '501',
       },
       isLoading: false,
       configuration: {
@@ -144,7 +144,7 @@ export const mockConfigurationErrorState = {
           [mockConfigurationCode]: {
             message: 'An awesome, fascinating and incredible error',
             name: 'Error name',
-            code: 501,
+            code: '501',
           },
         },
         isLoading: {

--- a/tests/__fixtures__/users/authentication.fixtures.ts
+++ b/tests/__fixtures__/users/authentication.fixtures.ts
@@ -22,11 +22,7 @@ export const mockCreateUserTokenData = {
     'd5b4f8e72f652d9e048d7e5c75f1ec97bb9eeaec2b080497eba0965abc0ade4d',
 };
 
-export const mockErrorObject = {
-  errorMessage: 'post user token error',
-  errorCode: 0,
-  status: 400,
-};
+export const mockErrorObject = new Error('post user token error');
 
 export const mockUserTokenResponse = {
   accessToken: '04b55bb7-f1af-4b45-aa10-5c4667a48936',

--- a/tests/__fixtures__/wishlists/wishlists.fixtures.ts
+++ b/tests/__fixtures__/wishlists/wishlists.fixtures.ts
@@ -84,7 +84,7 @@ export const mockWishlistState: StoreState = {
       item: {
         error: {
           [mockWishlistItemId]: {
-            code: -1,
+            code: '-1',
             status: 400,
             name: 'error',
             message: 'error message',
@@ -108,7 +108,7 @@ export const mockWishlistState: StoreState = {
       set: {
         error: {
           [mockWishlistSetId]: {
-            code: -1,
+            code: '-1',
             status: 400,
             name: 'error',
             message: 'error message',


### PR DESCRIPTION
## Description

- This changes error handling code in all redux actions that were not making sure that the error that was thrown respected the BlackoutError type.
- Changed type of `code` property in BlackoutError type to string instead of number as that field is defined as a string in backend services.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
