### PR TITLE
feat(analytics|react): allow analytics to work with any consent categories - NEXT

### DIFF
--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -529,10 +529,11 @@ class Analytics {
         return;
       }
 
-      let shouldLoad;
-
       try {
-        shouldLoad = integration.Factory.shouldLoad(loadEventData.consent);
+        const shouldLoad = integration.Factory.shouldLoad(
+          loadEventData.consent,
+          integration?.options,
+        );
 
         if (!shouldLoad) {
           // Nothing to do as well if the integration shouldn't load

--- a/packages/analytics/src/Consent.ts
+++ b/packages/analytics/src/Consent.ts
@@ -1,6 +1,4 @@
-import { CONSENT_KEYS } from './utils';
 import merge from 'lodash/merge';
-import pick from 'lodash/pick';
 import type { ConsentData } from './types/analytics.types';
 import type StorageWrapper from './utils/StorageWrapper';
 
@@ -47,12 +45,11 @@ class Consent {
    * chaining.
    */
   async set(data: ConsentData | undefined): Promise<Consent> {
-    const consent = pick(data, CONSENT_KEYS);
     const currentConsentFromStorage = ((await this.storage.getItem(
       'consent',
     )) || {}) as typeof data;
 
-    const newConsent = merge(currentConsentFromStorage, consent);
+    const newConsent = merge(currentConsentFromStorage, data);
 
     await this.storage.setItem('consent', newConsent);
 

--- a/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
@@ -134,11 +134,17 @@ Object {
   },
   "utils": Object {
     "ANALYTICS_UNIQUE_EVENT_ID": "__uniqueEventId",
+    "CONSENT_CATEGORIES_PROPERTY": "consentCategories",
     "CONSENT_KEYS": Array [
-      "marketing",
       "statistics",
+      "marketing",
       "preferences",
     ],
+    "DefaultConsentKeys": Object {
+      "MARKETING": "marketing",
+      "PREFERENCES": "preferences",
+      "STATISTICS": "statistics",
+    },
     "LOAD_INTEGRATION_TRACK_TYPE": "loadIntegration",
     "ON_SET_USER_TRACK_TYPE": "onSetUser",
     "StorageWrapper": [Function],

--- a/packages/analytics/src/__tests__/consent.test.ts
+++ b/packages/analytics/src/__tests__/consent.test.ts
@@ -60,34 +60,6 @@ describe('Consent', () => {
     expect(consentInStorage).toMatchObject(data);
   });
 
-  it('Should only set valid consent parameters on storage', async () => {
-    const invalidData = {
-      foo: true,
-    };
-
-    const inputConsentData = {
-      marketing: false,
-      statistics: true,
-    };
-
-    const outputConsentData = {
-      ...inputConsentData,
-    };
-
-    // @ts-expect-error
-    await consentInstance.set(invalidData);
-
-    const consentInStorage = await storage.getItem('consent');
-
-    expect(consentInStorage).not.toHaveProperty('foo');
-
-    await consentInstance.set(inputConsentData);
-
-    const newConsentInStorage = await storage.getItem('consent');
-
-    expect(newConsentInStorage).toMatchObject(outputConsentData);
-  });
-
   it('Should throw if an invalid storage instance is passed to the constructor', () => {
     const invalidData = undefined;
     // @ts-expect-error

--- a/packages/analytics/src/integrations/Integration.ts
+++ b/packages/analytics/src/integrations/Integration.ts
@@ -1,3 +1,4 @@
+import { CONSENT_CATEGORIES_PROPERTY } from '../utils';
 import type {
   ConsentData,
   EventData,
@@ -26,15 +27,54 @@ class Integration<T extends IntegrationOptions> {
   ) {}
 
   /**
+   * "consentCategories" that each integration can specify accordingly.
+   */
+  static [CONSENT_CATEGORIES_PROPERTY]: IntegrationOptions['consentCategories'] =
+    null;
+
+  /**
+   * Sets the given consent on the Class static property, so it can be accessed before the instance gets created.
+   *
+   * @param options - Integration options.
+   */
+  static validateConsentCategories(options: IntegrationOptions) {
+    const consentCategories = options?.[CONSENT_CATEGORIES_PROPERTY];
+
+    if (
+      consentCategories &&
+      typeof consentCategories !== 'string' &&
+      !Array.isArray(consentCategories)
+    ) {
+      throw new TypeError(
+        `[${this.prototype.constructor.name}] - "${CONSENT_CATEGORIES_PROPERTY}" is not an array nor a string. Make sure you are passing a valid consent type.`,
+      );
+    }
+  }
+
+  /**
    * Method to check if the integration is ready to be loaded.
    *
    * @param consent - The current consent given by the user.
+   * @param options - Integration options.
    *
    * @returns If the integration is ready to be loaded.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static shouldLoad(consent: ConsentData): boolean {
-    throw new Error('Method not implemented');
+  static shouldLoad(consented: ConsentData, options: IntegrationOptions) {
+    this.validateConsentCategories(options);
+
+    const consentCategories =
+      options?.[CONSENT_CATEGORIES_PROPERTY] ||
+      this[CONSENT_CATEGORIES_PROPERTY];
+
+    if (!consented || !consentCategories) {
+      return false;
+    }
+
+    const safeConsentCategories = Array.isArray(consentCategories)
+      ? consentCategories
+      : [consentCategories];
+
+    return safeConsentCategories.every(category => !!consented[category]);
   }
 
   /**

--- a/packages/analytics/src/integrations/__tests__/Integration.test.ts
+++ b/packages/analytics/src/integrations/__tests__/Integration.test.ts
@@ -49,12 +49,6 @@ describe('Integration', () => {
     expect(constructorSpy).toHaveBeenCalled();
   });
 
-  it('`shouldLoad` should throw a `Method not implemented` error by default', () => {
-    expect(() => {
-      Integration.shouldLoad(loadData.consent);
-    }).toThrow('Method not implemented');
-  });
-
   it('`track` should throw a `Method not implemented` error by default', () => {
     expect(() => {
       Integration.createInstance({}, loadData, {
@@ -72,7 +66,63 @@ describe('Integration', () => {
     expect(integration.track).toBeInstanceOf(Function);
   });
 
-  it('Should have a setConsent method', () => {
-    expect(integration.setConsent).toBeInstanceOf(Function);
+  it('should return an instance of itself or of an extended class', () => {
+    class MyIntegration extends Integration<IntegrationOptions> {}
+
+    expect(integration).toBeInstanceOf(Integration);
+    // @ts-expect-error - No need to pass options to test what we need here
+    expect(MyIntegration.createInstance()).toBeInstanceOf(Integration);
+  });
+
+  describe('Consent', () => {
+    it('Should not be ready to load by default', () => {
+      // @ts-expect-error - Ensure it returns false even when there's no consent
+      expect(Integration.shouldLoad()).toEqual(false);
+    });
+
+    it('Should have a setConsent method', () => {
+      expect(integration.setConsent).toBeInstanceOf(Function);
+    });
+
+    it('Should load only when ALL the provided consent categories are true', () => {
+      expect(
+        Integration.shouldLoad(
+          { foo: true, bar: true },
+          {
+            consentCategories: ['foo', 'bar'],
+          },
+        ),
+      ).toBe(true);
+
+      expect(
+        Integration.shouldLoad(
+          { foo: true, bar: false },
+          {
+            consentCategories: ['foo', 'bar'],
+          },
+        ),
+      ).toBe(false);
+
+      expect(
+        Integration.shouldLoad(
+          { foo: true, bar: false },
+          {
+            consentCategories: 'foo',
+          },
+        ),
+      ).toBe(true);
+    });
+
+    it('Should throw an error if passed an invalid consent type', () => {
+      expect(() =>
+        Integration.shouldLoad(
+          {},
+          {
+            // @ts-expect-error - Test an invalid type scenario
+            consentCategories: 123,
+          },
+        ),
+      ).toThrowError();
+    });
   });
 });

--- a/packages/analytics/src/types/analytics.types.ts
+++ b/packages/analytics/src/types/analytics.types.ts
@@ -1,5 +1,5 @@
 import type {
-  CONSENT_KEYS,
+  CONSENT_CATEGORIES_PROPERTY,
   LOAD_INTEGRATION_TRACK_TYPE,
   ON_SET_USER_TRACK_TYPE,
 } from '../utils/constants';
@@ -10,7 +10,7 @@ import type TrackTypes from '../types/TrackTypes';
 export type TrackTypesValues = typeof TrackTypes[keyof typeof TrackTypes];
 
 export type ConsentData = {
-  [key in typeof CONSENT_KEYS[number]]?: boolean;
+  [k: string]: boolean;
 };
 
 type CommonContextData = {
@@ -67,7 +67,9 @@ export type IntegrationRuntimeData = {
   name: string;
 };
 
-export type IntegrationOptions = Record<string, unknown>;
+export type IntegrationOptions = Record<string, unknown> & {
+  [CONSENT_CATEGORIES_PROPERTY]?: string | string[] | null;
+};
 
 export interface IntegrationFactory<T extends IntegrationOptions> {
   new (
@@ -81,7 +83,10 @@ export interface IntegrationFactory<T extends IntegrationOptions> {
     loadData: LoadIntegrationEventData,
     analytics: StrippedDownAnalytics,
   ): Integration<Options>;
-  shouldLoad(consent: ConsentData | null | undefined): boolean;
+  shouldLoad(
+    consent: ConsentData | null | undefined,
+    options: IntegrationOptions,
+  ): boolean;
 }
 
 export type ExtendedTrackTypes =

--- a/packages/analytics/src/utils/__tests__/__snapshots__/contants.test.ts.snap
+++ b/packages/analytics/src/utils/__tests__/__snapshots__/contants.test.ts.snap
@@ -2,10 +2,18 @@
 
 exports[`constants Should export CONSENT_KEYS 1`] = `
 Array [
-  "marketing",
   "statistics",
+  "marketing",
   "preferences",
 ]
+`;
+
+exports[`constants Should export DefaultConsentKeys 1`] = `
+Object {
+  "MARKETING": "marketing",
+  "PREFERENCES": "preferences",
+  "STATISTICS": "statistics",
+}
 `;
 
 exports[`constants Should export PACKAGE_NAME 1`] = `"@farfetch/blackout-analytics"`;

--- a/packages/analytics/src/utils/__tests__/contants.test.ts
+++ b/packages/analytics/src/utils/__tests__/contants.test.ts
@@ -8,4 +8,12 @@ describe('constants', () => {
   it('Should export CONSENT_KEYS', () => {
     expect(constants.CONSENT_KEYS).toMatchSnapshot();
   });
+
+  it('Should export DefaultConsentKeys', () => {
+    expect(constants.DefaultConsentKeys).toMatchSnapshot();
+  });
+
+  it('Should export CONSENT_CATEGORIES_PROPERTY', () => {
+    expect(constants.CONSENT_CATEGORIES_PROPERTY).toEqual('consentCategories');
+  });
 });

--- a/packages/analytics/src/utils/constants.ts
+++ b/packages/analytics/src/utils/constants.ts
@@ -7,7 +7,17 @@ const { name, version } = require('../../package.json');
 export const PACKAGE_VERSION = version;
 export const PACKAGE_NAME = name;
 export const PACKAGE_NAME_VERSION = `${PACKAGE_NAME}@${PACKAGE_VERSION}`;
-export const CONSENT_KEYS = ['marketing', 'statistics', 'preferences'] as const;
+export const DefaultConsentKeys = {
+  STATISTICS: 'statistics',
+  MARKETING: 'marketing',
+  PREFERENCES: 'preferences',
+};
+export const CONSENT_KEYS = [
+  DefaultConsentKeys.STATISTICS,
+  DefaultConsentKeys.MARKETING,
+  DefaultConsentKeys.PREFERENCES,
+];
+export const CONSENT_CATEGORIES_PROPERTY = 'consentCategories';
 export const LOAD_INTEGRATION_TRACK_TYPE = 'loadIntegration';
 export const ON_SET_USER_TRACK_TYPE = 'onSetUser';
 export const ANALYTICS_UNIQUE_EVENT_ID = '__uniqueEventId';

--- a/packages/analytics/src/utils/index.ts
+++ b/packages/analytics/src/utils/index.ts
@@ -3,6 +3,8 @@ export {
   LOAD_INTEGRATION_TRACK_TYPE,
   ON_SET_USER_TRACK_TYPE,
   ANALYTICS_UNIQUE_EVENT_ID,
+  DefaultConsentKeys,
+  CONSENT_CATEGORIES_PROPERTY,
 } from './constants';
 export * from './defaults';
 export * from './getters';

--- a/packages/react/src/analytics/integrations/GA/GA.ts
+++ b/packages/react/src/analytics/integrations/GA/GA.ts
@@ -17,7 +17,6 @@
  */
 import {
   TrackTypes as analyticsTrackTypes,
-  ConsentData,
   EventData,
   integrations,
   LoadIntegrationEventData,
@@ -88,16 +87,8 @@ class GA extends integrations.Integration<GAIntegrationOptions> {
     this.onSetUser(loadData);
   }
 
-  /**
-   * Method to check if the integration is ready to be loaded.
-   *
-   * @param consent - The consent object representing the user preferences.
-   *
-   * @returns If the integration is ready to be loaded.
-   */
-  static override shouldLoad(consent: ConsentData | null): boolean {
-    return !!consent && !!consent.statistics;
-  }
+  static override [utils.CONSENT_CATEGORIES_PROPERTY] =
+    utils.DefaultConsentKeys.STATISTICS;
 
   /**
    * Send page hits to GA.

--- a/packages/react/src/analytics/integrations/GA/__tests__/GA.test.ts
+++ b/packages/react/src/analytics/integrations/GA/__tests__/GA.test.ts
@@ -121,12 +121,12 @@ describe('GA Integration', () => {
   });
 
   it('`shouldLoad` should return false if there is no user consent', () => {
-    expect(GA.shouldLoad({ statistics: false })).toBe(false);
-    expect(GA.shouldLoad({})).toBe(false);
+    expect(GA.shouldLoad({ statistics: false }, {})).toBe(false);
+    expect(GA.shouldLoad({}, {})).toBe(false);
   });
 
   it('`shouldLoad` should return true if there is user consent', () => {
-    expect(GA.shouldLoad({ statistics: true })).toBe(true);
+    expect(GA.shouldLoad({ statistics: true }, {})).toBe(true);
   });
 
   describe('GA instance', () => {

--- a/packages/react/src/analytics/integrations/GA4/GA4.ts
+++ b/packages/react/src/analytics/integrations/GA4/GA4.ts
@@ -15,7 +15,6 @@
 import {
   PageTypes as analyticsPageTypes,
   TrackTypes as analyticsTrackTypes,
-  ConsentData,
   EventData,
   integrations,
   LoadIntegrationEventData,
@@ -107,16 +106,8 @@ class GA4 extends integrations.Integration<GA4IntegrationOptions> {
     this.onSetUser(loadData);
   }
 
-  /**
-   * Method to check if the integration is ready to be loaded.
-   *
-   * @param consent - The consent object representing the user preferences.
-   *
-   * @returns If the integration is ready to be loaded.
-   */
-  static override shouldLoad(consent: ConsentData): boolean {
-    return !!consent?.statistics;
-  }
+  static override [utils.CONSENT_CATEGORIES_PROPERTY] =
+    utils.DefaultConsentKeys.STATISTICS;
 
   /**
    * Initializes member variables from options and tries to initialize Google

--- a/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.ts
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.ts
@@ -97,12 +97,12 @@ describe('GA4 Integration', () => {
   });
 
   it('`shouldLoad` should return false if there is no user consent', () => {
-    expect(GA4.shouldLoad({ statistics: false })).toBe(false);
-    expect(GA4.shouldLoad({})).toBe(false);
+    expect(GA4.shouldLoad({ statistics: false }, {})).toBe(false);
+    expect(GA4.shouldLoad({}, {})).toBe(false);
   });
 
   it('`shouldLoad` should return true if there is user consent', () => {
-    expect(GA4.shouldLoad({ statistics: true })).toBe(true);
+    expect(GA4.shouldLoad({ statistics: true }, {})).toBe(true);
   });
 
   describe('GA4 instance', () => {


### PR DESCRIPTION
## Description
This PR introduces a new feature on the analytics package that allows the projects to define custom consent categories to integrations. The built-in ones will still use its default consent categories.

- Added custom consent feature;
- Adapted the .shouldLoad() method on the Integration class to contain all logic regarding the consent and removed this method from the integrations that no longer need it (as all the work will now be done on the static method of the Integration class;
- From now on, built-in integrations that need consent can just define a static property on the class called consentCategories - this will be used on the .shouldLoad() method of the Integration class if no custom consent categories are defined via the integration's options.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
