### PR TITLE
fix: select content analytics event

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -9,6 +9,7 @@ import {
 import { getProductId, logger } from '../../utils';
 import EventTypes from '../../types/EventTypes';
 import InteractionTypes from '../../types/InteractionTypes';
+import isNil from 'lodash/isNil';
 import PageTypes from '../../types/PageTypes';
 import type { EventData, TrackTypesValues } from '../..';
 import type {
@@ -526,7 +527,8 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
   [EventTypes.SELECT_CONTENT]: data => {
     const properties = data.properties;
 
-    if (!properties?.contentType || !properties?.id) {
+    // Treat id=0 as a truthy value in this event
+    if (!properties?.contentType || isNil(properties?.id)) {
       logger.error(
         `[Omnitracking] - Event ${data.event} properties "contentType" and "id" should be sent
                         on the payload when triggering a "select content" event. If you want to track this


### PR DESCRIPTION
## Description

This change fixes the validation of select content event parameters in case the id is equal to 0.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
