### PR TITLE
fix(react): fix ga4 events

### DIFF
--- a/packages/react/src/analytics/integrations/GA4/GA4.js
+++ b/packages/react/src/analytics/integrations/GA4/GA4.js
@@ -195,7 +195,7 @@ class GA4 extends integrations.Integration {
       case analyticsPageTypes.WISHLIST:
         // Make sure the page view fires first, so the event being triggered after uses the correct page path (otherwise the event fires with the previous one).
         await this.trackPage(data);
-        await this.trackEvent(data);
+        await this.trackEvent({ ...data, type: analyticsTrackTypes.TRACK });
 
         break;
       default:

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
@@ -80,6 +80,8 @@ Array [
     "search",
     Object {
       "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
       "search_term": "term",
     },
   ],
@@ -102,6 +104,8 @@ Array [
     "search",
     Object {
       "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
       "search_term": "query",
     },
   ],
@@ -885,6 +889,8 @@ Array [
           "size": "L",
         },
       ],
+      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
       "value": 19,
       "wishlist_id": undefined,
       "wishlist_name": undefined,
@@ -909,6 +915,8 @@ Array [
     "search",
     Object {
       "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
       "search_term": "shoes",
     },
   ],
@@ -931,6 +939,8 @@ Array [
     "view_wishlist",
     Object {
       "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
+      "path_clean": "/pt/",
       "wishlist_id": "d3618128-5aa9-4caa-a452-1dd1377a6190",
     },
   ],


### PR DESCRIPTION
## Description

This PR solves a minor problem about three specific events (search, view_wishlist, view_cart) which weren't being sent with page_path and path_clean, this was because the type was being sent as page, to correct this we need to specify that trackEvent is being triggered with `type: TrackTypes.TRACK`.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
