### PR TITLE
feat(core|client): add segment at targets on searchContent

### DIFF
--- a/packages/core/src/contents/client/__fixtures__/contents.fixtures.js
+++ b/packages/core/src/contents/client/__fixtures__/contents.fixtures.js
@@ -10,6 +10,7 @@ export default {
       moxios.stubRequest(
         join('/api/content/v1/search/contents', {
           query: params.queryParams,
+          queryOptions: { encode: false },
         }),
         {
           method: 'get',
@@ -22,6 +23,7 @@ export default {
       moxios.stubRequest(
         join('/api/content/v1/search/contents', {
           query: params.queryParams,
+          queryOptions: { encode: false },
         }),
         {
           method: 'get',

--- a/packages/core/src/contents/client/__tests__/getSearchContents.test.js
+++ b/packages/core/src/contents/client/__tests__/getSearchContents.test.js
@@ -20,6 +20,7 @@ describe('contents client', () => {
       environmentCode: 'live',
       codes: 123456789,
       contentTypeCode: 'pages',
+      'target.segments': 'private-sale,private-sale-guest-user',
     };
     const response = {
       number: 1,
@@ -35,6 +36,7 @@ describe('contents client', () => {
           code: 'cttpage',
           target: {
             contentzone: '10674',
+            segment: 'private-sale',
           },
           components: [
             {
@@ -85,7 +87,7 @@ describe('contents client', () => {
 
       await expect(getSearchContents(query)).resolves.toBe(response);
       expect(spy).toHaveBeenCalledWith(
-        '/content/v1/search/contents?codes=123456789&contentTypeCode=pages&environmentCode=live&spaceCode=website',
+        '/content/v1/search/contents?codes=123456789&contentTypeCode=pages&environmentCode=live&spaceCode=website&target.segments=private-sale,private-sale-guest-user',
         expectedConfig,
       );
     });
@@ -97,7 +99,7 @@ describe('contents client', () => {
 
       await expect(getSearchContents(query)).rejects.toMatchSnapshot();
       expect(spy).toHaveBeenCalledWith(
-        '/content/v1/search/contents?codes=123456789&contentTypeCode=pages&environmentCode=live&spaceCode=website',
+        '/content/v1/search/contents?codes=123456789&contentTypeCode=pages&environmentCode=live&spaceCode=website&target.segments=private-sale,private-sale-guest-user',
         expectedConfig,
       );
     });

--- a/packages/core/src/contents/client/getSearchContents.js
+++ b/packages/core/src/contents/client/getSearchContents.js
@@ -11,6 +11,8 @@ import join from 'proper-url-join';
  * @property {string} [language] - Using country code to query by a specific language (US).
  * @property {string} [country] - Using culture code to query by a specific country (en-US).
  * @property {string} [benefits] - Query content for a benefit (sale).
+ * @property {string} [segments] - String of segments to filter the query by a specific segment. This string should contain less than 10 segments.
+ * The segments should be separated by commas (,).
  */
 
 /**
@@ -39,7 +41,13 @@ import join from 'proper-url-join';
  */
 export default (query, config) =>
   client
-    .get(join('/content/v1/search/contents', { query }), config)
+    .get(
+      join('/content/v1/search/contents', {
+        query,
+        queryOptions: { encode: false },
+      }),
+      config,
+    )
     .then(response => response.data)
     .catch(error => {
       throw adaptError(error);


### PR DESCRIPTION
## Description

Add `target.segment` on searchContents function

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
