### PR TITLE
fix(core): refactor server initial state to search content type code

### DIFF
--- a/packages/core/src/contents/redux/actions/__tests__/__snapshots__/doGetContent.test.js.snap
+++ b/packages/core/src/contents/redux/actions/__tests__/__snapshots__/doGetContent.test.js.snap
@@ -4,9 +4,7 @@ exports[`doGetContent() action creator should create the correct actions for whe
 Object {
   "meta": Object {
     "query": Object {
-      "codes": Array [
-        "cttpage,boutiques",
-      ],
+      "codes": "cttpage",
       "contentTypeCode": "pages",
       "environmentCode": "live",
       "spaceCode": "website",
@@ -15,12 +13,11 @@ Object {
   "payload": Object {
     "entities": Object {
       "contentGroups": Object {
-        "pages!cttpage,boutiques!1": Object {
+        "pages!cttpage!1": Object {
           "entries": Array [
-            "1fa65fb0-49bf-43b3-902e-78d104f160a3",
             "01b7783c-1b9d-4d5d-915b-17a30c85082d",
           ],
-          "hash": "pages!cttpage,boutiques!1",
+          "hash": "pages!cttpage!1",
           "number": 1,
           "totalItems": 2,
           "totalPages": 1,
@@ -28,7 +25,7 @@ Object {
       },
       "contents": Object {
         "01b7783c-1b9d-4d5d-915b-17a30c85082d": Object {
-          "code": "boutiques",
+          "code": "cttpage",
           "components": Array [
             Object {
               "components": Array [
@@ -57,30 +54,10 @@ Object {
           },
           "versionId": "8402918c-b859-4b5b-8192-d83809bae1d0",
         },
-        "1fa65fb0-49bf-43b3-902e-78d104f160a3": Object {
-          "code": "cttpage",
-          "components": Array [
-            Object {
-              "content": "",
-              "displayOptions": Object {},
-              "name": "QA HTML Template",
-              "type": "html",
-            },
-          ],
-          "contentTypeCode": "pages",
-          "environmentCode": "live",
-          "id": undefined,
-          "publicationId": "1fa65fb0-49bf-43b3-902e-78d104f160a3",
-          "spaceCode": "website",
-          "target": Object {
-            "contentzone": "10674",
-          },
-          "versionId": "914480a1-21a3-4bb4-8670-40ab113b1a3a",
-        },
       },
     },
-    "hash": "pages!cttpage,boutiques!1",
-    "result": "pages!cttpage,boutiques!1",
+    "hash": "pages!cttpage!1",
+    "result": "pages!cttpage!1",
   },
   "type": "@farfetch/blackout-core/GET_CONTENT_SUCCESS",
 }

--- a/packages/core/src/contents/redux/serverInitialState.js
+++ b/packages/core/src/contents/redux/serverInitialState.js
@@ -30,13 +30,18 @@ export default ({ model }) => {
   const slugNormalized = stripSlugSubfolderJsonTrue(url.pathname, subfolder);
 
   const contents = searchContentRequests.reduce((acc, item) => {
-    const {
-      filters: { codes, contentTypeCode },
-      searchResponse,
-    } = item;
+    const { searchResponse } = item;
 
+    if (searchResponse.entries.length === 0) return acc;
+
+    const contentTypeCode = searchResponse.entries[0].contentTypeCode;
+    const codes = searchResponse.entries[0].code;
     const code = contentTypeCode === 'commerce_pages' ? slugNormalized : codes;
-    const hash = buildContentGroupHash({ codes: code, contentTypeCode });
+    const hash = buildContentGroupHash({
+      codes: code,
+      contentTypeCode,
+    });
+
     const { entities } = {
       ...normalize({ hash, ...searchResponse }, contentGroup),
     };

--- a/packages/react/src/content/hooks/__tests__/__fixtures__/Page.fixtures.js
+++ b/packages/react/src/content/hooks/__tests__/__fixtures__/Page.fixtures.js
@@ -2,14 +2,14 @@ import { contentQuery, params } from 'tests/__fixtures__/contents';
 import React from 'react';
 import usePage from '../../usePage';
 
-const slug = ['cttpage,boutiques'];
+const slug = 'cttpage';
 
 export const Page = () => {
   const { page, isLoading, error, resetContent, fetchContent } = usePage(
     slug,
     params,
   );
-  const pageTitle = page?.[1]?.components?.[0]?.components?.[0]?.fields?.title;
+  const pageTitle = page?.[0]?.components?.[0]?.components?.[0]?.fields?.title;
 
   if (isLoading) {
     return <span data-test="page-loading">Loading...</span>;

--- a/packages/react/src/content/hooks/__tests__/__snapshots__/useContentType.test.js.snap
+++ b/packages/react/src/content/hooks/__tests__/__snapshots__/useContentType.test.js.snap
@@ -27,12 +27,12 @@ exports[`useContentType should render with the state and selected content type a
     <h1
       data-test="contentType-title"
     >
-      Career
+      Career Page Title
     </h1>
     <div
       data-test="contentType-description"
     >
-      &lt;p&gt;Career test&lt;/p&gt;
+      &lt;p&gt;Here you can add some text to explain the Career&lt;/p&gt;
     </div>
   </div>
 </div>

--- a/packages/react/src/content/hooks/__tests__/useContentType.test.js
+++ b/packages/react/src/content/hooks/__tests__/useContentType.test.js
@@ -23,7 +23,7 @@ describe('useContentType', () => {
   afterEach(cleanup);
 
   it('should render with the state and selected content type', () => {
-    const { container, getByTestId } = wrap(<ContentType codes={null} />)
+    const { container, getByTestId } = wrap(<ContentType codes="career-test" />)
       .withStore(expectedNormalizedPayload)
       .render();
 
@@ -37,19 +37,21 @@ describe('useContentType', () => {
   });
 
   it('should render with the state and selected content type and code', () => {
-    const { container, getByTestId } = wrap(<ContentType codes="test-career" />)
+    const { container, getByTestId } = wrap(<ContentType codes="career-test" />)
       .withStore(expectedNormalizedPayload)
       .render();
 
-    expect(getByTestId('contentType-title').textContent).toBe('Career');
+    expect(getByTestId('contentType-title').textContent).toBe(
+      'Career Page Title',
+    );
     expect(getByTestId('contentType-description').textContent).toBe(
-      '<p>Career test</p>',
+      '<p>Here you can add some text to explain the Career</p>',
     );
     expect(container).toMatchSnapshot();
   });
 
   it('should call `fetchContentType` to dispatch a custom content type request', () => {
-    const { queryByTestId } = wrap(<ContentType codes={null} />)
+    const { queryByTestId } = wrap(<ContentType codes="career-test" />)
       .withStore(mockContentsInitialState)
       .render();
 
@@ -58,7 +60,7 @@ describe('useContentType', () => {
   });
 
   it('should render loading content for a custom content type', () => {
-    const { getByTestId } = wrap(<ContentType />)
+    const { getByTestId } = wrap(<ContentType codes="career-test" />)
       .withStore(mockContentsLoadingState)
       .render();
 
@@ -66,7 +68,7 @@ describe('useContentType', () => {
   });
 
   it('should render error content for a custom content type', () => {
-    const { getByTestId } = wrap(<ContentType />)
+    const { getByTestId } = wrap(<ContentType codes="career-test" />)
       .withStore(mockContentsErrorState)
       .render();
 

--- a/tests/__fixtures__/contents/contents.fixtures.js
+++ b/tests/__fixtures__/contents/contents.fixtures.js
@@ -3,7 +3,7 @@ import { buildContentGroupHash } from '@farfetch/blackout-core/contents/utils';
 export const contentQuery = {
   spaceCode: 'website',
   environmentCode: 'live',
-  codes: ['cttpage,boutiques'],
+  codes: 'cttpage',
   contentTypeCode: 'pages',
 };
 
@@ -21,16 +21,10 @@ export const navbarsQuery = {
   contentTypeCode: 'navbars',
 };
 
-export const contentTypeQuery = {
-  spaceCode: 'website',
-  environmentCode: 'live',
-  contentTypeCode: 'careers',
-};
-
 export const contentTypeQueryWithCodes = {
   spaceCode: 'website',
   environmentCode: 'live',
-  codes: 'test-career',
+  codes: 'career-test',
   contentTypeCode: 'careers',
 };
 
@@ -42,7 +36,6 @@ export const params = {
 export const contentHash = buildContentGroupHash(contentQuery);
 export const widgetHash = buildContentGroupHash(widgetQuery);
 export const navbarsHash = buildContentGroupHash(navbarsQuery);
-export const contentTypeHash = buildContentGroupHash(contentTypeQuery);
 export const contentTypeHashWithCodes = buildContentGroupHash(
   contentTypeQueryWithCodes,
 );
@@ -53,33 +46,13 @@ export const mockContents = {
   totalItems: 2,
   entries: [
     {
-      publicationId: '1fa65fb0-49bf-43b3-902e-78d104f160a3',
-      versionId: '914480a1-21a3-4bb4-8670-40ab113b1a3a',
-      spaceCode: 'website',
-      contentTypeCode: 'pages',
-      environmentCode: 'live',
-      id: undefined,
-      code: 'cttpage',
-      target: {
-        contentzone: '10674',
-      },
-      components: [
-        {
-          type: 'html',
-          content: '',
-          name: 'QA HTML Template',
-          displayOptions: {},
-        },
-      ],
-    },
-    {
       publicationId: '01b7783c-1b9d-4d5d-915b-17a30c85082d',
       versionId: '8402918c-b859-4b5b-8192-d83809bae1d0',
       spaceCode: 'website',
       contentTypeCode: 'pages',
       environmentCode: 'live',
       id: undefined,
-      code: 'boutiques',
+      code: 'cttpage',
       target: {
         contentzone: '10674',
       },
@@ -285,7 +258,7 @@ export const mockModel = {
     {
       filters: {
         spaceCode: 'website',
-        codes: ['cttpage', 'boutiques'],
+        codes: 'cttpage',
         contentTypeCode: 'pages',
         environmentCode: 'live',
         sort: 'publicationDate:desc',
@@ -321,18 +294,7 @@ export const mockModel = {
       },
       searchResponse: mockNavbars,
     },
-    {
-      filters: {
-        spaceCode: 'website',
-        contentTypeCode: 'careers',
-        environmentCode: 'live',
-        sort: 'publicationDate:desc',
-        target: {},
-        searchTags: [],
-        metadataCustom: {},
-      },
-      searchResponse: mockContentType,
-    },
+
     {
       filters: {
         spaceCode: 'website',
@@ -348,7 +310,7 @@ export const mockModel = {
         number: 1,
         totalItems: 1,
         totalPages: 1,
-        entries: [mockContentType.entries[1]],
+        entries: [mockContentType.entries[0]],
       },
     },
   ],
@@ -367,10 +329,7 @@ export const expectedNormalizedPayload = {
         number: 1,
         totalPages: 1,
         totalItems: 2,
-        entries: [
-          mockContents.entries[0].publicationId,
-          mockContents.entries[1].publicationId,
-        ],
+        entries: [mockContents.entries[0].publicationId],
       },
       [widgetHash]: {
         hash: widgetHash,
@@ -386,30 +345,17 @@ export const expectedNormalizedPayload = {
         totalItems: 1,
         entries: [mockNavbars.entries[0].publicationId],
       },
-      [contentTypeHash]: {
-        hash: contentTypeHash,
-        number: 1,
-        totalPages: 1,
-        totalItems: 2,
-        entries: [
-          mockContentType.entries[0].publicationId,
-          mockContentType.entries[1].publicationId,
-        ],
-      },
       [contentTypeHashWithCodes]: {
         hash: contentTypeHashWithCodes,
         number: 1,
         totalPages: 1,
         totalItems: 1,
-        entries: [mockContentType.entries[1].publicationId],
+        entries: [mockContentType.entries[0].publicationId],
       },
     },
     contents: {
       [mockContents.entries[0].publicationId]: {
         ...mockContents.entries[0],
-      },
-      [mockContents.entries[1].publicationId]: {
-        ...mockContents.entries[1],
       },
       [mockWidget.entries[0].publicationId]: {
         ...mockWidget.entries[0],
@@ -420,17 +366,13 @@ export const expectedNormalizedPayload = {
       [mockContentType.entries[0].publicationId]: {
         ...mockContentType.entries[0],
       },
-      [mockContentType.entries[1].publicationId]: {
-        ...mockContentType.entries[1],
-      },
     },
   },
   contents: {
     isLoading: {
-      'careers!all!1': false,
-      'careers!test-career!1': false,
+      'careers!career-test!1': false,
       'navbars!footer!1': false,
-      'pages!cttpage,boutiques!1': false,
+      'pages!cttpage!1': false,
       'widgets!newsletter-terms-and-conditions-widget!1': false,
     },
     error: {},
@@ -460,9 +402,9 @@ export const mockContentsLoadingState = {
   entities: {},
   contents: {
     isLoading: {
-      'careers!all!1': true,
+      'careers!career-test!1': true,
       'navbars!footer!1': true,
-      'pages!cttpage,boutiques!1': true,
+      'pages!cttpage!1': true,
       'widgets!newsletter-terms-and-conditions-widget!1': true,
     },
     error: {},
@@ -473,19 +415,19 @@ export const mockContentsErrorState = {
   entities: {},
   contents: {
     isLoading: {
-      'careers!all!1': false,
+      'careers!career-test!1': false,
       'navbars!footer!1': false,
-      'pages!cttpage,boutiques!1': false,
+      'pages!cttpage!1': false,
       'widgets!newsletter-terms-and-conditions-widget!1': false,
     },
     error: {
-      'careers!all!1': {
+      'careers!career-test!1': {
         message: 'Error',
       },
       'navbars!footer!1': {
         message: 'Error',
       },
-      'pages!cttpage,boutiques!1': {
+      'pages!cttpage!1': {
         message: 'Error',
       },
       'widgets!newsletter-terms-and-conditions-widget!1': {


### PR DESCRIPTION
## Description

- Changing serverInitialState `contentTypeCode` and `codes` params to depend on `seachResponse` entries. 

Note:
- Also, in discussing with the BE, it was found that the codes in the initial state only come with only one code. That why the changes in the `contents.fixtures`.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
