### PR TITLE
Feat(analytics): add filters validation analytics

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -34,29 +34,7 @@ Object {
 exports[`Omnitracking track events definitions \`Filters Applied\` return should match the snapshot 1`] = `
 Object {
   "filtersApplied": Object {
-    "brands": Array [
-      2765,
-      4062,
-    ],
-    "categories": Array [
-      135973,
-    ],
-    "colors": Array [
-      1,
-    ],
-    "discount": Array [
-      0,
-    ],
-    "gender": Array [
-      0,
-    ],
-    "price": Array [
-      0,
-      1950,
-    ],
-    "sizes": Array [
-      16,
-    ],
+    "filters": "{\\"brands\\":[2765,4062],\\"categories\\":[135973],\\"colors\\":[1],\\"discount\\":[0],\\"gender\\":[0],\\"price\\":[0,1950],\\"sizes\\":[16]}",
   },
   "tid": 2921,
 }
@@ -65,29 +43,7 @@ Object {
 exports[`Omnitracking track events definitions \`Filters Cleared\` return should match the snapshot 1`] = `
 Object {
   "filtersApplied": Object {
-    "brands": Array [
-      2765,
-      4062,
-    ],
-    "categories": Array [
-      135973,
-    ],
-    "colors": Array [
-      1,
-    ],
-    "discount": Array [
-      0,
-    ],
-    "gender": Array [
-      0,
-    ],
-    "price": Array [
-      0,
-      1950,
-    ],
-    "sizes": Array [
-      16,
-    ],
+    "filters": "{\\"brands\\":[2765,4062],\\"categories\\":[135973],\\"colors\\":[1],\\"discount\\":[0],\\"gender\\":[0],\\"price\\":[0,1950],\\"sizes\\":[16]}",
   },
   "tid": 2917,
 }

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -11,7 +11,7 @@ import EventTypes from '../../types/EventTypes';
 import InteractionTypes from '../../types/InteractionTypes';
 import isNil from 'lodash/isNil';
 import PageTypes from '../../types/PageTypes';
-import type { EventData, TrackTypesValues } from '../..';
+import type { EventData, EventProperties, TrackTypesValues } from '../..';
 import type {
   OmnitrackingPageEventsMapper,
   OmnitrackingTrackEventParameters,
@@ -373,6 +373,19 @@ export const pageViewEventTypes = {
 } as const;
 
 /**
+ * Returns the filter properties from an event.
+ *
+ * @param eventProperties - Properties from a track event.
+ *
+ * @returns Object containing the filter properties.
+ */
+const getFilterParametersFromEvent = (eventProperties: EventProperties) => ({
+  filters: eventProperties.filters
+    ? JSON.stringify(eventProperties.filters)
+    : undefined,
+});
+
+/**
  * Events mapper with possible keywords for each event type. This keywords can
  * match both with `window.location.href` or the page name passed via
  * `analytics.page(name, properties)`.
@@ -547,11 +560,11 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
   },
   [EventTypes.FILTERS_APPLIED]: (data: EventData<TrackTypesValues>) => ({
     tid: 2921,
-    filtersApplied: data.properties?.filters,
+    filtersApplied: getFilterParametersFromEvent(data.properties),
   }),
   [EventTypes.FILTERS_CLEARED]: (data: EventData<TrackTypesValues>) => ({
     tid: 2917,
-    filtersApplied: data.properties?.filters,
+    filtersApplied: getFilterParametersFromEvent(data.properties),
   }),
   [EventTypes.INTERACT_CONTENT]: (data: EventData<TrackTypesValues>) => {
     if (data.properties?.interactionType === InteractionTypes.SCROLL) {


### PR DESCRIPTION
## Description

- Add a method to stringify the filters object (this was already being done to GA4 but not for omni).

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
