### PR TITLE
feat(core): add bag operations endpoints

### DIFF
--- a/packages/core/src/bags/client/__fixtures__/getBagOperation.fixtures.js
+++ b/packages/core/src/bags/client/__fixtures__/getBagOperation.fixtures.js
@@ -1,0 +1,35 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: params => {
+    moxios.stubRequest(
+      join(
+        '/api/commerce/v1/bags',
+        params.bagId,
+        'operations',
+        params.bagOperationId,
+      ),
+      {
+        method: 'get',
+        response: params.response,
+        status: 200,
+      },
+    );
+  },
+  failure: params => {
+    moxios.stubRequest(
+      join(
+        '/api/commerce/v1/bags',
+        params.bagId,
+        'operations',
+        params.bagOperationId,
+      ),
+      {
+        method: 'get',
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/core/src/bags/client/__fixtures__/getBagOperations.fixtures.js
+++ b/packages/core/src/bags/client/__fixtures__/getBagOperations.fixtures.js
@@ -1,0 +1,29 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: params => {
+    moxios.stubRequest(
+      join('/api/commerce/v1/bags', params.bagId, 'operations', {
+        query: params.query,
+      }),
+      {
+        method: 'get',
+        response: params.response,
+        status: 200,
+      },
+    );
+  },
+  failure: params => {
+    moxios.stubRequest(
+      join('/api/commerce/v1/bags', params.bagId, 'operations', {
+        query: params.query,
+      }),
+      {
+        method: 'get',
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/core/src/bags/client/__tests__/__snapshots__/getBagOperation.test.js.snap
+++ b/packages/core/src/bags/client/__tests__/__snapshots__/getBagOperation.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getBagOperation should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/bags/client/__tests__/__snapshots__/getBagOperations.test.js.snap
+++ b/packages/core/src/bags/client/__tests__/__snapshots__/getBagOperations.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getBagOperations should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/bags/client/__tests__/getBagOperation.test.js
+++ b/packages/core/src/bags/client/__tests__/getBagOperation.test.js
@@ -1,0 +1,53 @@
+import { getBagOperation } from '..';
+import {
+  mockBagId,
+  mockBagOperation,
+  mockBagOperationId,
+} from 'tests/__fixtures__/bags';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/getBagOperation.fixtures';
+import moxios from 'moxios';
+
+describe('getBagOperation', () => {
+  const expectedConfig = undefined;
+  const spy = jest.spyOn(client, 'get');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = mockBagOperation;
+
+    fixtures.success({
+      bagId: mockBagId,
+      bagOperationId: mockBagOperationId,
+      response,
+    });
+
+    await expect(getBagOperation(mockBagId, mockBagOperationId)).resolves.toBe(
+      response,
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/bags/${mockBagId}/operations/${mockBagOperationId}`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure({ bagId: mockBagId, bagOperationId: mockBagOperationId });
+
+    await expect(
+      getBagOperation(mockBagId, mockBagOperationId),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/bags/${mockBagId}/operations/${mockBagOperationId}`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/bags/client/__tests__/getBagOperations.test.js
+++ b/packages/core/src/bags/client/__tests__/getBagOperations.test.js
@@ -1,0 +1,49 @@
+import { getBagOperations } from '..';
+import { mockBagId, mockBagOperations } from 'tests/__fixtures__/bags';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/getBagOperations.fixtures';
+import moxios from 'moxios';
+
+describe('getBagOperations', () => {
+  const expectedConfig = undefined;
+  const spy = jest.spyOn(client, 'get');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = mockBagOperations;
+
+    fixtures.success({
+      bagId: mockBagId,
+      query: { sort: 'createdDate:desc' },
+      response,
+    });
+
+    await expect(
+      getBagOperations(mockBagId, { sort: 'createdDate:desc' }),
+    ).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/bags/${mockBagId}/operations?sort=createdDate%3Adesc`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure({ bagId: mockBagId, query: { sort: 'createdDate:desc' } });
+
+    await expect(
+      getBagOperations(mockBagId, { sort: 'createdDate:desc' }),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/bags/${mockBagId}/operations?sort=createdDate%3Adesc`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/bags/client/getBagOperation.js
+++ b/packages/core/src/bags/client/getBagOperation.js
@@ -1,0 +1,24 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * Method responsible for retrieving an operation performed on the bag.
+ *
+ * @function getBagOperation
+ * @memberof module:bags/client
+ *
+ * @param {string} id - Universal identifier of the bag.
+ * @param {string} bagOperationId - Universal identifier of the bag operation.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Promise} Promise that will be resolved when the call to the
+ * endpoint finishes.
+ */
+export default (id, bagOperationId, config) =>
+  client
+    .get(join('/commerce/v1/bags', id, 'operations', bagOperationId), config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/bags/client/getBagOperations.js
+++ b/packages/core/src/bags/client/getBagOperations.js
@@ -1,0 +1,36 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * @typedef {object} GetBagOperationsQuery
+ *
+ * @property {number} page - Specify the number of the page to get, starting at 1. The default is 1.
+ * @property {number} pageSize - Specify the size of each page, as a number between 1 and 180. The default is 60.
+ * @property {Array<string>} sort - Sort the contents, as follows:
+ *                                  "createdDate:desc" - Sort by the creation date, starting by the most recent.
+ *                                  "createdDate:asc" - Sort by the creation date, starting by the oldest.
+ * @property {string} createdDate - Filter by the creation date, in RFC 3339 format, using ge and le operators separated by commas (,).
+ *                                  (e.g: "createdDate=ge:2019-01-20T10:01:55.883Z,le:2019-01-22T10:01:55.883Z").
+ */
+
+/**
+ * Method responsible for retrieving operations carried out on the bag.
+ *
+ * @function getBagOperations
+ * @memberof module:bags/client
+ *
+ * @param {string} id - Universal identifier of the bag.
+ * @param {GetBagOperationsQuery} query - Query parameters to apply.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Promise} Promise that will be resolved when the call to the
+ * endpoint finishes.
+ */
+export default (id, query, config) =>
+  client
+    .get(join('/commerce/v1/bags', id, 'operations', { query }), config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/bags/client/index.js
+++ b/packages/core/src/bags/client/index.js
@@ -14,6 +14,8 @@ warnDeprecatedMethod(
 );
 
 export { default as getBag } from './getBag';
+export { default as getBagOperation } from './getBagOperation';
+export { default as getBagOperations } from './getBagOperations';
 export { default as deleteBagItem } from './deleteBagItem';
 export { default as patchBagItem } from './patchBagItem';
 export { default as postBagItem } from './postBagItem';

--- a/packages/core/src/bags/redux/__tests__/selectors.test.js
+++ b/packages/core/src/bags/redux/__tests__/selectors.test.js
@@ -6,6 +6,10 @@ import {
   mockBagId,
   mockBagItemEntity,
   mockBagItemId,
+  mockBagOperation,
+  mockBagOperationId,
+  mockErrorState,
+  mockLoadingState,
   mockState,
 } from 'tests/__fixtures__/bags';
 import {
@@ -244,7 +248,7 @@ describe('bags redux selectors', () => {
   });
 
   describe('getBagItemAvailableSizes()', () => {
-    it('should return an mepty list if there are no sizes', () => {
+    it('should return an empty list if there are no sizes', () => {
       const productsWithoutSizes = {
         ...mockProduct,
         sizes: null,
@@ -468,6 +472,57 @@ describe('bags redux selectors', () => {
           size: 1,
         }),
       ).toBe(0);
+    });
+  });
+
+  describe('getBagOperations()', () => {
+    it('should return the latest bag operations content from state', () => {
+      const expectedResult = [
+        mockState.entities.bagOperations[101],
+        mockState.entities.bagOperations[mockBagOperationId],
+      ];
+
+      expect(selectors.getBagOperations(mockState)).toEqual(expectedResult);
+    });
+  });
+
+  describe('getBagOperation()', () => {
+    it('should return all data regarding a bag operation', () => {
+      const expectedResult = mockBagOperation;
+      const spy = jest.spyOn(fromEntities, 'getEntity');
+
+      expect(selectors.getBagOperation(mockState, mockBagOperationId)).toEqual(
+        expectedResult,
+      );
+      expect(spy).toHaveBeenCalledWith(
+        mockState,
+        'bagOperations',
+        mockBagOperationId,
+      );
+    });
+  });
+
+  describe('isBagOperationLoading()', () => {
+    it('should get the bag operation loading status', () => {
+      const spy = jest.spyOn(fromBag, 'getIsBagOperationLoading');
+
+      expect(
+        selectors.isBagOperationLoading(mockLoadingState, mockBagOperationId),
+      ).toEqual(true);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getBagOperationError()', () => {
+    it('should get the bag operation error', () => {
+      const expectedResult =
+        mockErrorState.bag.bagOperations.error[mockBagOperationId];
+      const spy = jest.spyOn(fromBag, 'getBagOperationError');
+
+      expect(
+        selectors.getBagOperationError(mockErrorState, mockBagOperationId),
+      ).toBe(expectedResult);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/core/src/bags/redux/actionTypes.js
+++ b/packages/core/src/bags/redux/actionTypes.js
@@ -45,3 +45,17 @@ export const UPDATE_BAG_ITEM_REQUEST =
 /** Action type dispatched when the update bag request succeeds. */
 export const UPDATE_BAG_ITEM_SUCCESS =
   '@farfetch/blackout-core/UPDATE_BAG_ITEM_SUCCESS';
+
+/** Action type dispatched when the get bag operation request fails. */
+export const GET_BAG_OPERATION_FAILURE =
+  '@farfetch/blackout-core/GET_BAG_OPERATION_FAILURE';
+/** Action type dispatched when the get bag operation request starts. */
+export const GET_BAG_OPERATION_REQUEST =
+  '@farfetch/blackout-core/GET_BAG_OPERATION_REQUEST';
+/** Action type dispatched when the get bag operation request succeeds. */
+export const GET_BAG_OPERATION_SUCCESS =
+  '@farfetch/blackout-core/GET_BAG_OPERATION_SUCCESS';
+
+/** Action type dispatched when the reset bag operations entities occurs. */
+export const RESET_BAG_OPERATIONS =
+  '@farfetch/blackout-core/RESET_BAG_OPERATIONS ';

--- a/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doAddBagItem.test.js.snap
+++ b/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doAddBagItem.test.js.snap
@@ -28,6 +28,11 @@ Object {
       },
       "bagItems": Object {
         "134": Object {
+          "@controls": Object {
+            "BagGet_operation": Object {
+              "href": "/v1/bags/7894746/operations/134",
+            },
+          },
           "attributes": Array [
             Object {
               "type": "1",
@@ -151,6 +156,11 @@ Object {
       },
       "bagItems": Object {
         "134": Object {
+          "@controls": Object {
+            "BagGet_operation": Object {
+              "href": "/v1/bags/7894746/operations/134",
+            },
+          },
           "attributes": Array [
             Object {
               "type": "1",

--- a/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doDeleteBagItem.test.js.snap
+++ b/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doDeleteBagItem.test.js.snap
@@ -20,6 +20,11 @@ Object {
       },
       "bagItems": Object {
         "134": Object {
+          "@controls": Object {
+            "BagGet_operation": Object {
+              "href": "/v1/bags/7894746/operations/134",
+            },
+          },
           "attributes": Array [
             Object {
               "type": "1",

--- a/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doGetBag.test.js.snap
+++ b/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doGetBag.test.js.snap
@@ -14,6 +14,11 @@ Object {
       },
       "bagItems": Object {
         "134": Object {
+          "@controls": Object {
+            "BagGet_operation": Object {
+              "href": "/v1/bags/7894746/operations/134",
+            },
+          },
           "attributes": Array [
             Object {
               "type": "1",
@@ -123,6 +128,11 @@ Object {
       },
       "bagItems": Object {
         "134": Object {
+          "@controls": Object {
+            "BagGet_operation": Object {
+              "href": "/v1/bags/7894746/operations/134",
+            },
+          },
           "attributes": Array [
             Object {
               "type": "1",

--- a/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doGetBagOperation.test.js.snap
+++ b/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doGetBagOperation.test.js.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doGetBagOperation() should create the correct actions for when the get bagOperation procedure is successful: get bagOperation success payload 1`] = `
+Object {
+  "payload": Object {
+    "bagOperationId": "134",
+    "entities": Object {
+      "bagOperations": Object {
+        "134": Object {
+          "changes": Array [
+            Object {
+              "changeType": "ItemIsUnavailable",
+              "currency": "string",
+              "itemId": 0,
+              "newPrice": Object {
+                "priceInclTaxes": 0,
+              },
+              "newValue": "string",
+              "oldPrice": Object {
+                "priceInclTaxes": 0,
+              },
+              "oldValue": "string",
+              "productId": 0,
+              "reason": "LackOfBenefits",
+              "variantId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            },
+          ],
+          "createdDate": "2023-01-19T15:46:00.223Z",
+          "id": "134",
+          "violations": Array [
+            Object {
+              "fixSuggestion": Object {
+                "action": "DecreaseQuantity",
+                "value": "string",
+              },
+              "itemsIds": Array [
+                0,
+              ],
+            },
+          ],
+        },
+      },
+    },
+    "result": "134",
+  },
+  "type": "@farfetch/blackout-core/GET_BAG_OPERATION_SUCCESS",
+}
+`;

--- a/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doUpdateBagItem.test.js.snap
+++ b/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doUpdateBagItem.test.js.snap
@@ -30,6 +30,11 @@ Object {
       },
       "bagItems": Object {
         "134": Object {
+          "@controls": Object {
+            "BagGet_operation": Object {
+              "href": "/v1/bags/7894746/operations/134",
+            },
+          },
           "attributes": Array [
             Object {
               "type": "1",
@@ -155,6 +160,11 @@ Object {
       },
       "bagItems": Object {
         "134": Object {
+          "@controls": Object {
+            "BagGet_operation": Object {
+              "href": "/v1/bags/7894746/operations/134",
+            },
+          },
           "attributes": Array [
             Object {
               "type": "1",

--- a/packages/core/src/bags/redux/actions/__tests__/doGetBagOperation.test.js
+++ b/packages/core/src/bags/redux/actions/__tests__/doGetBagOperation.test.js
@@ -1,0 +1,93 @@
+import { doGetBagOperation } from '../';
+import {
+  mockBagId,
+  mockBagOperation,
+  mockBagOperationId,
+  mockBagOperationsNormalizedPayload,
+} from 'tests/__fixtures__/bags';
+import { mockStore } from '../../../../../tests';
+import find from 'lodash/find';
+import reducer, { actionTypes } from '../../';
+
+const bagOperationMockStore = (state = {}) =>
+  mockStore({ bagOperations: reducer() }, state);
+
+describe('doGetBagOperation()', () => {
+  let store;
+  const normalizeSpy = jest.spyOn(require('normalizr'), 'normalize');
+  const getBagOperation = jest.fn();
+  const action = doGetBagOperation(getBagOperation);
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    store = bagOperationMockStore({
+      bagOperations: { id: mockBagOperationId },
+    });
+  });
+
+  it('should create the correct actions for when the get bagOperation procedure fails', async () => {
+    const expectedError = new Error('get bagOperation error');
+
+    getBagOperation.mockRejectedValueOnce(expectedError);
+
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(mockBagId, mockBagOperationId));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(getBagOperation).toHaveBeenCalledTimes(1);
+      expect(getBagOperation).toHaveBeenCalledWith(
+        mockBagId,
+        mockBagOperationId,
+        expectedConfig,
+      );
+
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          {
+            type: actionTypes.GET_BAG_OPERATION_REQUEST,
+            payload: { bagOperationId: mockBagOperationId },
+          },
+          {
+            type: actionTypes.GET_BAG_OPERATION_FAILURE,
+            payload: {
+              error: expectedError,
+              bagOperationId: mockBagOperationId,
+            },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the get bagOperation procedure is successful', async () => {
+    getBagOperation.mockResolvedValueOnce(mockBagOperation);
+    await store.dispatch(action(mockBagId, mockBagOperationId));
+
+    const actionResults = store.getActions();
+
+    expect(normalizeSpy).toHaveBeenCalledTimes(1);
+    expect(getBagOperation).toHaveBeenCalledTimes(1);
+    expect(getBagOperation).toHaveBeenCalledWith(
+      mockBagId,
+      mockBagOperationId,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      {
+        type: actionTypes.GET_BAG_OPERATION_REQUEST,
+        payload: { bagOperationId: mockBagOperationId },
+      },
+      {
+        payload: mockBagOperationsNormalizedPayload,
+        type: actionTypes.GET_BAG_OPERATION_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, { type: actionTypes.GET_BAG_OPERATION_SUCCESS }),
+    ).toMatchSnapshot('get bagOperation success payload');
+  });
+});

--- a/packages/core/src/bags/redux/actions/__tests__/reset.test.js
+++ b/packages/core/src/bags/redux/actions/__tests__/reset.test.js
@@ -1,6 +1,6 @@
 import { actionTypes } from '../..';
 import { mockStore } from '../../../../../tests';
-import { reset } from '../';
+import { reset, resetBagOperationsEntities } from '../';
 
 describe('reset() action creator', () => {
   let store;
@@ -21,6 +21,17 @@ describe('reset() action creator', () => {
       },
       {
         type: actionTypes.RESET_BAG_ENTITIES,
+      },
+    ]);
+  });
+
+  it('should dispatch the correct action to reset bag operations entities', () => {
+    store.dispatch(resetBagOperationsEntities());
+    const actionResults = store.getActions();
+
+    expect(actionResults).toMatchObject([
+      {
+        type: actionTypes.RESET_BAG_OPERATIONS,
       },
     ]);
   });

--- a/packages/core/src/bags/redux/actions/doGetBagOperation.js
+++ b/packages/core/src/bags/redux/actions/doGetBagOperation.js
@@ -1,0 +1,52 @@
+import {
+  GET_BAG_OPERATION_FAILURE,
+  GET_BAG_OPERATION_REQUEST,
+  GET_BAG_OPERATION_SUCCESS,
+} from '../actionTypes';
+import { normalize } from 'normalizr';
+import bagOperationSchema from '../../../entities/schemas/bagOperation';
+
+/**
+ * @callback GetBagOperationThunkFactory
+ * @param {number} bagId - Bag id.
+ * @param {string} bagOperationId - Bag operation id.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Load bag operation with given id.
+ *
+ * @function doGetBagOperation
+ * @memberof module:bags/actions
+ *
+ * @param {Function} getBagOperation - Get bag operation client.
+ *
+ * @returns {GetBagOperationThunkFactory} Thunk factory.
+ */
+export default getBagOperation =>
+  (bagId, bagOperationId, config) =>
+  async dispatch => {
+    dispatch({
+      type: GET_BAG_OPERATION_REQUEST,
+      payload: { bagOperationId },
+    });
+
+    try {
+      const result = await getBagOperation(bagId, bagOperationId, config);
+
+      dispatch({
+        payload: { ...normalize(result, bagOperationSchema), bagOperationId },
+        type: GET_BAG_OPERATION_SUCCESS,
+      });
+    } catch (error) {
+      dispatch({
+        payload: { error, bagOperationId },
+        type: GET_BAG_OPERATION_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/core/src/bags/redux/actions/index.js
+++ b/packages/core/src/bags/redux/actions/index.js
@@ -9,6 +9,7 @@
 export { default as doAddBagItem } from './doAddBagItem';
 export { default as doDeleteBagItem } from './doDeleteBagItem';
 export { default as doGetBag } from './doGetBag';
+export { default as doGetBagOperation } from './doGetBagOperation';
 export { default as doUpdateBagItem } from './doUpdateBagItem';
-export { default as reset } from './reset';
+export { default as reset, resetBagOperationsEntities } from './reset';
 export { default as resetState } from './resetState';

--- a/packages/core/src/bags/redux/actions/reset.js
+++ b/packages/core/src/bags/redux/actions/reset.js
@@ -1,4 +1,4 @@
-import { RESET_BAG_ENTITIES } from '../actionTypes';
+import { RESET_BAG_ENTITIES, RESET_BAG_OPERATIONS } from '../actionTypes';
 import resetState from './resetState';
 
 /**
@@ -25,6 +25,39 @@ import resetState from './resetState';
 const resetEntities = () => dispatch => {
   dispatch({
     type: RESET_BAG_ENTITIES,
+  });
+};
+
+/**
+ * Reset bag operations entities to its initial value.
+ *
+ * @private
+ * @function
+ * @memberof module:bags/actions
+ *
+ * @example
+ * // Store before executing action
+ * const store = {
+ *     entities: {
+ *         bag: { 123: {...} },
+ *         bagItems: { 1: {...} },
+ *         bagOperations: { 1: {...} }
+ *     }
+ * }
+ *
+ * // Result of reset bag operations entities:
+ * const store = {
+ *     entities: {
+ *         bag: { 123: {...} },
+ *         bagItems: { 1: {...} }
+ *     }
+ * }
+ *
+ * @returns {Function} Dispatch reset bag operations entities action.
+ */
+export const resetBagOperationsEntities = () => dispatch => {
+  dispatch({
+    type: RESET_BAG_OPERATIONS,
   });
 };
 

--- a/packages/core/src/bags/redux/index.js
+++ b/packages/core/src/bags/redux/index.js
@@ -1,5 +1,6 @@
 // @TODO: Remove the whole `redux` folder in version 2.0.0.
 import * as actionTypes from './actionTypes';
+import * as middlewares from './middlewares';
 import { warnDeprecatedMethod } from '../../helpers';
 import reducer, { entitiesMapper } from './reducer';
 
@@ -10,7 +11,8 @@ warnDeprecatedMethod(
 
 export * from './actions';
 export * from './selectors';
+export * from './middlewares';
 
-export { actionTypes, entitiesMapper };
+export { actionTypes, middlewares, entitiesMapper };
 
 export default reducer;

--- a/packages/core/src/bags/redux/middlewares/__tests__/getOperationsOnBagRequestSuccess.test.js
+++ b/packages/core/src/bags/redux/middlewares/__tests__/getOperationsOnBagRequestSuccess.test.js
@@ -1,0 +1,61 @@
+import {
+  ADD_ITEM_TO_BAG_SUCCESS,
+  DELETE_BAG_ITEM_SUCCESS,
+  GET_BAG_SUCCESS,
+  UPDATE_BAG_ITEM_SUCCESS,
+} from '../../actionTypes';
+import {
+  doGetBagOperation,
+  resetBagOperationsEntities,
+  resetState,
+} from '../../actions';
+import { getOperationsOnBagRequestSuccess } from '../';
+import {
+  mockBagId,
+  mockBagOperationId,
+  mockState,
+} from 'tests/__fixtures__/bags';
+import { mockStore } from '../../../../../tests';
+
+const mockGetOperation = jest.fn(() => ({ type: 'foo' }));
+jest.mock('../../actions', () => ({
+  ...jest.requireActual('../../actions'),
+  doGetBagOperation: jest.fn(() => mockGetOperation),
+  resetState: jest.fn(() => ({ type: 'foo' })),
+  resetBagOperationsEntities: jest.fn(() => ({ type: 'foo' })),
+}));
+
+describe('getOperationsOnBagRequestSuccess', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should do nothing if the action is not a bag request', () => {
+    const store = mockStore(null, {}, [getOperationsOnBagRequestSuccess]);
+
+    store.dispatch({ type: 'foo' });
+
+    expect(doGetBagOperation).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ADD_ITEM_TO_BAG_SUCCESS,
+    DELETE_BAG_ITEM_SUCCESS,
+    GET_BAG_SUCCESS,
+    UPDATE_BAG_ITEM_SUCCESS,
+  ])('should intercept %s, reset the state and get operations', actionType => {
+    const store = mockStore(null, mockState, [
+      getOperationsOnBagRequestSuccess,
+    ]);
+
+    store.dispatch({
+      type: actionType,
+    });
+
+    expect(resetState).toHaveBeenCalledWith(['bagOperations']);
+    expect(resetBagOperationsEntities).toHaveBeenCalled();
+    expect(doGetBagOperation).toHaveBeenCalled();
+    expect(mockGetOperation).toHaveBeenCalledWith(
+      mockBagId,
+      mockBagOperationId,
+    );
+  });
+});

--- a/packages/core/src/bags/redux/middlewares/getOperationsOnBagRequestSuccess.js
+++ b/packages/core/src/bags/redux/middlewares/getOperationsOnBagRequestSuccess.js
@@ -1,0 +1,57 @@
+import {
+  ADD_ITEM_TO_BAG_SUCCESS,
+  DELETE_BAG_ITEM_SUCCESS,
+  GET_BAG_SUCCESS,
+  UPDATE_BAG_ITEM_SUCCESS,
+} from '../actionTypes';
+import {
+  doGetBagOperation,
+  resetBagOperationsEntities,
+  resetState,
+} from '../actions';
+import { getBag, getBagId } from '../selectors';
+import { getBagOperation } from '../../client';
+
+const INTERCEPTED_BAG_ACTIONS = [
+  ADD_ITEM_TO_BAG_SUCCESS,
+  GET_BAG_SUCCESS,
+  UPDATE_BAG_ITEM_SUCCESS,
+  DELETE_BAG_ITEM_SUCCESS,
+];
+
+/**
+ * Middleware to clear previous operations and to fetch the operation of the
+ * newly executed bag request, if successful.
+ *
+ * @function getOperationsOnBagRequestSuccess
+ * @memberof module:bags/middlewares
+ *
+ * @param {object} store - Redux store at the moment.
+ *
+ * @returns {Function} Redux middleware.
+ */
+export default store => next => action => {
+  if (!INTERCEPTED_BAG_ACTIONS.includes(action.type)) {
+    return next(action);
+  }
+
+  const bagId = getBagId(store.getState());
+  const controls = getBag(store.getState())?.['@controls'];
+
+  if (controls) {
+    store.dispatch(resetState(['bagOperations']));
+    store.dispatch(resetBagOperationsEntities());
+
+    const getOperation = doGetBagOperation(getBagOperation);
+
+    Object.values(controls).forEach(({ href }) => {
+      const operationId = href?.split('/')?.pop();
+
+      if (operationId) {
+        store.dispatch(getOperation(bagId, operationId));
+      }
+    });
+  }
+
+  return next(action);
+};

--- a/packages/core/src/bags/redux/middlewares/index.js
+++ b/packages/core/src/bags/redux/middlewares/index.js
@@ -1,0 +1,8 @@
+/**
+ * Bag middlewares.
+ *
+ * @module bag/middlewares
+ * @category Bag
+ * @subcategory Middlewares
+ */
+export { default as getOperationsOnBagRequestSuccess } from './getOperationsOnBagRequestSuccess';

--- a/packages/core/src/bags/redux/reducer.js
+++ b/packages/core/src/bags/redux/reducer.js
@@ -15,6 +15,10 @@ const INITIAL_STATE = {
     error: {},
     isLoading: {},
   },
+  bagOperations: {
+    error: {},
+    isLoading: {},
+  },
 };
 
 const error = (
@@ -29,6 +33,7 @@ const error = (
     case actionTypes.DELETE_BAG_ITEM_REQUEST:
     case actionTypes.GET_BAG_REQUEST:
     case actionTypes.UPDATE_BAG_ITEM_REQUEST:
+    case actionTypes.GET_BAG_OPERATION_REQUEST:
       return INITIAL_STATE.error;
     default:
       return state;
@@ -108,6 +113,46 @@ const bagItems = (
   }
 };
 
+const bagOperations = (
+  state = INITIAL_STATE.bagOperations,
+  /* istanbul ignore next */ action = {},
+) => {
+  switch (action.type) {
+    case actionTypes.GET_BAG_OPERATION_REQUEST:
+      return {
+        isLoading: {
+          ...state.isLoading,
+          [action.payload.bagOperationId]: true,
+        },
+        error: {
+          ...state.error,
+          [action.payload.bagOperationId]: null,
+        },
+      };
+    case actionTypes.GET_BAG_OPERATION_SUCCESS:
+      return {
+        ...state,
+        isLoading: {
+          ...state.isLoading,
+          [action.payload.bagOperationId]: false,
+        },
+      };
+    case actionTypes.GET_BAG_OPERATION_FAILURE:
+      return {
+        isLoading: {
+          ...state.isLoading,
+          [action.payload.bagOperationId]: false,
+        },
+        error: {
+          ...state.error,
+          [action.payload.bagOperationId]: action.payload.error,
+        },
+      };
+    default:
+      return state;
+  }
+};
+
 export const entitiesMapper = {
   [actionTypes.DELETE_BAG_ITEM_SUCCESS]: (
     state,
@@ -122,7 +167,12 @@ export const entitiesMapper = {
     return newState;
   },
   [actionTypes.RESET_BAG_ENTITIES]: state => {
-    const { bag, bagItems, ...rest } = state;
+    const { bag, bagItems, bagOperations, ...rest } = state;
+
+    return rest;
+  },
+  [actionTypes.RESET_BAG_OPERATIONS]: state => {
+    const { bagOperations, ...rest } = state;
 
     return rest;
   },
@@ -133,12 +183,15 @@ export const getId = state => state.id;
 export const getIsLoading = state => state.isLoading;
 export const getIsBagItemLoading = state => state.bagItems.isLoading;
 export const getItemError = state => state.bagItems.error;
+export const getIsBagOperationLoading = state => state.bagOperations.isLoading;
+export const getBagOperationError = state => state.bagOperations.error;
 
 const reducer = combineReducers({
   error,
   id,
   isLoading,
   bagItems,
+  bagOperations,
 });
 
 /**

--- a/packages/core/src/bags/redux/selectors.js
+++ b/packages/core/src/bags/redux/selectors.js
@@ -10,8 +10,10 @@ import {
   getError,
   getId,
   getIsBagItemLoading,
+  getIsBagOperationLoading,
   getIsLoading,
   getItemError,
+  getBagOperationError as getOperationError,
 } from './reducer';
 
 /**
@@ -73,7 +75,7 @@ export const getBag = state => {
 export const getBagError = state => getError(state.bag) || undefined;
 
 /**
- * Retrieves a specific bag item by its id, with all proprerties populated (ie, the product).
+ * Retrieves a specific bag item by its id, with all properties populated (ie, the product).
  *
  * @function
  *
@@ -465,3 +467,82 @@ export const getItemWholeQuantity = (state, bagItem) => {
 
   return quantity || 0;
 };
+
+/**
+ * Retrieves a specific bag operation by its id,.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ * @param {string} bagOperationId - Unique identifier of the operation.
+ *
+ * @returns {object} - Bag operation entity for the given id.
+ *
+ * @example
+ * import { getBagOperation } from '@farfetch/blackout-core/bags/redux';
+ *
+ * const mapStateToProps = (state, { bagOperation: { id } }) => ({
+ *     bagOperation: getBagOperation(state, id)
+ * });
+ */
+export const getBagOperation = (state, bagOperationId) =>
+  getEntity(state, 'bagOperations', bagOperationId);
+
+/**
+ * Retrieves the error state of a specific bag operation by its id.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ * @param {string} bagOperationId - Unique identifier of the bag operation.
+ *
+ * @returns {object | undefined} - Error information, `undefined` if there are no errors.
+ *
+ * @example
+ * import { getBagOperationError } from '@farfetch/blackout-core/bags/redux';
+ *
+ * const mapStateToProps = (state, { bagOperation: { bagOperation: { id } } }) => ({
+ *     error: getBagOperationError(state, id)
+ * });
+ */
+export const getBagOperationError = (state, bagOperationId) =>
+  getOperationError(state.bag)[bagOperationId];
+
+/**
+ * Retrieves latest bag operations from the current user's bag.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {Array|undefined} - List of each bag operation entity from the current user's bag.
+ *
+ * @example
+ * import { getBagOperations } from '@farfetch/blackout-core/bags/redux';
+ *
+ * const mapStateToProps = state => ({
+ *     bagOperations: getBagOperations(state),
+ * });
+ */
+export const getBagOperations = state =>
+  Object.values(getEntity(state, 'bagOperations') || {});
+
+/**
+ * Retrieves the loading status of a specific bag operation by its id.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ * @param {string} bagOperationId - Unique identifier of the bag operation in the bag.
+ *
+ * @returns {boolean} - Whether the given bag operation is loading.
+ *
+ * @example
+ * import { isBagItemLoading } from '@farfetch/blackout-core/bags/redux';
+ *
+ * const mapStateToProps = (state, { bagItem: { id } }) => ({
+ *     isLoading: isBagItemLoading(state, id)
+ * });
+ */
+export const isBagOperationLoading = (state, bagOperationId) =>
+  getIsBagOperationLoading(state.bag)[bagOperationId];

--- a/packages/core/src/bags/redux/utils/bagOperationChangeTypes.js
+++ b/packages/core/src/bags/redux/utils/bagOperationChangeTypes.js
@@ -1,0 +1,15 @@
+export default {
+  ItemIsUnavailable: 'ItemIsUnavailable',
+  ItemOriginChanged: 'ItemOriginChanged',
+  PromoCodeEligibilityChanged: 'PromoCodeEligibilityChanged',
+  ShippingCostChanged: 'ShippingCostChanged',
+  ShippingFlatRateEligibilityChanged: 'ShippingFlatRateEligibilityChanged',
+  ItemPriceChanged: 'ItemPriceChanged',
+  PromotionNotApplied: 'PromotionNotApplied',
+  TotalDiscountChanged: 'TotalDiscountChanged',
+  ItemDiscountChanged: 'ItemDiscountChanged',
+  NotEnoughStock: 'NotEnoughStock',
+  ItemQuantityChanged: 'ItemQuantityChanged',
+  ItemIsNowAvailable: 'ItemIsNowAvailable',
+  ItemMerged: 'ItemMerged',
+};

--- a/packages/core/src/bags/redux/utils/index.js
+++ b/packages/core/src/bags/redux/utils/index.js
@@ -8,3 +8,4 @@
 export { default as createBagItemHash } from './createBagItemHash';
 export { default as buildBagItem } from './buildBagItem';
 export { default as areBagItemsIdentical } from './areBagItemsIdentical';
+export { default as bagOperationChangeTypes } from './bagOperationChangeTypes';

--- a/packages/core/src/entities/redux/__tests__/__snapshots__/reducer.test.js.snap
+++ b/packages/core/src/entities/redux/__tests__/__snapshots__/reducer.test.js.snap
@@ -18,6 +18,7 @@ Object {
   "bag": Object {
     "@farfetch/blackout-core/DELETE_BAG_ITEM_SUCCESS": [Function],
     "@farfetch/blackout-core/RESET_BAG_ENTITIES": [Function],
+    "@farfetch/blackout-core/RESET_BAG_OPERATIONS ": [Function],
   },
   "checkout": Object {
     "@farfetch/blackout-core/COMPLETE_PAYMENT_CHECKOUT_SUCCESS": [Function],

--- a/packages/core/src/entities/schemas/bag.js
+++ b/packages/core/src/entities/schemas/bag.js
@@ -1,9 +1,10 @@
 import { schema } from 'normalizr';
 import bagItem from './bagItem';
+import bagOperation from './bagOperation';
 
 export default new schema.Entity(
   'bag',
-  { items: [bagItem] },
+  { items: [bagItem], bagOperations: [bagOperation] },
   {
     processStrategy: value => {
       // Pass `productImgQueryParam` to `product`

--- a/packages/core/src/entities/schemas/bagOperation.js
+++ b/packages/core/src/entities/schemas/bagOperation.js
@@ -1,0 +1,3 @@
+import { schema } from 'normalizr';
+
+export default new schema.Entity('bagOperations');

--- a/tests/__fixtures__/bags/bag.fixtures.js
+++ b/tests/__fixtures__/bags/bag.fixtures.js
@@ -1,8 +1,5 @@
-import {
-  mockBagEntity,
-  mockBagItemEntity,
-  mockBagItemId,
-} from './bagItem.fixtures';
+import { mockBagItemEntity, mockBagItemId } from './bagItem.fixtures';
+import { mockBagOperation, mockBagOperationId } from './bagOperations.fixtures';
 import {
   mockProduct,
   mockProductId,
@@ -21,12 +18,27 @@ export const mockData = {
   quantity: 1,
 };
 
+export const mockBagEntity = {
+  id: mockBagId,
+  items: [mockBagItemId, 101, 102, 103, 104],
+  bagOperations: [mockBagOperationId, 101, 102, 103, 104],
+  '@controls': {
+    BagGet_operation: {
+      href: `/v1/bags/${mockBagId}/operations/${mockBagOperationId}`,
+    },
+  },
+};
+
 export const mockInitialState = {
   bag: {
     error: null,
     id: mockBagId,
     isLoading: false,
     bagItems: {
+      error: {},
+      isLoading: {},
+    },
+    bagOperations: {
       error: {},
       isLoading: {},
     },
@@ -45,6 +57,12 @@ export const mockLoadingState = {
       error: {},
       isLoading: {
         [mockBagItemId]: true,
+      },
+    },
+    bagOperations: {
+      error: {},
+      isLoading: {
+        [mockBagOperationId]: true,
       },
     },
   },
@@ -66,6 +84,14 @@ export const mockErrorState = {
         [mockBagItemId]: false,
       },
     },
+    bagOperations: {
+      error: {
+        [mockBagOperationId]: { message: 'An unexpected error occurred' },
+      },
+      isLoading: {
+        [mockBagOperationId]: false,
+      },
+    },
   },
   entities: {
     bag: {},
@@ -84,6 +110,10 @@ export const mockState = {
       error: {
         [mockBagItemId]: { message: 'error: not loaded' },
       },
+    },
+    bagOperations: {
+      isLoading: {},
+      error: {},
     },
   },
   entities: {
@@ -147,6 +177,13 @@ export const mockState = {
         ],
       },
     },
+    bagOperations: {
+      [mockBagOperationId]: mockBagOperation,
+      101: {
+        ...mockBagOperation,
+        id: '101',
+      },
+    },
   },
 };
 export const mockResponse = {
@@ -184,6 +221,11 @@ export const mockResponse = {
       productName: 'Oxford Shirt',
       type: 0,
       promotionEvaluationId: mockPromotionEvaluationId,
+      '@controls': {
+        BagGet_operation: {
+          href: `/v1/bags/${mockBagId}/operations/${mockBagOperationId}`,
+        },
+      },
     },
   ],
 };

--- a/tests/__fixtures__/bags/bagItem.fixtures.js
+++ b/tests/__fixtures__/bags/bagItem.fixtures.js
@@ -1,14 +1,8 @@
-import { mockBagId } from './bag.fixtures';
 import { mockMerchantId, mockProduct, mockProductId } from '../products';
 import { mockPromotionEvaluationItemId } from '../promotionEvaluations';
 
 export const mockBagItemId = 134;
 export const mockProductAggregatorId = 321;
-
-export const mockBagEntity = {
-  id: mockBagId,
-  items: [mockBagItemId, 101, 102, 103, 104],
-};
 
 export const mockBagItem = {
   id: mockBagItemId,

--- a/tests/__fixtures__/bags/bagOperations.fixtures.js
+++ b/tests/__fixtures__/bags/bagOperations.fixtures.js
@@ -1,0 +1,48 @@
+export const mockBagOperationId = '134';
+
+export const mockBagOperation = {
+  id: mockBagOperationId,
+  createdDate: '2023-01-19T15:46:00.223Z',
+  changes: [
+    {
+      changeType: 'ItemIsUnavailable',
+      productId: 0,
+      variantId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+      itemId: 0,
+      oldPrice: {
+        priceInclTaxes: 0,
+      },
+      newPrice: {
+        priceInclTaxes: 0,
+      },
+      oldValue: 'string',
+      newValue: 'string',
+      currency: 'string',
+      reason: 'LackOfBenefits',
+    },
+  ],
+  violations: [
+    {
+      itemsIds: [0],
+      fixSuggestion: {
+        action: 'DecreaseQuantity',
+        value: 'string',
+      },
+    },
+  ],
+};
+
+export const mockBagOperations = {
+  number: 1,
+  totalPages: 1,
+  totalItems: 1,
+  entries: [mockBagOperation],
+};
+
+export const mockBagOperationsNormalizedPayload = {
+  bagOperationId: mockBagOperationId,
+  entities: {
+    bagOperations: { [mockBagOperationId]: mockBagOperation },
+  },
+  result: mockBagOperationId,
+};

--- a/tests/__fixtures__/bags/index.js
+++ b/tests/__fixtures__/bags/index.js
@@ -1,2 +1,3 @@
 export * from './bag.fixtures';
 export * from './bagItem.fixtures';
+export * from './bagOperations.fixtures';


### PR DESCRIPTION
## Description

This adds the client and redux logic for bag operations.

It also includes a middleware that fetches the bag operations whenever a bag request is successful.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
