### PR TITLE
fix(react): add missing export on vitorino

### DIFF
--- a/packages/react/src/analytics/integrations/Vitorino/index.js
+++ b/packages/react/src/analytics/integrations/Vitorino/index.js
@@ -1,2 +1,2 @@
 export { default } from './Vitorino';
-export * from './Vitorino';
+export { VITORINO_PROVIDERS } from './constants';


### PR DESCRIPTION
## Description

- Add missing export of VITORINO_PROVIDERS.

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
