### PR TITLE
fix(redux): subfolder on useLocale & serverInitialState

### DIFF
--- a/packages/react/src/contents/hooks/__tests__/__fixtures__/useSeoMetadata.fixtures.ts
+++ b/packages/react/src/contents/hooks/__tests__/__fixtures__/useSeoMetadata.fixtures.ts
@@ -15,6 +15,7 @@ export const mockInitialState = {
     },
   },
   locale: {
+    subfolder: 'en-GB',
     countryCode: 'GB',
     sourceCountryCode: 'GB',
     cities: { isLoading: false, error: null },

--- a/packages/react/src/locale/hooks/__tests__/useLocale.test.tsx
+++ b/packages/react/src/locale/hooks/__tests__/useLocale.test.tsx
@@ -35,7 +35,7 @@ describe('useLocale', () => {
 
     expect(current).toStrictEqual({
       data: {
-        subfolder: mockCountry.defaultSubfolder.replace('/', ''),
+        subfolder: mockLocaleState.locale.subfolder,
         countryCultureCode: mockCountry.defaultCulture,
         countryCode: mockCountry.code,
         country: mockCountryNormalized,

--- a/packages/react/src/locale/hooks/useLocale.ts
+++ b/packages/react/src/locale/hooks/useLocale.ts
@@ -2,8 +2,8 @@ import {
   getCountry,
   getCountryCode,
   getCountryCulture,
-  getCountryStructure,
   getSourceCountryCode,
+  getSubfolder,
 } from '@farfetch/blackout-redux';
 import { useSelector } from 'react-redux';
 
@@ -12,10 +12,9 @@ export function useLocale() {
   const countryCode = useSelector(getCountryCode);
   const countryCultureCode = useSelector(getCountryCulture);
   const sourceCountryCode = useSelector(getSourceCountryCode);
-  const countryStructure = useSelector(getCountryStructure);
   const country = useSelector(getCountry);
+  const subfolder = useSelector(getSubfolder);
   // Custom logic
-  const subfolder = countryStructure?.replace(/(\/)/, '');
   const currency = country?.currencies?.[0];
 
   return {

--- a/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1043,6 +1043,7 @@ Object {
   "getStaffMember": [Function],
   "getStaffMemberError": [Function],
   "getState": [Function],
+  "getSubfolder": [Function],
   "getSubmitFormDataError": [Function],
   "getSubscriptionPackages": [Function],
   "getSubscriptionPackagesError": [Function],
@@ -1227,6 +1228,7 @@ Object {
     "FETCH_COUNTRY_SUCCESS": "@farfetch/blackout-redux/FETCH_COUNTRY_SUCCESS",
     "RESET_LOCALE_STATE": "@farfetch/blackout-redux/RESET_LOCALE_STATE",
     "SET_COUNTRY_CODE": "@farfetch/blackout-redux/SET_COUNTRY_CODE",
+    "SET_SUBFOLDER": "@farfetch/blackout-redux/SET_COUNTRY_CODE",
   },
   "localeEntitiesMapper": Object {
     "@farfetch/blackout-redux/FETCH_COUNTRY_ADDRESS_SCHEMA_SUCCESS": [Function],

--- a/packages/redux/src/locale/__tests__/selectors.test.ts
+++ b/packages/redux/src/locale/__tests__/selectors.test.ts
@@ -44,6 +44,7 @@ describe('locale redux selectors', () => {
         isLoading: false,
         error: null,
       },
+      subfolder: 'en-US',
       sourceCountryCode: 'US',
     },
     entities: {

--- a/packages/redux/src/locale/__tests__/serverInitialState.test.ts
+++ b/packages/redux/src/locale/__tests__/serverInitialState.test.ts
@@ -12,6 +12,7 @@ describe('local serverInitialState()', () => {
       locale: {
         countryCode: 'US',
         sourceCountryCode: 'PT',
+        subfolder: '/en-us',
       },
       entities: {
         countries: {
@@ -42,6 +43,7 @@ describe('local serverInitialState()', () => {
       locale: {
         countryCode: '',
         sourceCountryCode: null,
+        subfolder: null,
         cities: {
           error: null,
           isLoading: false,

--- a/packages/redux/src/locale/actionTypes.ts
+++ b/packages/redux/src/locale/actionTypes.ts
@@ -100,6 +100,11 @@ export const FETCH_COUNTRY_ADDRESS_SCHEMA_SUCCESS =
 export const SET_COUNTRY_CODE = '@farfetch/blackout-redux/SET_COUNTRY_CODE';
 
 /**
+ * Action type dispatched when set subfolder.
+ */
+export const SET_SUBFOLDER = '@farfetch/blackout-redux/SET_COUNTRY_CODE';
+
+/**
  * Action type dispatched when reset locale.
  */
 export const RESET_LOCALE_STATE = '@farfetch/blackout-redux/RESET_LOCALE_STATE';

--- a/packages/redux/src/locale/reducer.ts
+++ b/packages/redux/src/locale/reducer.ts
@@ -9,6 +9,7 @@ import type { StoreState } from '../types';
 export const INITIAL_STATE_LOCALE: LocaleState = {
   countryCode: '',
   sourceCountryCode: null,
+  subfolder: null,
   cities: {
     error: null,
     isLoading: false,
@@ -42,6 +43,18 @@ const countryCode = (
         'payload.countryCode',
         INITIAL_STATE_LOCALE.countryCode,
       );
+    default:
+      return state;
+  }
+};
+
+const subfolder = (
+  state = INITIAL_STATE_LOCALE.subfolder,
+  action: AnyAction,
+): LocaleState['subfolder'] => {
+  switch (action.type) {
+    case actionTypes.SET_SUBFOLDER:
+      return get(action, 'payload.subfolder', INITIAL_STATE_LOCALE.subfolder);
     default:
       return state;
   }
@@ -184,6 +197,8 @@ export const getCountriesError = (
 export const getCountryCode = (
   state: LocaleState,
 ): LocaleState['countryCode'] => state.countryCode;
+export const getSubfolder = (state: LocaleState): LocaleState['subfolder'] =>
+  state.subfolder;
 export const getSourceCountryCode = (
   state: LocaleState,
 ): LocaleState['sourceCountryCode'] => state.sourceCountryCode;
@@ -205,6 +220,7 @@ const reducers = combineReducers({
   states,
   sourceCountryCode,
   countriesAddressSchemas,
+  subfolder,
 });
 
 export const entitiesMapper = {

--- a/packages/redux/src/locale/selectors.ts
+++ b/packages/redux/src/locale/selectors.ts
@@ -14,6 +14,7 @@ import {
   getCountryStateCitiesError as getCountryStateCitiesErrorFromReducer,
   getCountryStatesError as getCountryStatesErrorFromReducer,
   getSourceCountryCode as getSourceCountryCodeFromReducer,
+  getSubfolder as getSubfolderFromReducer,
 } from './reducer';
 import { getEntities, getEntityById } from '../entities/selectors/entity';
 import get from 'lodash/get';
@@ -674,3 +675,13 @@ export const areCountryAddressSchemasFetched = (
     !areCountriesAddressSchemasLoading(state)
   );
 };
+
+/**
+ * Returns the locale subfolder.
+ *
+ * @param state - Application state.
+ *
+ * @returns - The subfolder for the locale state received.
+ */
+export const getSubfolder = (state: StoreState) =>
+  getSubfolderFromReducer(state.locale as LocaleState);

--- a/packages/redux/src/locale/serverInitialState.ts
+++ b/packages/redux/src/locale/serverInitialState.ts
@@ -50,6 +50,7 @@ const localeServerInitialState: ServerInitialState = ({ model }) => {
     locale: {
       countryCode,
       sourceCountryCode: requestSourceCountryCode,
+      subfolder,
     },
     entities,
   };

--- a/packages/redux/src/locale/types/actions.types.ts
+++ b/packages/redux/src/locale/types/actions.types.ts
@@ -13,6 +13,10 @@ export interface ActionSetCountryCode extends Action {
   type: typeof actionTypes.SET_COUNTRY_CODE;
 }
 
+export interface ActionSetSubFolder extends Action {
+  type: typeof actionTypes.SET_SUBFOLDER;
+}
+
 export interface ActionFetchCountriesFailure extends Action {
   type: typeof actionTypes.FETCH_COUNTRIES_FAILURE;
   payload: { error: BlackoutError | null };

--- a/packages/redux/src/locale/types/reducer.types.ts
+++ b/packages/redux/src/locale/types/reducer.types.ts
@@ -4,6 +4,7 @@ import type { StateWithoutResult } from '../../types';
 
 export type LocaleState = CombinedState<{
   countryCode: string;
+  subfolder: string | null;
   sourceCountryCode: string | null;
   cities: {
     error: BlackoutError | null;

--- a/tests/__fixtures__/locale/locale.fixtures.ts
+++ b/tests/__fixtures__/locale/locale.fixtures.ts
@@ -297,6 +297,7 @@ export const mockLocaleState = {
       isLoading: false,
     },
     sourceCountryCode: null,
+    subfolder: '/en-pt',
     countriesAddressSchemas: {
       error: null,
       isLoading: false,


### PR DESCRIPTION
## Description

- Change useLocale hook to use subfolder from locale state. 

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
