### PR TITLE
fix(core): checkout reducer not overwriting address state

### DIFF
--- a/packages/core/src/checkout/redux/__tests__/reducer.test.js
+++ b/packages/core/src/checkout/redux/__tests__/reducer.test.js
@@ -750,6 +750,89 @@ describe('checkout reducer', () => {
         ).toEqual(result);
       });
 
+      it('should reset address state code and name if they are not filled', () => {
+        const result = {
+          checkoutOrders: {
+            1: {
+              checkout: 123,
+              tags: ['NEW_GIFT'],
+              shippingAddress: {
+                state: {},
+              },
+              billingAddress: {
+                state: {},
+              },
+            },
+          },
+        };
+        const state = {
+          checkoutOrders: {
+            1: {
+              checkout: 123,
+              tags: ['GIFT'],
+              shippingAddress: {
+                state: {
+                  code: 'code',
+                  name: 'name',
+                },
+              },
+              billingAddress: {
+                state: {},
+              },
+            },
+          },
+        };
+
+        expect(
+          entitiesMapper[actionTypes.UPDATE_CHECKOUT_SUCCESS](state, {
+            payload: { entities: result, result: 1 },
+            type: actionTypes.UPDATE_CHECKOUT_SUCCESS,
+          }),
+        ).toEqual(result);
+      });
+
+      it('should reset click and collect if it is not filled', () => {
+        const result = {
+          checkoutOrders: {
+            1: {
+              checkout: 123,
+              tags: ['NEW_GIFT'],
+            },
+          },
+        };
+
+        const expectedResult = {
+          checkoutOrders: {
+            1: {
+              checkout: 123,
+              tags: ['NEW_GIFT'],
+              collectPoints: [{ collectPointId: 123 }],
+            },
+          },
+        };
+
+        const state = {
+          checkoutOrders: {
+            1: {
+              checkout: 123,
+              tags: ['GIFT'],
+              clickAndCollect: {
+                collectPointId: 123,
+              },
+              collectPoints: [{ collectPointId: 123 }],
+            },
+          },
+        };
+
+        expect(
+          // @ts-expect-error Simplified state for testing purposes
+          entitiesMapper[actionTypes.UPDATE_CHECKOUT_SUCCESS](state, {
+            payload: { entities: result, result: 1 },
+            type: actionTypes.UPDATE_CHECKOUT_SUCCESS,
+          }),
+        ).toEqual(expectedResult);
+      });
+
       it(`should replace entity checkout child array after ${actionTypes.UPDATE_CHECKOUT_SUCCESS}`, () => {
         const state = {
           checkout: {


### PR DESCRIPTION
## Description

This fixes an issue where the properties `state.code` and `state.name`  in the shipping/billing address of a checkout order would not be cleared in the store if their value was `undefined`.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

No.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
