### PR TITLE
fix(redux): refactor server initial state to search content type code

### DIFF
--- a/packages/redux/src/contents/serverInitialState.ts
+++ b/packages/redux/src/contents/serverInitialState.ts
@@ -23,12 +23,17 @@ const serverInitialState: ServerInitialState = ({ model }) => {
   const { searchContentRequests, slug, seoMetadata, subfolder } = model;
 
   const contents = searchContentRequests.reduce((acc, item) => {
-    const {
-      filters: { codes, contentTypeCode },
-      searchResponse,
-    } = item;
+    const { searchResponse } = item;
+    const firstSearchResponseItem = searchResponse.entries[0];
 
-    const hash = generateContentHash({ codes, contentTypeCode });
+    if (!firstSearchResponseItem) {
+      return acc;
+    }
+
+    const hash = generateContentHash({
+      codes: firstSearchResponseItem.code,
+      contentTypeCode: firstSearchResponseItem.contentTypeCode,
+    });
 
     const { entities, result } = {
       ...normalize({ hash, ...searchResponse }, contentEntries),

--- a/tests/__fixtures__/contents/contents.fixtures.mts
+++ b/tests/__fixtures__/contents/contents.fixtures.mts
@@ -31,23 +31,16 @@ export const navbarsQuery = {
   contentTypeCode: 'navbars',
 };
 
-export const contentTypeQuery = {
-  spaceCode: 'website',
-  environmentCode: 'live',
-  contentTypeCode: 'careers',
-};
-
 export const contentTypeQueryWithCodes = {
   spaceCode: 'website',
   environmentCode: 'live',
-  codes: 'test-career',
+  codes: 'career-test',
   contentTypeCode: 'careers',
 };
 
 export const contentHash = generateContentHash(contentQuery);
 export const widgetHash = generateContentHash(widgetQuery);
 export const navbarsHash = generateContentHash(navbarsQuery);
-export const contentTypeHash = generateContentHash(contentTypeQuery);
 export const contentTypeHashWithCodes = generateContentHash(
   contentTypeQueryWithCodes,
 );
@@ -326,19 +319,7 @@ export const mockModel = {
     {
       filters: {
         spaceCode: 'website',
-        contentTypeCode: 'careers',
-        environmentCode: 'live',
-        sort: 'publicationDate:desc',
-        target: {},
-        searchTags: [],
-        metadataCustom: {},
-      },
-      searchResponse: mockContentType,
-    },
-    {
-      filters: {
-        spaceCode: 'website',
-        codes: 'test-career',
+        codes: 'career-test',
         contentTypeCode: 'careers',
         environmentCode: 'live',
         sort: 'publicationDate:desc',
@@ -350,7 +331,7 @@ export const mockModel = {
         number: 1,
         totalItems: 1,
         totalPages: 1,
-        entries: [mockContentType.entries[1]],
+        entries: [mockContentType.entries[0]],
       },
     },
   ],
@@ -436,26 +417,11 @@ export const expectedNormalizedPayload = {
           totalPages: 1,
         },
       },
-      [contentTypeHash]: {
-        error: null,
-        isLoading: false,
-        result: {
-          // We will need to fix this duplication when the codes is 'all'
-          entries: [
-            '6fc6f3c1-ae2b-44d3-abec-54f0b679b19f',
-            '7255bc1f-517f-4c7d-bfdb-6e10fe037c68',
-          ],
-          hash: contentTypeHash,
-          number: 1,
-          totalItems: 2,
-          totalPages: 1,
-        },
-      },
       [contentTypeHashWithCodes]: {
         error: null,
         isLoading: false,
         result: {
-          entries: ['7255bc1f-517f-4c7d-bfdb-6e10fe037c68'],
+          entries: ['6fc6f3c1-ae2b-44d3-abec-54f0b679b19f'],
           hash: contentTypeHashWithCodes,
           number: 1,
           totalItems: 1,
@@ -492,10 +458,6 @@ export const expectedNormalizedPayload = {
       '6fc6f3c1-ae2b-44d3-abec-54f0b679b19f': {
         ...(mockContentType.entries[0] as ContentEntry),
         publicationDate: 1589466373692,
-      } as ContentsEntity,
-      '7255bc1f-517f-4c7d-bfdb-6e10fe037c68': {
-        ...(mockContentType.entries[1] as ContentEntry),
-        publicationDate: 1589217764375,
       } as ContentsEntity,
     },
   },


### PR DESCRIPTION
## Description

- Changing serverInitialState `contentTypeCode` and `codes` params to depend on `seachResponse` entries. 

Note:
- Also, in discussing with the BE, it was found that the codes in the initial state only come with only one code. That why the changes in the `contents.fixtures`.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies
None

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
