### PR TITLE
fix(redux): checkout reducer not overwriting address state

### DIFF
--- a/packages/redux/src/checkout/__tests__/reducer.test.ts
+++ b/packages/redux/src/checkout/__tests__/reducer.test.ts
@@ -11,6 +11,8 @@ import {
   mockCheckoutDetailsEntity,
   mockCheckoutOrderItemEntity,
   mockCheckoutOrderItemProductsEntity,
+  mockCheckoutState,
+  mockCollectPoint,
   mockCollectPointsResponse,
   mockDeliveryBundlesResponse,
   mockGetOperationActionPayload,
@@ -1294,6 +1296,7 @@ describe('checkout reducer', () => {
       const result = {
         checkoutOrders: {
           1: {
+            ...mockCheckoutState.entities.checkoutOrders[checkoutOrderId],
             checkout: 123,
             tags: ['NEW_GIFT'],
           },
@@ -1302,13 +1305,14 @@ describe('checkout reducer', () => {
       const state = {
         checkoutOrders: {
           1: {
+            ...mockCheckoutState.entities.checkoutOrders[checkoutOrderId],
             checkout: 123,
             tags: ['GIFT'],
           },
         },
       };
 
-      it.each([
+      it.each<keyof typeof entitiesMapper>([
         actionTypes.CREATE_CHECKOUT_ORDER_SUCCESS,
         actionTypes.SET_CHECKOUT_ORDER_PROMOCODE_SUCCESS,
         actionTypes.FETCH_CHECKOUT_ORDER_SUCCESS,
@@ -1317,13 +1321,96 @@ describe('checkout reducer', () => {
         actionTypes.SET_CHECKOUT_ORDER_TAGS_SUCCESS,
       ])('should handle %s action type', actionType => {
         expect(
-          // @ts-expect-error
           entitiesMapper[actionType](state, {
             meta: { id: 1 },
             payload: { entities: result },
             type: actionType,
           }),
         ).toEqual(result);
+      });
+
+      it('should reset address state code and name if they are not filled', () => {
+        const result = {
+          checkoutOrders: {
+            1: {
+              checkout: 123,
+              tags: ['NEW_GIFT'],
+              shippingAddress: {
+                state: {},
+              },
+              billingAddress: {
+                state: {},
+              },
+            },
+          },
+        };
+        const state = {
+          checkoutOrders: {
+            1: {
+              checkout: 123,
+              tags: ['GIFT'],
+              shippingAddress: {
+                state: {
+                  code: 'code',
+                  name: 'name',
+                },
+              },
+              billingAddress: {
+                state: {},
+              },
+            },
+          },
+        };
+
+        expect(
+          // @ts-expect-error Simplified state for testing purposes
+          entitiesMapper[actionTypes.UPDATE_CHECKOUT_ORDER_SUCCESS](state, {
+            payload: { entities: result, result: 1 },
+            type: actionTypes.UPDATE_CHECKOUT_ORDER_SUCCESS,
+          }),
+        ).toEqual(result);
+      });
+
+      it('should reset click and collect if it is not filled', () => {
+        const result = {
+          checkoutOrders: {
+            1: {
+              checkout: 123,
+              tags: ['NEW_GIFT'],
+            },
+          },
+        };
+
+        const expectedResult = {
+          checkoutOrders: {
+            1: {
+              checkout: 123,
+              tags: ['NEW_GIFT'],
+              collectPoints: [mockCollectPoint],
+            },
+          },
+        };
+
+        const state = {
+          checkoutOrders: {
+            1: {
+              checkout: 123,
+              tags: ['GIFT'],
+              clickAndCollect: {
+                collectPointId: 123,
+              },
+              collectPoints: [mockCollectPoint],
+            },
+          },
+        };
+
+        expect(
+          // @ts-expect-error Simplified state for testing purposes
+          entitiesMapper[actionTypes.UPDATE_CHECKOUT_ORDER_SUCCESS](state, {
+            payload: { entities: result, result: 1 },
+            type: actionTypes.UPDATE_CHECKOUT_ORDER_SUCCESS,
+          }),
+        ).toEqual(expectedResult);
       });
 
       it(`should replace entity checkout child array after ${actionTypes.UPDATE_CHECKOUT_ORDER_SUCCESS}`, () => {

--- a/packages/redux/src/checkout/reducer.ts
+++ b/packages/redux/src/checkout/reducer.ts
@@ -4,6 +4,7 @@ import { LOGOUT_SUCCESS } from '../users/authentication/actionTypes';
 import assignWith from 'lodash/assignWith';
 import createMergedObject from '../helpers/createMergedObject';
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 import mergeWith from 'lodash/mergeWith';
 import produce from 'immer';
 import reducerFactory, {
@@ -168,24 +169,72 @@ const convertCheckoutOrder = (
     checkoutOrders: Record<string, CheckoutOrderEntity>;
   };
 
-  const shouldResetClickAndCollect =
-    !!get(mergedState, `checkoutOrders[${result}].clickAndCollect`) &&
-    !get(entities, `checkoutOrders[${result}].clickAndCollect`);
+  const mergedClickAndCollectState = get(
+    mergedState,
+    `checkoutOrders[${result}].clickAndCollect`,
+  );
+  const receivedClickAndCollectState = get(
+    entities,
+    `checkoutOrders[${result}].clickAndCollect`,
+  );
+  const shouldReplaceClickAndCollect = !isEqual(
+    mergedClickAndCollectState,
+    receivedClickAndCollectState,
+  );
 
-  if (!shouldResetClickAndCollect) {
-    return mergedState;
-  }
+  const mergedShippingAddressState = get(
+    mergedState,
+    `checkoutOrders[${result}].shippingAddress.state`,
+  );
+  const receivedShippingAddressState = get(
+    entities,
+    `checkoutOrders[${result}].shippingAddress.state`,
+  );
+  const shouldReplaceShippingState = !isEqual(
+    mergedShippingAddressState,
+    receivedShippingAddressState,
+  );
 
-  return {
-    ...mergedState,
-    checkoutOrders: {
-      ...mergedState.checkoutOrders,
-      [result]: {
-        collectpoints: mergedState.checkoutOrders[result]?.collectpoints,
-        ...entities?.checkoutOrders[result],
-      },
-    },
-  };
+  const mergedBillingAddressState = get(
+    mergedState,
+    `checkoutOrders[${result}].billingAddress.state`,
+  );
+  const receivedBillingAddressState = get(
+    entities,
+    `checkoutOrders[${result}].billingAddress.state`,
+  );
+  const shouldReplaceBillingState = !isEqual(
+    mergedBillingAddressState,
+    receivedBillingAddressState,
+  );
+
+  return produce(mergedState, draftState => {
+    const checkoutOrder = draftState?.checkoutOrders?.[result];
+
+    if (
+      !checkoutOrder ||
+      (!shouldReplaceClickAndCollect &&
+        !shouldReplaceBillingState &&
+        !shouldReplaceShippingState)
+    ) {
+      return;
+    }
+
+    if (shouldReplaceClickAndCollect) {
+      checkoutOrder.clickAndCollect =
+        entities.checkoutOrders[result]?.clickAndCollect;
+    }
+
+    if (shouldReplaceShippingState) {
+      checkoutOrder.shippingAddress.state =
+        entities.checkoutOrders[result]?.shippingAddress?.state;
+    }
+
+    if (shouldReplaceBillingState) {
+      checkoutOrder.billingAddress.state =
+        entities.checkoutOrders[result]?.billingAddress?.state;
+    }
+  });
 };
 
 const mergeCheckoutOrder = (


### PR DESCRIPTION
## Description

This fixes an issue where the properties `state.code` and `state.name` in the shipping/billing address of a checkout order would not be cleared in the store if their value was `undefined`.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
