### PR TITLE
feat(core|react): add unique id to GTM integration

### DIFF
--- a/packages/core/src/analytics/Analytics.js
+++ b/packages/core/src/analytics/Analytics.js
@@ -1,4 +1,9 @@
-import { getContextDefaults, logger, StorageWrapper } from './utils';
+import {
+  ANALYTICS_UNIQUE_EVENT_ID,
+  getContextDefaults,
+  logger,
+  StorageWrapper,
+} from './utils';
 import { Integration } from './integrations';
 import { v4 as uuidv4 } from 'uuid';
 import Consent from './Consent';
@@ -556,7 +561,7 @@ class Analytics {
     Object.assign(context, {
       event: {
         ...eventContext,
-        __uniqueEventId: uuidv4(),
+        [ANALYTICS_UNIQUE_EVENT_ID]: uuidv4(),
       },
     });
 

--- a/packages/core/src/analytics/__fixtures__/commonData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/commonData.fixtures.js
@@ -1,8 +1,9 @@
+import { ANALYTICS_UNIQUE_EVENT_ID } from '../utils';
 export const mockAnalyticsUniqueEventId =
   '111945ad-b9d4-4c21-b3b0-2764b31bd1111';
 
 export const mockCommonData = {
-  __uniqueEventId: mockAnalyticsUniqueEventId,
+  [ANALYTICS_UNIQUE_EVENT_ID]: mockAnalyticsUniqueEventId,
   timestamp: 1567010265879,
   userLocalId: 'd9864a1c112d-47ff-8ee4-968c-5acecae23',
 };

--- a/packages/core/src/analytics/__fixtures__/pageData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/pageData.fixtures.js
@@ -1,3 +1,4 @@
+import { ANALYTICS_UNIQUE_EVENT_ID } from '../utils';
 import {
   expectedCommonParameters,
   mockAnalyticsUniqueEventId,
@@ -108,7 +109,7 @@ const pageMockData = {
       pageLocationReferrer: 'https://example.com',
     },
     event: {
-      __uniqueEventId: mockAnalyticsUniqueEventId,
+      [ANALYTICS_UNIQUE_EVENT_ID]: mockAnalyticsUniqueEventId,
     },
   },
   timestamp: mockCommonData.timestamp,

--- a/packages/core/src/analytics/__tests__/analytics.test.js
+++ b/packages/core/src/analytics/__tests__/analytics.test.js
@@ -1,5 +1,5 @@
+import { ANALYTICS_UNIQUE_EVENT_ID, logger, PACKAGE_NAME } from '../utils';
 import { Integration } from '../integrations';
-import { logger, PACKAGE_NAME } from '../utils';
 import { TestStorage } from '../../../tests/helpers';
 import Analytics from '../';
 import eventTypes from '../types/eventTypes';
@@ -798,7 +798,7 @@ describe('analytics', () => {
               ...context,
               event: {
                 ...context.event,
-                __uniqueEventId: expect.any(String),
+                [ANALYTICS_UNIQUE_EVENT_ID]: expect.any(String),
               },
             },
             user: await analytics.user(),

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -3,6 +3,7 @@
  * @private
  */
 
+import { ANALYTICS_UNIQUE_EVENT_ID } from '../../utils';
 import {
   CLIENT_LANGUAGES_LIST,
   DEFAULT_CLIENT_LANGUAGE,
@@ -35,7 +36,7 @@ import platformTypes from '../../types/platformTypes';
 export const getCommonParameters = data => {
   return {
     clientTimestamp: new Date(data.timestamp).toJSON(),
-    uuid: get(data, 'context.event.__uniqueEventId'),
+    uuid: get(data, `context.event.${ANALYTICS_UNIQUE_EVENT_ID}`),
   };
 };
 
@@ -318,7 +319,6 @@ export const getValParameterForEvent = (valParameters = {}) => {
  * Generates a payment attempt reference ID based on the correlationID (user local ID) and the timestamp of the event.
  *
  * @param {object} data - Event data passed by analytics.
- 
  * @returns {string} - The payment attempt reference ID.
  */
 export const generatePaymentAttemptReferenceId = data => {

--- a/packages/core/src/analytics/utils/constants.js
+++ b/packages/core/src/analytics/utils/constants.js
@@ -14,3 +14,5 @@ export const CONSENT_KEYS = [
   DefaultConsentKeys.PREFERENCES,
 ];
 export const CONSENT_CATEGORIES_PROPERTY = 'consentCategories';
+
+export const ANALYTICS_UNIQUE_EVENT_ID = '__blackoutAnalyticsEventId';

--- a/packages/react/src/analytics/integrations/GA4/GA4.js
+++ b/packages/react/src/analytics/integrations/GA4/GA4.js
@@ -37,7 +37,6 @@ import {
   OPTION_SCHEMAS,
   OPTION_SCOPE_COMMANDS,
   OPTION_SET_CUSTOM_USER_ID_PROPERTY,
-  OPTION_UNIQUE_EVENT_ID_KEY,
 } from './constants';
 import { validateFields } from './validation/optionsValidator';
 import defaultSchemaEventsMap from '../shared/validation/eventSchemas';
@@ -369,11 +368,14 @@ class GA4 extends integrations.Integration {
    */
   postProcessEvent(command, data) {
     const eventProperties = command[2];
-    const uniqueEventId = get(data, 'context.event.__uniqueEventId');
+    const uniqueEventId = get(
+      data,
+      `context.event.${utils.ANALYTICS_UNIQUE_EVENT_ID}`,
+    );
     const contextLocation = utils.getLocation(data);
 
     if (typeof eventProperties === 'object') {
-      eventProperties[OPTION_UNIQUE_EVENT_ID_KEY] = uniqueEventId;
+      eventProperties[utils.ANALYTICS_UNIQUE_EVENT_ID] = uniqueEventId;
 
       if (data.type === analyticsTrackTypes.TRACK) {
         eventProperties['page_path'] =

--- a/packages/react/src/analytics/integrations/GTM/GTM.js
+++ b/packages/react/src/analytics/integrations/GTM/GTM.js
@@ -297,8 +297,14 @@ class GTM extends Integration {
       return this;
     }
 
+    const uniqueEventId = get(
+      data,
+      `context.event.${coreUtils.ANALYTICS_UNIQUE_EVENT_ID}`,
+    );
+
     const payload = {
       ...eventProperties,
+      [coreUtils.ANALYTICS_UNIQUE_EVENT_ID]: uniqueEventId,
       type: data.type,
       event: data.event,
     };

--- a/packages/react/src/analytics/integrations/__fixtures__/analyticsPageData.fixtures.json
+++ b/packages/react/src/analytics/integrations/__fixtures__/analyticsPageData.fixtures.json
@@ -63,7 +63,7 @@
       }
     },
     "event": {
-      "__uniqueEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111"
+      "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111"
     }
   },
   "timestamp": 1567010265879

--- a/packages/react/src/analytics/integrations/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/__tests__/GA4.test.js
@@ -298,8 +298,8 @@ describe('GA4 Integration', () => {
                   mockedPageData.context.web.window.location.query,
                 ),
               path_clean: mockedPageData.context.web.window.location.pathname,
-              __blackoutAnalyticsEventId:
-                mockedPageData.context.event.__uniqueEventId,
+              [utils.ANALYTICS_UNIQUE_EVENT_ID]:
+                mockedPageData.context.event[utils.ANALYTICS_UNIQUE_EVENT_ID],
             },
           ],
         ];

--- a/packages/react/src/analytics/integrations/__tests__/GTM.test.js
+++ b/packages/react/src/analytics/integrations/__tests__/GTM.test.js
@@ -435,7 +435,7 @@ describe('GTM', () => {
 
       dataLayerEntry = getDataLayerEntryByEvent(analyticsEvent.event);
 
-      expect(dataLayerEntry).toBeDefined();
+      expect(dataLayerEntry).toMatchSnapshot();
     });
   });
 

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GTM.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GTM.test.js.snap
@@ -382,3 +382,23 @@ exports[`GTM EventsMapper Should match the snapshot for the event: stores 1`] = 
 exports[`GTM EventsMapper Should match the snapshot for the event: unsubscribe 1`] = `Object {}`;
 
 exports[`GTM EventsMapper Should match the snapshot for the event: wishlist 1`] = `Object {}`;
+
+exports[`GTM eventSchemas Should allow to extend the eventSchema 1`] = `
+Object {
+  "__blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+  "event": "Product Clicked",
+  "product": Object {
+    "brand": undefined,
+    "category": undefined,
+    "id": undefined,
+    "list": undefined,
+    "name": undefined,
+    "position": undefined,
+    "price": undefined,
+    "quantity": undefined,
+    "size": undefined,
+    "variant": undefined,
+  },
+  "type": "track",
+}
+`;


### PR DESCRIPTION
## Description

- Added new property on track events, to set __blackoutAnalyticsEventId on GTM. This property is already used on other integrations to relation events on different integrations.

- Code refactor: created new constant on analytics package to define default property name for __blackoutAnalyticsEventId, avoiding possible inconsistencies.


<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
