### PR TITLE
feat(client): add segment at target on searchContents

### DIFF
--- a/packages/client/src/contents/__tests__/getSearchContents.test.ts
+++ b/packages/client/src/contents/__tests__/getSearchContents.test.ts
@@ -20,6 +20,7 @@ describe('contents client', () => {
       target: {
         channel: 'channel',
         language: 'en-US',
+        segments: 'private-sale,private-sale-guest-user',
       },
     };
     const response = {
@@ -90,7 +91,7 @@ describe('contents client', () => {
       await expect(getSearchContents(query)).resolves.toEqual(response);
 
       expect(spy).toHaveBeenCalledWith(
-        '/content/v1/search/contents?codes=123456789&contentTypeCode=pages&environmentCode=live&spaceCode=website&target.channel=channel&target.language=en-US',
+        '/content/v1/search/contents?codes=123456789&contentTypeCode=pages&environmentCode=live&spaceCode=website&target.channel=channel&target.language=en-US&target.segments=private-sale,private-sale-guest-user',
         expectedConfig,
       );
     });
@@ -103,7 +104,7 @@ describe('contents client', () => {
       await expect(getSearchContents(query)).rejects.toMatchSnapshot();
 
       expect(spy).toHaveBeenCalledWith(
-        '/content/v1/search/contents?codes=123456789&contentTypeCode=pages&environmentCode=live&spaceCode=website&target.channel=channel&target.language=en-US',
+        '/content/v1/search/contents?codes=123456789&contentTypeCode=pages&environmentCode=live&spaceCode=website&target.channel=channel&target.language=en-US&target.segments=private-sale,private-sale-guest-user',
         expectedConfig,
       );
     });

--- a/packages/client/src/contents/getSearchContents.ts
+++ b/packages/client/src/contents/getSearchContents.ts
@@ -26,6 +26,7 @@ const getSearchContents: GetSearchContents = (query, config?) => {
     .get(
       join('/content/v1/search/contents', {
         query: payload as Omit<QuerySearchContents, 'target'>,
+        queryOptions: { encode: false },
       }),
       config,
     )

--- a/packages/client/src/contents/types/contents.types.ts
+++ b/packages/client/src/contents/types/contents.types.ts
@@ -6,6 +6,7 @@ export type Targets = {
   country?: string;
   benefits?: string;
   channel?: string;
+  segments?: string;
 } & Record<string, string | undefined>;
 
 export type QuerySearchContents = {
@@ -17,7 +18,7 @@ export type QuerySearchContents = {
   contentTypeCode: string;
   // List of codes that representing the content code (about-us|today-news|header|productId...).
   codes?: string | string[];
-  // The targets and respective values that a content type is configured (contentzone:ROW | country:GB | language:en-GB | benefits:test).
+  // The targets and respective values that a content type is configured (contentzone:ROW | country:GB | language:en-GB | benefits:test | segments: 'private-sale,private-sale-guest-user').  // The segments list should contain less than 10 strings. They should separated by a comma (,).
   target?: Targets;
   // Sort content by (publicationDate:desc | publicationDate:asc | metadataCustom.eventDate:desc | metadataCustom.X:asc).
   sort?: string;


### PR DESCRIPTION
## Description

Add `target.segment ` on searchContents function

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
