### PR TITLE
fix(redux): fix immer imports to work with nodenext

### DIFF
--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@farfetch/blackout-analytics": "^1.0.0-next.126",
     "@farfetch/blackout-client": "^2.0.0-next.243",
-    "immer": "^9.0.6",
+    "immer": "^9.0.19",
     "lodash": "^4.17.21",
     "redux": "^4.1.0",
     "redux-mock-store": "^1.5.4",
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "@farfetch/blackout-analytics": "^1.0.0-next.87",
     "@farfetch/blackout-client": "^2.0.0-next.216",
-    "immer": "^9.0.6",
+    "immer": "^9.0.19",
     "lodash": "^4.17.21",
     "redux": "^4.1.0",
     "redux-thunk": "^2.4.1",

--- a/packages/redux/src/checkout/reducer.ts
+++ b/packages/redux/src/checkout/reducer.ts
@@ -1,12 +1,12 @@
 import * as actionTypes from './actionTypes';
 import { type AnyAction, combineReducers, type Reducer } from 'redux';
 import { LOGOUT_SUCCESS } from '../users/authentication/actionTypes';
+import { produce } from 'immer';
 import assignWith from 'lodash/assignWith';
 import createMergedObject from '../helpers/createMergedObject';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import mergeWith from 'lodash/mergeWith';
-import produce from 'immer';
 import reducerFactory, {
   createReducerWithResult,
 } from '../helpers/reducerFactory';

--- a/packages/redux/src/locale/reducer.ts
+++ b/packages/redux/src/locale/reducer.ts
@@ -1,7 +1,7 @@
 import * as actionTypes from './actionTypes';
 import { type AnyAction, combineReducers, type Reducer } from 'redux';
+import { produce } from 'immer';
 import get from 'lodash/get';
-import produce from 'immer';
 import reducerFactory from '../helpers/reducerFactory';
 import type { LocaleState } from './types';
 import type { StoreState } from '../types';

--- a/packages/redux/src/orders/reducer.ts
+++ b/packages/redux/src/orders/reducer.ts
@@ -6,9 +6,9 @@ import {
   LOGOUT_SUCCESS,
   REGISTER_SUCCESS,
 } from '../users/authentication/actionTypes';
+import { produce } from 'immer';
 import merge from 'lodash/merge';
 import omit from 'lodash/omit';
-import produce from 'immer';
 import reducerFactory from '../helpers/reducerFactory';
 import type * as T from './types';
 import type {

--- a/packages/redux/src/returns/reducer.ts
+++ b/packages/redux/src/returns/reducer.ts
@@ -6,9 +6,9 @@ import {
   LOGOUT_SUCCESS,
   REGISTER_SUCCESS,
 } from '../users/authentication/actionTypes';
+import { produce } from 'immer';
 import generateReturnPickupCapabilityHash from './helpers/generateReturnPickupCapabilityHash';
 import omit from 'lodash/omit';
-import produce from 'immer';
 import type {
   FetchReturnFailureAction,
   FetchReturnPickupCapabilityFailureAction,

--- a/packages/redux/src/users/addresses/reducer.ts
+++ b/packages/redux/src/users/addresses/reducer.ts
@@ -1,7 +1,7 @@
 import * as actionTypes from './actionTypes';
 import { type AnyAction, combineReducers, type Reducer } from 'redux';
+import { produce } from 'immer';
 import omit from 'lodash/omit';
-import produce from 'immer';
 import reducerFactory, {
   createReducerWithResult,
 } from '../../helpers/reducerFactory';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6738,10 +6738,10 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
-immer@^9.0.6:
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
-  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
+immer@^9.0.19:
+  version "9.0.19"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.19.tgz#67fb97310555690b5f9cd8380d38fc0aabb6b38b"
+  integrity sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
## Description

This updates immer requirements to version 9.0.19 and changes the imports to use named exports instead of default due to an issue with webpack importing.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
