### PR TITLE
feat(analytics|react): add unique id to GTM integration for next

### DIFF
--- a/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
@@ -133,7 +133,7 @@ Object {
     "Omnitracking": [Function],
   },
   "utils": Object {
-    "ANALYTICS_UNIQUE_EVENT_ID": "__uniqueEventId",
+    "ANALYTICS_UNIQUE_EVENT_ID": "__blackoutAnalyticsEventId",
     "CONSENT_CATEGORIES_PROPERTY": "consentCategories",
     "CONSENT_KEYS": Array [
       "statistics",

--- a/packages/analytics/src/__tests__/analytics.test.ts
+++ b/packages/analytics/src/__tests__/analytics.test.ts
@@ -1,5 +1,5 @@
+import { ANALYTICS_UNIQUE_EVENT_ID, logger } from '../utils';
 import { Integration } from '../integrations';
-import { logger } from '../utils';
 import { mockUsersResponse } from 'tests/__fixtures__/users';
 import { PACKAGE_NAME } from '../utils/constants';
 import Analytics from '../';
@@ -851,7 +851,7 @@ describe('analytics', () => {
               ...context,
               event: {
                 ...eventContext,
-                __uniqueEventId: expect.any(String),
+                [ANALYTICS_UNIQUE_EVENT_ID]: expect.any(String),
               },
             },
             user: await analytics.user(),

--- a/packages/analytics/src/utils/constants.ts
+++ b/packages/analytics/src/utils/constants.ts
@@ -17,7 +17,8 @@ export const CONSENT_KEYS = [
   DefaultConsentKeys.MARKETING,
   DefaultConsentKeys.PREFERENCES,
 ];
+
 export const CONSENT_CATEGORIES_PROPERTY = 'consentCategories';
 export const LOAD_INTEGRATION_TRACK_TYPE = 'loadIntegration';
 export const ON_SET_USER_TRACK_TYPE = 'onSetUser';
-export const ANALYTICS_UNIQUE_EVENT_ID = '__uniqueEventId';
+export const ANALYTICS_UNIQUE_EVENT_ID = '__blackoutAnalyticsEventId';

--- a/packages/react/src/analytics/integrations/GA4/GA4.ts
+++ b/packages/react/src/analytics/integrations/GA4/GA4.ts
@@ -43,7 +43,6 @@ import {
   OPTION_SCHEMAS,
   OPTION_SCOPE_COMMANDS,
   OPTION_SET_CUSTOM_USER_ID_PROPERTY,
-  OPTION_UNIQUE_EVENT_ID_KEY,
 } from './constants';
 import { validateFields } from './validation/optionsValidator';
 import defaultSchemaEventsMap from '../shared/validation/eventSchemas';
@@ -402,7 +401,7 @@ class GA4 extends integrations.Integration<GA4IntegrationOptions> {
         `context.event.${utils.ANALYTICS_UNIQUE_EVENT_ID}`,
       ) as string;
 
-      eventProperties[OPTION_UNIQUE_EVENT_ID_KEY] = uniqueEventId;
+      eventProperties[utils.ANALYTICS_UNIQUE_EVENT_ID] = uniqueEventId;
 
       if (data.type === analyticsTrackTypes.TRACK) {
         eventProperties['page_path'] =

--- a/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.ts
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/GA4.test.ts
@@ -332,7 +332,7 @@ describe('GA4 Integration', () => {
             'event',
             'page_view',
             {
-              __blackoutAnalyticsEventId: expect.any(String),
+              [utils.ANALYTICS_UNIQUE_EVENT_ID]: expect.any(String),
               page_path: pathName + utils.stringifyQuery(query),
               path_clean: pathName,
             },

--- a/packages/react/src/analytics/integrations/GA4/constants.ts
+++ b/packages/react/src/analytics/integrations/GA4/constants.ts
@@ -18,5 +18,4 @@ export const OPTION_SCOPE_COMMANDS = 'scopeCommands';
 export const OPTION_SCHEMAS = 'schemas';
 export const OPTION_DATA_LAYER_NAME = 'dataLayerName';
 export const OPTION_SET_CUSTOM_USER_ID_PROPERTY = 'setCustomUserIdProperty';
-export const OPTION_UNIQUE_EVENT_ID_KEY = '__blackoutAnalyticsEventId';
 export const OPTION_DEBUG_MODE = 'debugMode';

--- a/packages/react/src/analytics/integrations/GTM/GTM.ts
+++ b/packages/react/src/analytics/integrations/GTM/GTM.ts
@@ -325,8 +325,14 @@ class GTM extends integrations.Integration<GTMIntegrationOptions> {
       return this;
     }
 
+    const uniqueEventId = get(
+      data,
+      `context.event.${coreUtils.ANALYTICS_UNIQUE_EVENT_ID}`,
+    ) as string;
+
     const payload = {
       ...(eventProperties as object),
+      [coreUtils.ANALYTICS_UNIQUE_EVENT_ID]: uniqueEventId,
       type: data.type,
       event: data.event,
     };

--- a/packages/react/src/analytics/integrations/GTM/__tests__/GTM.test.ts
+++ b/packages/react/src/analytics/integrations/GTM/__tests__/GTM.test.ts
@@ -153,7 +153,7 @@ describe('GTM', () => {
           context: {
             currencyCode: data.context.currencyCode,
             eventContext: {
-              __uniqueEventId: expect.any(String),
+              [utils.ANALYTICS_UNIQUE_EVENT_ID]: expect.any(String),
             },
             libraryVersion: data.context.library.version,
             // @ts-expect-error Force cast to facilitate testing
@@ -326,6 +326,23 @@ describe('GTM', () => {
       dataLayerEntry = getDataLayerEntryByEvent(invalidEventName);
 
       expect(dataLayerEntry).toBeUndefined();
+    });
+
+    it('Should track with unique id on track result', () => {
+      const analyticsEvent = {
+        ...analyticsTrackDataMock,
+        event: EventTypes.PRODUCT_CLICKED,
+        properties: {
+          id: 123123,
+        },
+      };
+
+      gtm.track(analyticsEvent);
+
+      // Valid, known event
+      const dataLayerEntry = getDataLayerEntryByEvent(analyticsEvent.event);
+
+      expect(dataLayerEntry).toMatchSnapshot();
     });
 
     it('Should log an error if an event does not have a function as the property value', () => {

--- a/packages/react/src/analytics/integrations/GTM/__tests__/__snapshots__/GTM.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GTM/__tests__/__snapshots__/GTM.test.ts.snap
@@ -557,3 +557,15 @@ exports[`GTM EventsMapper Should match the snapshot for the event: stores 1`] = 
 exports[`GTM EventsMapper Should match the snapshot for the event: unsubscribe 1`] = `Object {}`;
 
 exports[`GTM EventsMapper Should match the snapshot for the event: wishlist 1`] = `Object {}`;
+
+exports[`GTM Track Should track with unique id on track result 1`] = `
+Object {
+  "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
+  "event": "Product Clicked",
+  "product": Object {
+    "category": undefined,
+    "id": 123123,
+  },
+  "type": "track",
+}
+`;

--- a/tests/__fixtures__/analytics/baseAnalyticsEventData.fixtures.ts
+++ b/tests/__fixtures__/analytics/baseAnalyticsEventData.fixtures.ts
@@ -76,7 +76,7 @@ const fixtures = {
       pageLocationReferrer: 'https://example.com',
     },
     event: {
-      __uniqueEventId: '4eabf689-96e3-4952-8176-248a848f1e1f',
+      __blackoutAnalyticsEventId: '4eabf689-96e3-4952-8176-248a848f1e1f',
     },
   },
   timestamp: 1567010265879,


### PR DESCRIPTION
## Description

- Added new property on track events, to set __blackoutAnalyticsEventId
on GTM. This property is already used on other integrations to relation
events on different integrations.

- Code refactor: created new contant on analytics package to define
default property name for __blackoutAnalyticsEventId, avoiding possible inconsistencies.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
