### PR TITLE
fix: filters validation analytics

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -33,18 +33,14 @@ Object {
 
 exports[`Omnitracking track events definitions \`Filters Applied\` return should match the snapshot 1`] = `
 Object {
-  "filtersApplied": Object {
-    "filters": "{\\"brands\\":[2765,4062],\\"categories\\":[135973],\\"colors\\":[1],\\"discount\\":[0],\\"gender\\":[0],\\"price\\":[0,1950],\\"sizes\\":[16]}",
-  },
+  "filtersApplied": "{\\"brands\\":[2765,4062],\\"categories\\":[135973],\\"colors\\":[1],\\"discount\\":[0],\\"gender\\":[0],\\"price\\":[0,1950],\\"sizes\\":[16]}",
   "tid": 2921,
 }
 `;
 
 exports[`Omnitracking track events definitions \`Filters Cleared\` return should match the snapshot 1`] = `
 Object {
-  "filtersApplied": Object {
-    "filters": "{\\"brands\\":[2765,4062],\\"categories\\":[135973],\\"colors\\":[1],\\"discount\\":[0],\\"gender\\":[0],\\"price\\":[0,1950],\\"sizes\\":[16]}",
-  },
+  "filtersApplied": "{\\"brands\\":[2765,4062],\\"categories\\":[135973],\\"colors\\":[1],\\"discount\\":[0],\\"gender\\":[0],\\"price\\":[0,1950],\\"sizes\\":[16]}",
   "tid": 2917,
 }
 `;

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -379,11 +379,8 @@ export const pageViewEventTypes = {
  *
  * @returns Object containing the filter properties.
  */
-const getFilterParametersFromEvent = (eventProperties: EventProperties) => ({
-  filters: eventProperties.filters
-    ? JSON.stringify(eventProperties.filters)
-    : undefined,
-});
+const getFilterParametersFromEvent = (eventProperties: EventProperties) =>
+  eventProperties.filters ? JSON.stringify(eventProperties.filters) : undefined;
 
 /**
  * Events mapper with possible keywords for each event type. This keywords can


### PR DESCRIPTION
## Description

- Fixed filters validation method. It was returning an object when it should be returning directly the string.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
