### PR TITLE
feat(core|react): allow analytics to work with any consent categories

### DIFF
--- a/packages/core/src/analytics/Analytics.js
+++ b/packages/core/src/analytics/Analytics.js
@@ -174,7 +174,7 @@ class Analytics {
   }
 
   /**
-   * This method will be called whenever integrations are loaded into analytics. To be overriden by subclasses.
+   * This method will be called whenever integrations are loaded into analytics. To be overridden by subclasses.
    *
    * @protected
    * @returns {Promise} Promise that will resolve when the method finishes.
@@ -421,7 +421,10 @@ class Analytics {
         return;
       }
 
-      const shouldLoad = integration.Factory.shouldLoad(loadEventData.consent);
+      const shouldLoad = integration.Factory.shouldLoad(
+        loadEventData.consent,
+        integration?.options,
+      );
 
       if (!shouldLoad) {
         // Nothing to do as well if the integration shouldn't load

--- a/packages/core/src/analytics/Consent.js
+++ b/packages/core/src/analytics/Consent.js
@@ -1,6 +1,4 @@
-import { CONSENT_KEYS } from './utils';
 import merge from 'lodash/merge';
-import pick from 'lodash/pick';
 
 /**
  * Stores the consent values in a new instance.
@@ -47,12 +45,10 @@ class Consent {
    * @returns {Promise<Consent>} Promise that will resolve with the instance that was used when calling this method to allow chaining.
    */
   async set(data = {}) {
-    const consent = pick(data, CONSENT_KEYS);
-
     const currentConsentFromStorage =
       (await this.storage.getItem('consent')) || {};
 
-    const newConsent = merge(currentConsentFromStorage, consent);
+    const newConsent = merge(currentConsentFromStorage, data);
 
     await this.storage.setItem('consent', newConsent);
 

--- a/packages/core/src/analytics/__tests__/analytics.test.js
+++ b/packages/core/src/analytics/__tests__/analytics.test.js
@@ -43,12 +43,6 @@ class NoIntegrationInstanceIntegration extends Integration {
   }
 }
 
-class DefaultCreateInstanceIntegration extends Integration {
-  static shouldLoad() {
-    return true;
-  }
-}
-
 class CreateInstanceThrowsIntegration extends Integration {
   static shouldLoad() {
     return true;
@@ -535,20 +529,12 @@ describe('analytics', () => {
               'noIntegrationInstanceIntegration',
               NoIntegrationInstanceIntegration,
             )
-            .addIntegration(
-              'defaultCreateInstanceIntegration',
-              DefaultCreateInstanceIntegration,
-            )
             .ready();
 
-          expect(loggerErrorSpy).toBeCalledTimes(2);
+          expect(loggerErrorSpy).toBeCalledTimes(1);
 
           expect(
             analytics.integration('noIntegrationInstanceIntegration'),
-          ).toBeNull();
-
-          expect(
-            analytics.integration('defaultCreateInstanceIntegration'),
           ).toBeNull();
         });
 

--- a/packages/core/src/analytics/__tests__/consent.test.js
+++ b/packages/core/src/analytics/__tests__/consent.test.js
@@ -59,29 +59,6 @@ describe('Consent', () => {
     expect(consentInStorage).toMatchObject(data);
   });
 
-  it('Should only set valid consent parameters on storage', async () => {
-    const invalidData = {
-      foo: true,
-    };
-
-    const data = {
-      marketing: false,
-      statistics: true,
-    };
-
-    await consentInstance.set(invalidData);
-
-    const consentInStorage = await storage.getItem('consent');
-
-    expect(consentInStorage).not.toHaveProperty('foo');
-
-    await consentInstance.set(data);
-
-    const newConsentInStorage = await storage.getItem('consent');
-
-    expect(newConsentInStorage).toMatchObject(data);
-  });
-
   it('Should throw if an invalid storage instance is passed to the constructor', () => {
     expect(() => new Consent()).toThrow();
   });

--- a/packages/core/src/analytics/integrations/__tests__/Integration.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Integration.test.js
@@ -17,10 +17,6 @@ describe('Integration', () => {
     integration = new Integration(options, loadData);
   });
 
-  it('Should not be ready to load by default', () => {
-    expect(Integration.shouldLoad()).toEqual(false);
-  });
-
   it('Should set the options passed in the constructor', () => {
     expect(integration.options).toEqual(options);
   });
@@ -29,7 +25,60 @@ describe('Integration', () => {
     expect(integration.track).toBeInstanceOf(Function);
   });
 
-  it('Should have a setConsent method', () => {
-    expect(integration.setConsent).toBeInstanceOf(Function);
+  it('should return an instance of itself or of an extended class', () => {
+    class MyIntegration extends Integration {}
+
+    expect(integration).toBeInstanceOf(Integration);
+    expect(MyIntegration.createInstance()).toBeInstanceOf(Integration);
+  });
+
+  describe('Consent', () => {
+    it('Should not be ready to load by default', () => {
+      expect(Integration.shouldLoad()).toEqual(false);
+    });
+
+    it('Should have a setConsent method', () => {
+      expect(integration.setConsent).toBeInstanceOf(Function);
+    });
+
+    it('Should load only when ALL the provided consent categories are true', () => {
+      expect(
+        Integration.shouldLoad(
+          { foo: true, bar: true },
+          {
+            consentCategories: ['foo', 'bar'],
+          },
+        ),
+      ).toBe(true);
+
+      expect(
+        Integration.shouldLoad(
+          { foo: true, bar: false },
+          {
+            consentCategories: ['foo', 'bar'],
+          },
+        ),
+      ).toBe(false);
+
+      expect(
+        Integration.shouldLoad(
+          { foo: true, bar: false },
+          {
+            consentCategories: 'foo',
+          },
+        ),
+      ).toBe(true);
+    });
+
+    it('Should throw an error if passed an invalid consent type', () => {
+      expect(() =>
+        Integration.shouldLoad(
+          {},
+          {
+            consentCategories: 123,
+          },
+        ),
+      ).toThrowError();
+    });
   });
 });

--- a/packages/core/src/analytics/utils/__tests__/__snapshots__/contants.test.js.snap
+++ b/packages/core/src/analytics/utils/__tests__/__snapshots__/contants.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`constants Should export CONSENT_KEYS 1`] = `
 Array [
-  "marketing",
   "statistics",
+  "marketing",
   "preferences",
 ]
 `;

--- a/packages/core/src/analytics/utils/constants.js
+++ b/packages/core/src/analytics/utils/constants.js
@@ -3,4 +3,14 @@ import { version } from '../../../package.json';
 export const PACKAGE_VERSION = version;
 export const PACKAGE_NAME = '@farfetch/blackout-core/analytics';
 export const PACKAGE_NAME_VERSION = `${PACKAGE_NAME}@${PACKAGE_VERSION}`;
-export const CONSENT_KEYS = ['marketing', 'statistics', 'preferences'];
+export const DefaultConsentKeys = {
+  STATISTICS: 'statistics',
+  MARKETING: 'marketing',
+  PREFERENCES: 'preferences',
+};
+export const CONSENT_KEYS = [
+  DefaultConsentKeys.STATISTICS,
+  DefaultConsentKeys.MARKETING,
+  DefaultConsentKeys.PREFERENCES,
+];
+export const CONSENT_CATEGORIES_PROPERTY = 'consentCategories';

--- a/packages/react/src/analytics/integrations/Castle/CastleV1.js
+++ b/packages/react/src/analytics/integrations/Castle/CastleV1.js
@@ -45,18 +45,6 @@ class Castle extends integrations.Integration {
   }
 
   /**
-   * Creates and returns the instance for Castle integration.
-   *
-   * @param {object} options - Integration options.
-   * @param {object} loadData - Analytics's load event data.
-   *
-   * @returns {Castle} The instance created.
-   */
-  static createInstance(options, loadData) {
-    return new Castle(options, loadData);
-  }
-
-  /**
    * Creates an instance of Castle integration.
    *
    * @param {object} options - Integration options.

--- a/packages/react/src/analytics/integrations/Castle/CastleV2.js
+++ b/packages/react/src/analytics/integrations/Castle/CastleV2.js
@@ -60,18 +60,6 @@ class CastleV2 extends integrations.Integration {
   }
 
   /**
-   * Creates and returns the instance for CastleV2 integration.
-   *
-   * @param {object} options - Integration options.
-   * @param {object} loadData - Analytics's load event data.
-   *
-   * @returns {CastleV2} The instance created.
-   */
-  static createInstance(options, loadData) {
-    return new CastleV2(options, loadData);
-  }
-
-  /**
    * Creates an instance of CastleV2 integration.
    *
    * @param {object} options - Integration options.

--- a/packages/react/src/analytics/integrations/Forter/Forter.js
+++ b/packages/react/src/analytics/integrations/Forter/Forter.js
@@ -49,19 +49,6 @@ class Forter extends integrations.Integration {
   }
 
   /**
-   * Method used to create a new Forter instance by analytics.
-   *
-   * @param {object} options   - User configured options.
-   * @param {object} loadData  - Analytics's load event data.
-   * @param {object} analytics - Stripped down analytics instance with helper methods.
-   *
-   * @returns {Forter} An instance of Forter class.
-   */
-  static createInstance(options, loadData, analytics) {
-    return new Forter(options, loadData, analytics);
-  }
-
-  /**
    * Creates an instance of Forter integration.
    *
    * @param {object} options  - User configured options.

--- a/packages/react/src/analytics/integrations/GA/GA.js
+++ b/packages/react/src/analytics/integrations/GA/GA.js
@@ -62,29 +62,8 @@ class GA extends integrations.Integration {
     this.onSetUser(loadData);
   }
 
-  /**
-   * Method to check if the integration is ready to be loaded.
-   *
-   * @param {object} consent - The consent object representing the user preferences.
-   *
-   * @returns {boolean} If the integration is ready to be loaded.
-   */
-  static shouldLoad(consent) {
-    return !!consent && !!consent.statistics;
-  }
-
-  /**
-   * Method used to create a new GA instance by analytics.
-   *
-   * @param {object} options - Integration options.
-   * @param {object} loadData - Analytics's load event data.
-   *
-   * @returns {GA} An instance of GA class.
-   */
-  static createInstance(options, loadData) {
-    return new GA(options, loadData);
-  }
-
+  static [utils.CONSENT_CATEGORIES_PROPERTY] =
+    utils.DefaultConsentKeys.STATISTICS;
   /**
    * Send page hits to GA.
    *

--- a/packages/react/src/analytics/integrations/GA4/GA4.js
+++ b/packages/react/src/analytics/integrations/GA4/GA4.js
@@ -80,32 +80,8 @@ class GA4 extends integrations.Integration {
     this.onSetUser(loadData);
   }
 
-  /**
-   * Method to check if the integration is ready to be loaded.
-   *
-   * @param {object} consent - The consent object representing the user preferences.
-   *
-   * @returns {boolean} If the integration is ready to be loaded.
-   */
-  static shouldLoad(consent) {
-    return !!consent?.statistics;
-  }
-
-  /**
-   * Method used to create a new GA4 instance by analytics.
-   *
-   * @async
-   *
-   * @param {object} options - Integration options.
-   * @param {object} loadData - Analytics's load event data.
-   * @param {object} analytics - Analytics stripped down instance.
-   *
-   * @returns {GA4} An instance of GA4 class.
-   *
-   */
-  static createInstance(options, loadData, analytics) {
-    return new GA4(options, loadData, analytics);
-  }
+  static [utils.CONSENT_CATEGORIES_PROPERTY] =
+    utils.DefaultConsentKeys.STATISTICS;
 
   /**
    * Initializes member variables from options and tries to initialize Google Analytics 4.

--- a/packages/react/src/analytics/integrations/GTM/GTM.js
+++ b/packages/react/src/analytics/integrations/GTM/GTM.js
@@ -88,18 +88,6 @@ class GTM extends Integration {
   }
 
   /**
-   * Method used to create a new GTM instance by analytics.
-   *
-   * @param {object} options - Integration options.
-   * @param {object} loadData - Analytics's load event data.
-   *
-   * @returns {object} An instance of GTM class.
-   */
-  static createInstance(options, loadData) {
-    return new GTM(options, loadData);
-  }
-
-  /**
    * Method to check if the integration is ready to be loaded.
    * This integration should always load. Then, in the container,
    * each tag should be configured with the proper trigger according its category: Preferences, statistics or marketing.

--- a/packages/react/src/analytics/integrations/Riskified.js
+++ b/packages/react/src/analytics/integrations/Riskified.js
@@ -38,18 +38,6 @@ class Riskified extends integrations.Integration {
   }
 
   /**
-   * Method used to create a new Riskified instance by analytics.
-   *
-   * @param {object} options - Integration options.
-   * @param {object} loadData - Analytics's load event data.
-   *
-   * @returns {Riskified} The Riskified instance to allow chaining calls.
-   */
-  static createInstance(options, loadData) {
-    return new Riskified(options, loadData);
-  }
-
-  /**
    * Creates an instance of Riskified and sets the script on the page.
    *
    * @param {object} options - Custom options for the integration.

--- a/packages/react/src/analytics/integrations/Vitorino/Vitorino.js
+++ b/packages/react/src/analytics/integrations/Vitorino/Vitorino.js
@@ -40,19 +40,6 @@ export default class Vitorino extends integrations.Integration {
   }
 
   /**
-   * Creates and returns the instance for Vitorino integration.
-   *
-   * @param {object} options - Integration options.
-   * @param {object} loadData - Analytics' load event data.
-   * @param {object} analytics - Analytics stripped down instance.
-   *
-   * @returns {Vitorino} The instance created.
-   */
-  static createInstance(options, loadData, analytics) {
-    return new Vitorino(options, loadData, analytics);
-  }
-
-  /**
    * Creates an instance of Vitorino integration.
    *
    * @param {object} options - Integration options.


### PR DESCRIPTION
## Description
This PR introduces a new feature on the analytics package that allows the projects to define custom consent categories to integrations. The built-in ones will still use its default consent categories.

- Added custom consent feature;
- Adapted the `.shouldLoad()` method on the `Integration` class  to contain all logic regarding the consent and removed this method from the integrations that no longer need it (as all the work will now be done on the static method of the `Integration` class;
- From now on, built-in integrations that need consent can just define a static property on the class called `consentCategories` - this will be used on the `.shouldLoad()` method of the `Integration` class if no custom consent categories are defined via the integration's options.
- Removed some unnecessary static `createInstance` methods from integrations.
- Other minor improvements.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
