### PR TITLE
fix(redux): fix useBag hook actions

### DIFF
--- a/packages/react/src/bags/hooks/useBag.ts
+++ b/packages/react/src/bags/hooks/useBag.ts
@@ -82,6 +82,8 @@ const useBag = (options: UseBagOptions = {}) => {
         throw new AddUpdateItemBagError(-1);
       }
 
+      const itemsRefreshed = getBagItems(getState());
+
       // Iterate through the stock of different merchants
       for (const { merchantId, quantity: merchantQuantity } of size.stock) {
         // If there is no quantity on this merchant jump to the next one
@@ -104,7 +106,7 @@ const useBag = (options: UseBagOptions = {}) => {
         // by comparing the bag items' hash
         const hash = generateBagItemHash(requestData);
 
-        const itemInBag = items?.find(
+        const itemInBag = itemsRefreshed?.find(
           item => generateBagItemHash(item) === hash,
         );
 
@@ -152,7 +154,7 @@ const useBag = (options: UseBagOptions = {}) => {
         throw new AddUpdateItemBagError(3);
       }
     },
-    [addBagItem, items, updateBagItem],
+    [addBagItem, getState, updateBagItem],
   );
 
   const addItem = useCallback(
@@ -455,7 +457,9 @@ const useBag = (options: UseBagOptions = {}) => {
       },
       metadata?: BagItemActionMetadata,
     ) => {
-      const bagItem = items.find(item => item.id === bagItemId);
+      const itemsRefreshed = getBagItems(getState());
+
+      const bagItem = itemsRefreshed.find(item => item.id === bagItemId);
 
       if (!bagItem || !bagItem.product) {
         throw new BagItemNotFoundError();
@@ -478,7 +482,7 @@ const useBag = (options: UseBagOptions = {}) => {
 
       return;
     },
-    [handleFullUpdate, handleQuantityChange, handleSizeChange, items],
+    [getState, handleFullUpdate, handleQuantityChange, handleSizeChange],
   );
 
   const data = useMemo(() => {

--- a/packages/redux/src/bags/actions/factories/addBagItemFactory.ts
+++ b/packages/redux/src/bags/actions/factories/addBagItemFactory.ts
@@ -69,7 +69,7 @@ const addBagItemFactory =
         { items: [bagItemSchema] },
       );
 
-      dispatch({
+      await dispatch({
         payload: normalizedBag,
         type: actionTypes.ADD_BAG_ITEM_SUCCESS,
         meta: {

--- a/packages/redux/src/bags/actions/factories/fetchBagFactory.ts
+++ b/packages/redux/src/bags/actions/factories/fetchBagFactory.ts
@@ -44,7 +44,7 @@ const fetchBagFactory =
         { items: [bagItemSchema] },
       );
 
-      dispatch({
+      await dispatch({
         payload: normalizedBag,
         type: actionTypes.FETCH_BAG_SUCCESS,
       });

--- a/packages/redux/src/bags/actions/factories/fetchBagOperationFactory.ts
+++ b/packages/redux/src/bags/actions/factories/fetchBagOperationFactory.ts
@@ -33,7 +33,7 @@ const fetchBagOperationFactory =
 
       const result = await getBagOperation(bagId, bagOperationId, config);
 
-      dispatch({
+      await dispatch({
         payload: { ...normalize(result, bagOperationSchema) },
         meta: { bagOperationId },
         type: FETCH_BAG_OPERATION_SUCCESS,

--- a/packages/redux/src/bags/actions/factories/removeBagItemFactory.ts
+++ b/packages/redux/src/bags/actions/factories/removeBagItemFactory.ts
@@ -63,7 +63,7 @@ const removeBagItemFactory =
         { items: [bagItemSchema] },
       );
 
-      dispatch({
+      await dispatch({
         payload: normalizedBag,
         type: actionTypes.REMOVE_BAG_ITEM_SUCCESS,
         meta: {

--- a/packages/redux/src/bags/actions/factories/setBagPromocodesFactory.ts
+++ b/packages/redux/src/bags/actions/factories/setBagPromocodesFactory.ts
@@ -27,7 +27,7 @@ const setBagPromocodesFactory =
 
       const result = await putBagPromocodes(bagId, data, config);
 
-      dispatch({
+      await dispatch({
         payload: {
           result: bagId,
           entities: {

--- a/packages/redux/src/bags/actions/factories/updateBagItemFactory.ts
+++ b/packages/redux/src/bags/actions/factories/updateBagItemFactory.ts
@@ -67,7 +67,7 @@ const updateBagItemFactory =
         { items: [bagItemSchema] },
       );
 
-      dispatch({
+      await dispatch({
         payload: normalizedBag,
         type: actionTypes.UPDATE_BAG_ITEM_SUCCESS,
         meta: {

--- a/packages/redux/src/users/authentication/actions/factories/fetchGuestUserFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/fetchGuestUserFactory.ts
@@ -29,7 +29,7 @@ const fetchGuestUserFactory =
         result: result.id,
       };
 
-      dispatch({
+      await dispatch({
         payload: userEntity,
         type: actionTypes.FETCH_GUEST_USER_SUCCESS,
       });

--- a/packages/redux/src/users/authentication/actions/factories/fetchUserFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/fetchUserFactory.ts
@@ -29,7 +29,7 @@ const fetchUserFactory =
         result: result.id,
       };
 
-      dispatch({
+      await dispatch({
         payload: userEntity,
         type: actionTypes.FETCH_USER_SUCCESS,
         meta: config,

--- a/packages/redux/src/users/authentication/actions/factories/loginFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/loginFactory.ts
@@ -36,7 +36,7 @@ const loginFactory =
         result: userId,
       };
 
-      dispatch({
+      await dispatch({
         payload: userEntity,
         type: actionTypes.LOGIN_SUCCESS,
         meta: { isLoginAction: true, method: LoginMethodParameterTypes.TENANT },

--- a/packages/redux/src/users/authentication/actions/factories/logoutFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/logoutFactory.ts
@@ -24,7 +24,7 @@ const logoutFactory =
 
       const result = await postLogout(config);
 
-      dispatch({
+      await dispatch({
         type: actionTypes.LOGOUT_SUCCESS,
       });
 

--- a/packages/redux/src/users/authentication/actions/factories/registerFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/registerFactory.ts
@@ -36,7 +36,7 @@ const registerFactory =
         result: userId,
       };
 
-      dispatch({
+      await dispatch({
         payload: userEntity,
         type: actionTypes.REGISTER_SUCCESS,
         meta: {

--- a/packages/redux/src/wishlists/actions/factories/addWishlistItemFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/addWishlistItemFactory.ts
@@ -59,7 +59,7 @@ const addWishlistItemFactory =
         productImgQueryParam,
       }));
 
-      dispatch({
+      await dispatch({
         meta: { ...metadata, ...data, wishlistId },
         payload: normalize(
           { ...result, items: newItems },

--- a/packages/redux/src/wishlists/actions/factories/addWishlistSetFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/addWishlistSetFactory.ts
@@ -43,7 +43,7 @@ const addWishlistSetFactory =
 
       const result = await postWishlistSet(wishlistId, data, config);
 
-      dispatch({
+      await dispatch({
         payload: normalize(result, wishlistSetSchema),
         type: actionTypes.ADD_WISHLIST_SET_SUCCESS,
       });

--- a/packages/redux/src/wishlists/actions/factories/fetchWishlistFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/fetchWishlistFactory.ts
@@ -41,7 +41,7 @@ const fetchWishlistFactory =
         productImgQueryParam,
       }));
 
-      dispatch({
+      await dispatch({
         payload: normalize(
           { ...result, items: newItems },
           { items: [wishlistItemSchema] },

--- a/packages/redux/src/wishlists/actions/factories/fetchWishlistSetFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/fetchWishlistSetFactory.ts
@@ -46,7 +46,7 @@ const fetchWishlistSetFactory =
 
       const result = await getWishlistSet(wishlistId, wishlistSetId, config);
 
-      dispatch({
+      await dispatch({
         meta: { wishlistSetId },
         payload: normalize(result, wishlistSetSchema),
         type: actionTypes.FETCH_WISHLIST_SET_SUCCESS,

--- a/packages/redux/src/wishlists/actions/factories/fetchWishlistSetsFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/fetchWishlistSetsFactory.ts
@@ -41,7 +41,7 @@ const fetchWishlistSetsFactory =
 
       const result = await getWishlistSets(wishlistId, config);
 
-      dispatch({
+      await dispatch({
         payload: normalize(result, [wishlistSetSchema]),
         type: actionTypes.FETCH_WISHLIST_SETS_SUCCESS,
       });

--- a/packages/redux/src/wishlists/actions/factories/removeWishlistItemFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/removeWishlistItemFactory.ts
@@ -71,7 +71,7 @@ const removeWishlistItemFactory =
         productImgQueryParam,
       }));
 
-      dispatch({
+      await dispatch({
         payload: normalize(
           { ...result, items: newItems },
           { items: [wishlistItemSchema] },

--- a/packages/redux/src/wishlists/actions/factories/removeWishlistSetFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/removeWishlistSetFactory.ts
@@ -40,7 +40,7 @@ const removeWishlistSetFactory =
 
       await deleteWishlistSet(wishlistId, wishlistSetId, config);
 
-      dispatch({
+      await dispatch({
         meta: { wishlistSetId },
         type: actionTypes.REMOVE_WISHLIST_SET_SUCCESS,
       });

--- a/packages/redux/src/wishlists/actions/factories/updateWishlistItemFactory.ts
+++ b/packages/redux/src/wishlists/actions/factories/updateWishlistItemFactory.ts
@@ -74,7 +74,7 @@ const updateWishlistItemFactory =
         productImgQueryParam,
       }));
 
-      dispatch({
+      await dispatch({
         meta: {
           ...metadata,
           ...data,


### PR DESCRIPTION
## Description

This fixes the `useBag` hook actions which were using stale `items` data when the actions were invoked in succession (like a call to removeItem is awaited and then a call to addItem is made). The fix is to remove the `items` from the callbacks and use `getState` to get the most updated state from the store.
Also, it was needed to await the `dispatch` calls to the bag success actions to make sure that when the `.then` callback is invoked all the middlewares have run first and the state in the store was updated. We will need to change all factory actions to await the dispatch of the success action (at least) eventually but on this PR I only included wishlist, bag and user authentication actions as they are the most problematic.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
