### PR TITLE
fix: add "type": "module" to all packages

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -4,6 +4,7 @@
   "description": "Centralized and agnostic way of tracking data with built-in integrations",
   "license": "MIT",
   "main": "src/index.ts",
+  "type": "module",
   "sideEffects": false,
   "scripts": {
     "build": "yarn build:transpile && yarn build:types",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,6 +4,7 @@
   "description": "Clients to connect to the Farfetch Platform Solutions' services",
   "license": "MIT",
   "main": "src/index.ts",
+  "type": "module",
   "sideEffects": false,
   "scripts": {
     "build": "yarn build:transpile && yarn build:types",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,6 +4,7 @@
   "description": "React components, hooks and other tools filled with business logic to help using the Farfetch Platform Solutions' services in web or native e-commerce apps",
   "license": "MIT",
   "main": "./src/index.ts",
+  "type": "module",
   "sideEffects": false,
   "scripts": {
     "build": "yarn build:transpile && yarn build:types",

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "src/index.ts",
   "sideEffects": false,
+  "type": "module",
   "scripts": {
     "build": "yarn build:transpile && yarn build:types",
     "build:transpile": "../../scripts/transpile.sh",


### PR DESCRIPTION
## Description

This adds "type": "module" to all package.json files of all packages that was missing. This will broad the compatibility of the packages with other frameworks like fastify.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
