### PR TITLE
feat(core|redux): add get return workflow endpoint

### DIFF
--- a/packages/core/src/returns/client/__fixtures__/getReturnWorkflow.fixtures.js
+++ b/packages/core/src/returns/client/__fixtures__/getReturnWorkflow.fixtures.js
@@ -1,0 +1,20 @@
+import get from 'lodash/get';
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: params => {
+    moxios.stubRequest(join('/api/account/v1/returns', params.id, 'workflow'), {
+      method: 'get',
+      response: get(params, 'response'),
+      status: 200,
+    });
+  },
+  failure: params => {
+    moxios.stubRequest(join('/api/account/v1/returns', params.id, 'workflow'), {
+      method: 'get',
+      response: 'stub error',
+      status: 404,
+    });
+  },
+};

--- a/packages/core/src/returns/client/__tests__/__snapshots__/getReturnWorkflow.test.js.snap
+++ b/packages/core/src/returns/client/__tests__/__snapshots__/getReturnWorkflow.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getReturnWorkflow should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/returns/client/__tests__/getReturnWorkflow.test.js
+++ b/packages/core/src/returns/client/__tests__/getReturnWorkflow.test.js
@@ -1,0 +1,42 @@
+import { getReturnWorkflow } from '..';
+import client from '../../../helpers/client';
+import fixture from '../__fixtures__/getReturnWorkflow.fixtures';
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+describe('getReturnWorkflow', () => {
+  const spy = jest.spyOn(client, 'get');
+  const id = '123456';
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = {};
+
+    fixture.success({ id, response });
+
+    expect.assertions(2);
+    await expect(getReturnWorkflow(id)).resolves.toBe(response);
+    expect(spy).toHaveBeenCalledWith(
+      join(`/account/v1/returns/${id}/workflow`),
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixture.failure({ id });
+
+    expect.assertions(2);
+    await expect(getReturnWorkflow(id)).rejects.toMatchSnapshot();
+    expect(spy).toHaveBeenCalledWith(
+      join(`/account/v1/returns/${id}/workflow`),
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/returns/client/getReturnWorkflow.js
+++ b/packages/core/src/returns/client/getReturnWorkflow.js
@@ -1,0 +1,24 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * Method responsible for obtaining the workflow of a specific return.
+ *
+ * @function getReturnWorkflow
+ * @memberof module:returns/client
+ *
+ * @param {string} id - Return identifier.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Promise} Promise that will resolve when the call to
+ * the endpoint finishes.
+ */
+
+export default (id, config) =>
+  client
+    .get(join('/account/v1/returns', id, 'workflow'), config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/returns/client/index.js
+++ b/packages/core/src/returns/client/index.js
@@ -16,3 +16,4 @@ export { default as getPickupRescheduleRequests } from './getPickupRescheduleReq
 export { default as postPickupRescheduleRequests } from './postPickupRescheduleRequests';
 export { default as getPickupRescheduleRequest } from './getPickupRescheduleRequest';
 export { default as getUserReturns } from './getUserReturns';
+export { default as getReturnWorkflow } from './getReturnWorkflow';


### PR DESCRIPTION
## Description

This adds client and redux action for new getReturnWorkflow endpoint.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
