### PR TITLE
Feat(core): add put bags promo codes endopint

### DIFF
--- a/packages/core/src/bags/client/__fixtures__/putBagPromocodes.fixtures.js
+++ b/packages/core/src/bags/client/__fixtures__/putBagPromocodes.fixtures.js
@@ -1,0 +1,25 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: params => {
+    moxios.stubRequest(
+      join('/api/commerce/v1/bags', params.bagId, 'promocodes'),
+      {
+        method: 'put',
+        response: params.response,
+        status: 200,
+      },
+    );
+  },
+  failure: params => {
+    moxios.stubRequest(
+      join('/api/commerce/v1/bags', params.bagId, 'promocodes'),
+      {
+        method: 'put',
+        response: 'stub error',
+        status: 404,
+      },
+    );
+  },
+};

--- a/packages/core/src/bags/client/__tests__/__snapshots__/putBagPromocodes.test.js.snap
+++ b/packages/core/src/bags/client/__tests__/__snapshots__/putBagPromocodes.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`putBagPromocodes should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/bags/client/__tests__/putBagPromocodes.test.js
+++ b/packages/core/src/bags/client/__tests__/putBagPromocodes.test.js
@@ -1,0 +1,52 @@
+import {
+  mockBagId,
+  mockBagPromocodesData,
+  mockBagPromocodesResponse,
+} from 'tests/__fixtures__/bags';
+import { putBagPromocodes } from '../';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/putBagPromocodes.fixtures';
+import moxios from 'moxios';
+
+describe('putBagPromocodes', () => {
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  const spy = jest.spyOn(client, 'put');
+  const expectedConfig = undefined;
+  const response = mockBagPromocodesResponse;
+  const urlToBeCalled = `/commerce/v1/bags/${mockBagId}/promocodes`;
+
+  it('should handle a client request successfully', async () => {
+    fixtures.success({
+      bagId: mockBagId,
+      response,
+    });
+
+    await expect(
+      putBagPromocodes(mockBagId, mockBagPromocodesData),
+    ).resolves.toBe(response);
+    expect(spy).toHaveBeenCalledWith(
+      urlToBeCalled,
+      mockBagPromocodesData,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure({ bagId: mockBagId, response });
+
+    await expect(
+      putBagPromocodes(mockBagId, mockBagPromocodesData),
+    ).rejects.toMatchSnapshot();
+    expect(spy).toHaveBeenCalledWith(
+      urlToBeCalled,
+      mockBagPromocodesData,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/bags/client/index.js
+++ b/packages/core/src/bags/client/index.js
@@ -19,3 +19,4 @@ export { default as getBagOperations } from './getBagOperations';
 export { default as deleteBagItem } from './deleteBagItem';
 export { default as patchBagItem } from './patchBagItem';
 export { default as postBagItem } from './postBagItem';
+export { default as putBagPromocodes } from './putBagPromocodes';

--- a/packages/core/src/bags/client/putBagPromocodes.js
+++ b/packages/core/src/bags/client/putBagPromocodes.js
@@ -1,0 +1,33 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * @typedef {object} PutBagPromocodesData
+ *
+ * @alias PutBagPromocodesData
+ * @memberof module:bags/client
+ *
+ * @property {Array<string>} promocodes - Promocodes.
+ */
+
+/**
+ * Method responsible for adding promo codes information to the user bag.
+ *
+ * @function putPromocodes
+ * @memberof module:bags/client
+ *
+ * @param {string} id - Universal identifier of the bag.
+ * @param {PutBagPromocodesData} data - Request data.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Promise} Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+export default (id, data, config) =>
+  client
+    .put(join('/commerce/v1/bags', id, 'promocodes'), data, config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/bags/redux/__tests__/reducer.test.js
+++ b/packages/core/src/bags/redux/__tests__/reducer.test.js
@@ -60,6 +60,7 @@ describe('bags redux reducer', () => {
       const expectedState = {
         ...mockState.bag,
         bagOperations: initialState.bagOperations,
+        bagPromocodes: initialState.bagPromocodes,
       };
 
       expect(
@@ -475,6 +476,28 @@ describe('bags redux reducer', () => {
 
       expect(fromReducer.getBagOperationError({ bagOperations })).toEqual(
         bagOperations.error,
+      );
+    });
+  });
+
+  describe('getAreBagPromocodesLoading() selector', () => {
+    it('should return the `bagPromocodes.isLoading` property from a given state', () => {
+      const bagPromocodes = { isLoading: true };
+
+      expect(
+        fromReducer.getAreBagPromocodesLoading({
+          bagPromocodes,
+        }),
+      ).toEqual(bagPromocodes.isLoading);
+    });
+  });
+
+  describe('getBagPromocodesError() selector', () => {
+    it('should return the `bagPromocodes.error` property from a given state', () => {
+      const bagPromocodes = { error: 'Error' };
+
+      expect(fromReducer.getBagPromocodesError({ bagPromocodes })).toEqual(
+        bagPromocodes.error,
       );
     });
   });

--- a/packages/core/src/bags/redux/__tests__/selectors.test.js
+++ b/packages/core/src/bags/redux/__tests__/selectors.test.js
@@ -8,6 +8,7 @@ import {
   mockBagItemId,
   mockBagOperation,
   mockBagOperationId,
+  mockBagPromocodesResponse,
   mockErrorState,
   mockLoadingState,
   mockState,
@@ -522,6 +523,37 @@ describe('bags redux selectors', () => {
       expect(
         selectors.getBagOperationError(mockErrorState, mockBagOperationId),
       ).toBe(expectedResult);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getBagPromocodesError()', () => {
+    it('should get the bag promocodes error property from state', () => {
+      const expectedResult = mockState.bag.bagPromocodes.error;
+      const spy = jest.spyOn(fromBag, 'getBagPromocodesError');
+
+      expect(selectors.getBagPromocodesError(mockState)).toBe(expectedResult);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('areBagPromocodesLoading()', () => {
+    it('should get the bag promocodes loading status from state', () => {
+      const expectedResult = mockState.bag.bagPromocodes.isLoading;
+      const spy = jest.spyOn(fromBag, 'getAreBagPromocodesLoading');
+
+      expect(selectors.areBagPromocodesLoading(mockState)).toBe(expectedResult);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getBagPromocodesInformation()', () => {
+    it('should return all bag promocodes information', () => {
+      const spy = jest.spyOn(fromBag, 'getId');
+
+      expect(selectors.getBagPromocodesInformation(mockState)).toEqual(
+        mockBagPromocodesResponse.promoCodesInformation,
+      );
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/core/src/bags/redux/actionTypes.js
+++ b/packages/core/src/bags/redux/actionTypes.js
@@ -24,6 +24,16 @@ export const DELETE_BAG_ITEM_REQUEST =
 export const DELETE_BAG_ITEM_SUCCESS =
   '@farfetch/blackout-core/DELETE_BAG_ITEM_SUCCESS';
 
+/** Action type dispatched when the set promocodes from bag request fails. */
+export const SET_BAG_PROMOCODES_FAILURE =
+  '@farfetch/blackout-core/SET_BAG_PROMOCODES_FAILURE';
+/** Action type dispatched when the set promocodes from bag request starts. */
+export const SET_BAG_PROMOCODES_REQUEST =
+  '@farfetch/blackout-core/SET_BAG_PROMOCODES_REQUEST';
+/** Action type dispatched when the set promocodes from bag request succeeds. */
+export const SET_BAG_PROMOCODES_SUCCESS =
+  '@farfetch/blackout-core/SET_BAG_PROMOCODES_SUCCESS';
+
 /** Action type dispatched when the get bag request fails. */
 export const GET_BAG_FAILURE = '@farfetch/blackout-core/GET_BAG_FAILURE';
 /** Action type dispatched when the get bag request starts. */

--- a/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doSetBagPromocodes.test.js.snap
+++ b/packages/core/src/bags/redux/actions/__tests__/__snapshots__/doSetBagPromocodes.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doSetBagPromocodes() action creator should create the correct actions for when the set bag item procedure is successful: set bag promocodes success payload 1`] = `
+Object {
+  "payload": Object {
+    "entities": Object {
+      "bagPromocodesInformation": Object {
+        "7894746": Array [
+          Object {
+            "isValid": true,
+            "promoCode": "code-1",
+          },
+        ],
+      },
+    },
+    "result": "7894746",
+  },
+  "type": "@farfetch/blackout-core/SET_BAG_PROMOCODES_SUCCESS",
+}
+`;

--- a/packages/core/src/bags/redux/actions/__tests__/doSetBagPromocodes.test.js
+++ b/packages/core/src/bags/redux/actions/__tests__/doSetBagPromocodes.test.js
@@ -1,0 +1,99 @@
+import { doSetBagPromocodes } from '..';
+import {
+  mockBagId,
+  mockBagPromocodesData,
+  mockBagPromocodesResponse,
+  mockState,
+} from 'tests/__fixtures__/bags';
+import { mockStore } from '../../../../../tests';
+import find from 'lodash/find';
+import reducer, { actionTypes } from '../..';
+import thunk from 'redux-thunk';
+
+const mockMiddlewares = [
+  thunk.withExtraArgument({
+    getOptions: () => ({ productImgQueryParam: '?c=2' }),
+  }),
+];
+const bagMockStore = (state = {}) =>
+  mockStore({ bag: reducer() }, state, mockMiddlewares);
+const expectedConfig = undefined;
+
+describe('doSetBagPromocodes() action creator', () => {
+  let store;
+
+  const setBagPromocodes = jest.fn();
+  const action = doSetBagPromocodes(setBagPromocodes);
+  const payload = {
+    result: mockBagId,
+    entities: {
+      bagPromocodesInformation: {
+        [mockBagId]: mockBagPromocodesResponse.promoCodesInformation,
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    store = bagMockStore(mockState);
+  });
+
+  it('should create the correct actions for when the set bag promocodes procedure fails', async () => {
+    const expectedError = new Error('set bag promocodes error');
+
+    setBagPromocodes.mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(mockBagPromocodesData));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(setBagPromocodes).toHaveBeenCalledTimes(1);
+      expect(setBagPromocodes).toHaveBeenCalledWith(
+        mockBagId,
+        mockBagPromocodesData,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          {
+            type: actionTypes.SET_BAG_PROMOCODES_REQUEST,
+          },
+          {
+            payload: {
+              error: expectedError,
+            },
+            type: actionTypes.SET_BAG_PROMOCODES_FAILURE,
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the set bag item procedure is successful', async () => {
+    setBagPromocodes.mockResolvedValueOnce(mockBagPromocodesResponse);
+    await store.dispatch(action(mockBagPromocodesData));
+
+    const actionResults = store.getActions();
+
+    expect(setBagPromocodes).toHaveBeenCalledTimes(1);
+    expect(setBagPromocodes).toHaveBeenCalledWith(
+      mockBagId,
+      mockBagPromocodesData,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.SET_BAG_PROMOCODES_REQUEST },
+      {
+        payload,
+        type: actionTypes.SET_BAG_PROMOCODES_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, {
+        type: actionTypes.SET_BAG_PROMOCODES_SUCCESS,
+      }),
+    ).toMatchSnapshot('set bag promocodes success payload');
+  });
+});

--- a/packages/core/src/bags/redux/actions/doSetBagPromocodes.js
+++ b/packages/core/src/bags/redux/actions/doSetBagPromocodes.js
@@ -1,0 +1,62 @@
+import { getBagId } from '../selectors';
+import {
+  SET_BAG_PROMOCODES_FAILURE,
+  SET_BAG_PROMOCODES_REQUEST,
+  SET_BAG_PROMOCODES_SUCCESS,
+} from '../actionTypes';
+
+/**
+ * @callback SetBagPromocodesThunkFactory
+ * @param {number} bagId - Bag id.
+ * @param {object} data - Extra data usefull for action meta.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Set promocodes to the current bag.
+ *
+ * @function doSetBagPromocodes
+ * @memberof module:bags/actions
+ *
+ * @param {Function} setBagPromocodes - Set promocodes in in bag client.
+ *
+ * @returns {SetBagPromocodesThunkFactory} Thunk factory.
+ */
+export default setBagPromocodes =>
+  (data, config) =>
+  async (dispatch, getState) => {
+    const state = getState();
+    const bagId = getBagId(state);
+
+    dispatch({
+      type: SET_BAG_PROMOCODES_REQUEST,
+    });
+
+    try {
+      const { promoCodesInformation } = await setBagPromocodes(
+        bagId,
+        data,
+        config,
+      );
+
+      dispatch({
+        payload: {
+          result: bagId,
+          entities: {
+            bagPromocodesInformation: { [bagId]: promoCodesInformation },
+          },
+        },
+        type: SET_BAG_PROMOCODES_SUCCESS,
+      });
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: SET_BAG_PROMOCODES_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/core/src/bags/redux/actions/index.js
+++ b/packages/core/src/bags/redux/actions/index.js
@@ -10,6 +10,7 @@ export { default as doAddBagItem } from './doAddBagItem';
 export { default as doDeleteBagItem } from './doDeleteBagItem';
 export { default as doGetBag } from './doGetBag';
 export { default as doGetBagOperation } from './doGetBagOperation';
+export { default as doSetBagPromocodes } from './doSetBagPromocodes';
 export { default as doUpdateBagItem } from './doUpdateBagItem';
 export { default as reset, resetBagOperationsEntities } from './reset';
 export { default as resetState } from './resetState';

--- a/packages/core/src/bags/redux/middlewares/__tests__/getBagOnSetPromocodesRequestSuccess.test.js
+++ b/packages/core/src/bags/redux/middlewares/__tests__/getBagOnSetPromocodesRequestSuccess.test.js
@@ -1,0 +1,35 @@
+import { doGetBag } from '../../actions';
+import { getBagOnSetPromocodesRequestSuccess } from '..';
+import { mockBagId, mockState } from 'tests/__fixtures__/bags';
+import { mockStore } from '../../../../../tests';
+import { SET_BAG_PROMOCODES_SUCCESS } from '../../actionTypes';
+
+const mockGetBag = jest.fn(() => ({ type: 'foo' }));
+jest.mock('../../actions', () => ({
+  ...jest.requireActual('../../actions'),
+  doGetBag: jest.fn(() => mockGetBag),
+}));
+
+describe('getBagOnSetPromocodesRequestSuccess', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should do nothing if the action is not SET_BAG_PROMOCODES_SUCCESS', () => {
+    const store = mockStore(null, {}, [getBagOnSetPromocodesRequestSuccess]);
+
+    store.dispatch({ type: 'foo' });
+
+    expect(doGetBag).not.toHaveBeenCalled();
+  });
+
+  it('should intercept SET_BAG_PROMOCODES_SUCCESS and get bag', () => {
+    const store = mockStore(null, mockState, [
+      getBagOnSetPromocodesRequestSuccess,
+    ]);
+
+    store.dispatch({
+      type: SET_BAG_PROMOCODES_SUCCESS,
+    });
+
+    expect(mockGetBag).toHaveBeenCalledWith(mockBagId);
+  });
+});

--- a/packages/core/src/bags/redux/middlewares/getBagOnSetPromocodesRequestSuccess.js
+++ b/packages/core/src/bags/redux/middlewares/getBagOnSetPromocodesRequestSuccess.js
@@ -1,0 +1,27 @@
+import { doGetBag } from '../actions';
+import { getBag as getBagClient } from '../../client';
+import { getBagId } from '../selectors';
+import { SET_BAG_PROMOCODES_SUCCESS } from '../actionTypes';
+
+/**
+ * Middleware to fetch the bag of the
+ * newly executed set promocodes request, if successful.
+ *
+ * @function getBagOnSetPromocodesRequestSuccess
+ * @memberof module:bags/middlewares
+ *
+ * @param {object} store - Redux store at the moment.
+ *
+ * @returns {Function} Redux middleware.
+ */
+export default store => next => action => {
+  if (SET_BAG_PROMOCODES_SUCCESS !== action.type) {
+    return next(action);
+  }
+
+  const bagId = getBagId(store.getState());
+  const getBag = doGetBag(getBagClient);
+  store.dispatch(getBag(bagId));
+
+  return next(action);
+};

--- a/packages/core/src/bags/redux/middlewares/index.js
+++ b/packages/core/src/bags/redux/middlewares/index.js
@@ -5,4 +5,5 @@
  * @category Bag
  * @subcategory Middlewares
  */
+export { default as getBagOnSetPromocodesRequestSuccess } from './getBagOnSetPromocodesRequestSuccess';
 export { default as getOperationsOnBagRequestSuccess } from './getOperationsOnBagRequestSuccess';

--- a/packages/core/src/bags/redux/reducer.js
+++ b/packages/core/src/bags/redux/reducer.js
@@ -5,7 +5,7 @@
  */
 import * as actionTypes from './actionTypes';
 import { combineReducers } from 'redux';
-import { createMergedObject } from '../../helpers/redux';
+import { createMergedObject, reducerFactory } from '../../helpers/redux';
 
 const INITIAL_STATE = {
   error: null,
@@ -18,6 +18,10 @@ const INITIAL_STATE = {
   bagOperations: {
     error: {},
     isLoading: {},
+  },
+  bagPromocodes: {
+    error: null,
+    isLoading: false,
   },
 };
 
@@ -153,6 +157,12 @@ const bagOperations = (
   }
 };
 
+const bagPromocodes = reducerFactory(
+  'SET_BAG_PROMOCODES',
+  INITIAL_STATE.bagPromocodes,
+  actionTypes,
+);
+
 export const entitiesMapper = {
   [actionTypes.DELETE_BAG_ITEM_SUCCESS]: (
     state,
@@ -167,7 +177,8 @@ export const entitiesMapper = {
     return newState;
   },
   [actionTypes.RESET_BAG_ENTITIES]: state => {
-    const { bag, bagItems, bagOperations, ...rest } = state;
+    const { bag, bagItems, bagOperations, bagPromocodesInformation, ...rest } =
+      state;
 
     return rest;
   },
@@ -185,6 +196,9 @@ export const getIsBagItemLoading = state => state.bagItems.isLoading;
 export const getItemError = state => state.bagItems.error;
 export const getIsBagOperationLoading = state => state.bagOperations.isLoading;
 export const getBagOperationError = state => state.bagOperations.error;
+export const getAreBagPromocodesLoading = state =>
+  state.bagPromocodes.isLoading;
+export const getBagPromocodesError = state => state.bagPromocodes.error;
 
 const reducer = combineReducers({
   error,
@@ -192,6 +206,7 @@ const reducer = combineReducers({
   isLoading,
   bagItems,
   bagOperations,
+  bagPromocodes,
 });
 
 /**

--- a/packages/core/src/bags/redux/selectors.js
+++ b/packages/core/src/bags/redux/selectors.js
@@ -5,8 +5,8 @@
  */
 import { areBagItemsIdentical, buildBagItem, createBagItemHash } from './utils';
 import { createSelector } from 'reselect';
-import { getEntity, getProduct } from '../../entities/redux/selectors';
 import {
+  getAreBagPromocodesLoading,
   getError,
   getId,
   getIsBagItemLoading,
@@ -14,7 +14,9 @@ import {
   getIsLoading,
   getItemError,
   getBagOperationError as getOperationError,
+  getBagPromocodesError as getPromocodesError,
 } from './reducer';
+import { getEntity, getProduct } from '../../entities/redux/selectors';
 
 /**
  * Retrieves the universal identifier of the current user's bag.
@@ -538,11 +540,74 @@ export const getBagOperations = state =>
  * @returns {boolean} - Whether the given bag operation is loading.
  *
  * @example
- * import { isBagItemLoading } from '@farfetch/blackout-core/bags/redux';
+ * import { isBagOperationLoading } from '@farfetch/blackout-core/bags/redux';
  *
- * const mapStateToProps = (state, { bagItem: { id } }) => ({
- *     isLoading: isBagItemLoading(state, id)
+ * const mapStateToProps = (state, { bagOperation: { bagOperation: { id } } }) => ({
+ *     isLoading: isBagOperationLoading(state, id)
  * });
  */
 export const isBagOperationLoading = (state, bagOperationId) =>
   getIsBagOperationLoading(state.bag)[bagOperationId];
+
+/**
+ * Retrieves the error state of the bag promocodes.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns - Error information, `undefined` if there are no errors.
+ *
+ * @example
+ * ```
+ * import { getBagPromocodesError } from '@farfetch/blackout-core/bags/redux';
+ *
+ * const mapStateToProps = (state) => ({
+ *     error: getBagPromocodesError(state)
+ * });
+ * ```
+ */
+export const getBagPromocodesError = state => getPromocodesError(state.bag);
+
+/**
+ * Retrieves the loading status of bag promocodes.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns - Whether the set bag promocodes is loading.
+ *
+ * @example
+ * ```
+ * import { areBagPromocodesLoading } from '@farfetch/blackout-core/bags/redux';
+ *
+ * const mapStateToProps = (state) => ({
+ *     areLoading: areBagPromocodesLoading(state)
+ * });
+ * ```
+ */
+export const areBagPromocodesLoading = state =>
+  getAreBagPromocodesLoading(state.bag);
+
+/**
+ * Retrieves current promocodes information in bag.
+ *
+ * @function
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {object} - Bag PromoCodes Information.
+ *
+ * @example
+ * import { getBagPromocodesInformation } from '@farfetch/blackout-core/bags/redux';
+ *
+ * const mapStateToProps = state => ({
+ *     bagPromocodesInformation: getBagPromocodesInformation(state)
+ * });
+ */
+export const getBagPromocodesInformation = state => {
+  const bagId = getBagId(state);
+
+  return getEntity(state, 'bagPromocodesInformation', bagId);
+};

--- a/tests/__fixtures__/bags/bag.fixtures.js
+++ b/tests/__fixtures__/bags/bag.fixtures.js
@@ -9,6 +9,17 @@ import { mockPromotionEvaluationId } from '../promotionEvaluations';
 
 export const mockBagId = '7894746';
 export const mockError = 'Unexpected Error';
+export const mockBagPromocodesData = {
+  promocodes: ['code-1'],
+};
+export const mockBagPromocodesResponse = {
+  promoCodesInformation: [
+    {
+      promoCode: 'code-1',
+      isValid: true,
+    },
+  ],
+};
 
 export const mockData = {
   merchant: { id: 1 },
@@ -42,6 +53,10 @@ export const mockInitialState = {
       error: {},
       isLoading: {},
     },
+    bagPromocodes: {
+      error: null,
+      isLoading: false,
+    },
   },
   entities: {
     bag: {},
@@ -64,6 +79,10 @@ export const mockLoadingState = {
       isLoading: {
         [mockBagOperationId]: true,
       },
+    },
+    bagPromocodes: {
+      error: null,
+      isLoading: true,
     },
   },
   entities: {
@@ -92,6 +111,10 @@ export const mockErrorState = {
         [mockBagOperationId]: false,
       },
     },
+    bagPromocodes: {
+      error: { message: 'An unexpected error occurred' },
+      isLoading: false,
+    },
   },
   entities: {
     bag: {},
@@ -114,6 +137,10 @@ export const mockState = {
     bagOperations: {
       isLoading: {},
       error: {},
+    },
+    bagPromocodes: {
+      isLoading: false,
+      error: null,
     },
   },
   entities: {
@@ -183,6 +210,9 @@ export const mockState = {
         ...mockBagOperation,
         id: '101',
       },
+    },
+    bagPromocodesInformation: {
+      [mockBagId]: mockBagPromocodesResponse.promoCodesInformation,
     },
   },
 };


### PR DESCRIPTION
## Description

This PR adds the ability to set promo code in bag (in this moment only **one** promo code can be applied)

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
