### PR TITLE
fix(redux): fix product attributes server render

### DIFF
--- a/packages/client/src/checkout/__tests__/getCheckoutOrderDetails.test.ts
+++ b/packages/client/src/checkout/__tests__/getCheckoutOrderDetails.test.ts
@@ -385,6 +385,8 @@ describe('checkout client', () => {
             discount: 0,
             currency: 'string',
             rank: 0,
+            finalPrice: 0,
+            formattedFinalPrice: 'string',
             itemsDeliveryOptions: [
               {
                 itemId: 0,

--- a/packages/client/src/checkout/types/deliveryBundle.types.ts
+++ b/packages/client/src/checkout/types/deliveryBundle.types.ts
@@ -12,6 +12,8 @@ export type DeliveryBundle = {
   isSelected: boolean;
   price: number;
   formattedPrice: string;
+  finalPrice: number;
+  formattedFinalPrice: string;
   discount: number;
   currency: string;
   rank: number;

--- a/packages/redux/src/checkout/actions/__tests__/__snapshots__/createCheckoutOrder.test.ts.snap
+++ b/packages/redux/src/checkout/actions/__tests__/__snapshots__/createCheckoutOrder.test.ts.snap
@@ -367,6 +367,8 @@ Object {
         "12345678": Object {
           "currency": "EUR",
           "discount": 0,
+          "finalPrice": 10,
+          "formattedFinalPrice": "10",
           "formattedPrice": "10",
           "id": "12345678",
           "isSelected": true,

--- a/packages/redux/src/checkout/actions/__tests__/__snapshots__/fetchCheckoutOrder.test.ts.snap
+++ b/packages/redux/src/checkout/actions/__tests__/__snapshots__/fetchCheckoutOrder.test.ts.snap
@@ -367,6 +367,8 @@ Object {
         "12345678": Object {
           "currency": "EUR",
           "discount": 0,
+          "finalPrice": 10,
+          "formattedFinalPrice": "10",
           "formattedPrice": "10",
           "id": "12345678",
           "isSelected": true,

--- a/packages/redux/src/checkout/actions/__tests__/__snapshots__/setCheckoutOrderItemTags.test.ts.snap
+++ b/packages/redux/src/checkout/actions/__tests__/__snapshots__/setCheckoutOrderItemTags.test.ts.snap
@@ -367,6 +367,8 @@ Object {
         "12345678": Object {
           "currency": "EUR",
           "discount": 0,
+          "finalPrice": 10,
+          "formattedFinalPrice": "10",
           "formattedPrice": "10",
           "id": "12345678",
           "isSelected": true,

--- a/packages/redux/src/checkout/actions/__tests__/__snapshots__/setCheckoutOrderPromocode.test.ts.snap
+++ b/packages/redux/src/checkout/actions/__tests__/__snapshots__/setCheckoutOrderPromocode.test.ts.snap
@@ -367,6 +367,8 @@ Object {
         "12345678": Object {
           "currency": "EUR",
           "discount": 0,
+          "finalPrice": 10,
+          "formattedFinalPrice": "10",
           "formattedPrice": "10",
           "id": "12345678",
           "isSelected": true,

--- a/packages/redux/src/checkout/actions/__tests__/__snapshots__/setCheckoutOrderTags.test.ts.snap
+++ b/packages/redux/src/checkout/actions/__tests__/__snapshots__/setCheckoutOrderTags.test.ts.snap
@@ -367,6 +367,8 @@ Object {
         "12345678": Object {
           "currency": "EUR",
           "discount": 0,
+          "finalPrice": 10,
+          "formattedFinalPrice": "10",
           "formattedPrice": "10",
           "id": "12345678",
           "isSelected": true,

--- a/packages/redux/src/checkout/actions/__tests__/__snapshots__/updateCheckoutOrder.test.ts.snap
+++ b/packages/redux/src/checkout/actions/__tests__/__snapshots__/updateCheckoutOrder.test.ts.snap
@@ -367,6 +367,8 @@ Object {
         "12345678": Object {
           "currency": "EUR",
           "discount": 0,
+          "finalPrice": 10,
+          "formattedFinalPrice": "10",
           "formattedPrice": "10",
           "id": "12345678",
           "isSelected": true,
@@ -803,6 +805,8 @@ Object {
         "12345678": Object {
           "currency": "EUR",
           "discount": 0,
+          "finalPrice": 10,
+          "formattedFinalPrice": "10",
           "formattedPrice": "10",
           "id": "12345678",
           "isSelected": true,

--- a/packages/redux/src/products/serverInitialState/products.ts
+++ b/packages/redux/src/products/serverInitialState/products.ts
@@ -51,7 +51,11 @@ const serverInitialState: ProductsServerInitialState = ({
     // Send this to the entity's `adaptProductImages`
     productImgQueryParam,
     // Data needed to support product information
-    attributes: productAttributes,
+    // Set attributes to undefined if the productAttributes array
+    // is empty. This is because by default the server render will
+    // return an empty array, even when no request to fetch the
+    // product attributes was made.
+    attributes: productAttributes?.length === 0 ? undefined : productAttributes,
     breadCrumbs,
     colorSet,
     colorSwatch,

--- a/tests/__fixtures__/checkout/checkout.fixtures.ts
+++ b/tests/__fixtures__/checkout/checkout.fixtures.ts
@@ -152,6 +152,8 @@ export const mockDeliveryBundlesResponse = [
     discount: 0,
     currency: 'EUR',
     rank: 1,
+    finalPrice: 10,
+    formattedFinalPrice: '10',
     itemsDeliveryOptions: [
       {
         itemId: 95097041,
@@ -1030,6 +1032,8 @@ const deliveryBundle = {
   discount: 0,
   currency: '€',
   rank: 1,
+  finalPrice: 25,
+  formattedFinalPrice: '25 €',
   itemDeliveryProvisioning: [],
 };
 


### PR DESCRIPTION
## Description

This changes the serverInitialState handling of the
`productAttributes` property from page model to discard it if the value
is an empty array since the server will return an empty array by default
even when no request to fetch the product attributes was made.
Without this change, it was impossible to distinguish if the product
has no attributes or if the attributes were not fetched and the client
should then fetch them.

Also, added a fix for the DeliveryBundle type in checkout which
was missing some properties.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
