### PR TITLE
feat(analytics|react): add parameters checkout abandoned event next

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -11,6 +11,13 @@ Object {
 
 exports[`Omnitracking track events definitions \`Checkout Abandoned\` return should match the snapshot 1`] = `
 Object {
+  "checkoutOrderId": 12345678,
+  "checkoutStep": 2,
+  "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\",\\"packagingType\\":\\"foo\\"}",
+  "orderCode": "50314b8e9bcf000000000000",
+  "orderVAT": 2.04,
+  "paymentType": "credit",
+  "shipping": 10,
   "tid": 2084,
 }
 `;
@@ -21,13 +28,12 @@ Object {
   "basketValue": 24.64,
   "checkoutOrderId": 12345678,
   "checkoutStep": 1,
-  "deliveryType": "Standard/standard",
+  "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/standard\\",\\"courierType\\":\\"Next Day\\"}",
   "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1}]",
   "orderCode": "50314b8e9bcf000000000000",
   "orderVAT": 2.04,
   "paymentType": "credit card",
   "shipping": 3.6,
-  "shippingTier": "Next Day",
   "tid": 2918,
 }
 `;

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -444,14 +444,13 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
   [EventTypes.CHECKOUT_STARTED]: data => ({
     tid: 2918,
     ...getCheckoutEventGenericProperties(data),
+    deliveryInformationDetails: getDeliveryInformationDetails(data),
     basketCurrency: data.properties?.currency,
     basketValue: data.properties?.total,
     checkoutStep: data.properties?.step,
-    deliveryType: data.properties?.deliveryType,
     lineItems: getProductLineItems(data),
     paymentType: data.properties?.paymentType,
     shipping: data.properties?.shipping,
-    shippingTier: data.properties?.shippingTier,
     orderVAT: data.properties?.tax,
   }),
   [EventTypes.CHECKOUT_STEP_EDITING]: data => ({
@@ -503,8 +502,14 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     tid: 2832,
     lineItems: getProductLineItems(data),
   }),
-  [EventTypes.CHECKOUT_ABANDONED]: () => ({
+  [EventTypes.CHECKOUT_ABANDONED]: data => ({
     tid: 2084,
+    ...getCheckoutEventGenericProperties(data),
+    deliveryInformationDetails: getDeliveryInformationDetails(data),
+    checkoutStep: data.properties?.step,
+    paymentType: data.properties?.paymentType,
+    shipping: data.properties?.shipping,
+    orderVAT: data.properties?.tax,
   }),
   [EventTypes.PROMOCODE_APPLIED]: data => ({
     tid: 311,

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -562,10 +562,15 @@ export const getProductLineItemsQuantity = (
 export const getDeliveryInformationDetails = (
   data: EventData<TrackTypesValues>,
 ) => {
-  if (data.properties?.deliveryType || data.properties?.shippingTier) {
+  if (
+    data.properties?.deliveryType ||
+    data.properties?.shippingTier ||
+    data.properties?.packagingType
+  ) {
     return JSON.stringify({
       deliveryType: data.properties.deliveryType,
       courierType: data.properties.shippingTier,
+      packagingType: data.properties.packagingType,
     });
   }
 

--- a/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
@@ -199,6 +199,7 @@ Object {
     "FF_CURRENCY": "FF-Currency",
   },
   "integrations": Object {
+    "CASTLE_CLIENT_ID_HEADER_NAME": "X-Castle-Request-Token",
     "Castle": [Function],
     "Forter": [Function],
     "GA": [Function],

--- a/packages/react/src/analytics/integrations/Castle/index.ts
+++ b/packages/react/src/analytics/integrations/Castle/index.ts
@@ -1,3 +1,6 @@
-export { default } from './Castle.js';
+export {
+  default,
+  CLIENT_ID_HEADER_NAME as CASTLE_CLIENT_ID_HEADER_NAME,
+} from './Castle.js';
 
 export * from './types/index.js';

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -228,13 +228,21 @@ exports[`GA4 Integration GA4 instance When it is instantiated correctly Event Ma
 Array [
   Array [
     "event",
-    "abandon_confirmation_checkout",
+    "view_checkout_abandon_confirmation",
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
+      "checkout_step": 2,
       "coupon": "ACME2019",
       "currency": "USD",
+      "delivery_type": "Standard/Standard",
+      "packaging_type": "foo",
       "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
       "path_clean": "/en-pt/",
+      "payment_type": "credit",
+      "shipping": 10,
+      "shipping_tier": "Next Day",
+      "tax": 2.04,
+      "transaction_id": "50314b8e9bcf000000000000",
       "value": 24.64,
     },
   ],

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.ts
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.ts
@@ -44,7 +44,7 @@ const eventMapping = {
   [EventTypes.FILTERS_APPLIED]: 'apply_filters',
   [EventTypes.FILTERS_CLEARED]: 'clear_filters',
   [EventTypes.SHARE]: 'share',
-  [EventTypes.CHECKOUT_ABANDONED]: 'abandon_confirmation_checkout',
+  [EventTypes.CHECKOUT_ABANDONED]: 'view_checkout_abandon_confirmation',
   [EventTypes.PLACE_ORDER_STARTED]: 'place_order',
   [EventTypes.PROMOCODE_APPLIED]: 'apply_promo_code',
   [EventTypes.CHECKOUT_STEP_EDITING]: 'edit_checkout_step',
@@ -443,8 +443,16 @@ const getCheckoutAbandonedParametersFromEvent = (
   eventProperties: EventProperties,
 ) => {
   return {
-    currency: eventProperties.currency,
+    checkout_step: eventProperties.step,
     coupon: eventProperties.coupon,
+    currency: eventProperties.currency,
+    delivery_type: eventProperties.deliveryType,
+    packaging_type: eventProperties.packagingType,
+    payment_type: eventProperties.paymentType,
+    shipping_tier: eventProperties.shippingTier,
+    shipping: eventProperties.shipping,
+    tax: eventProperties.tax,
+    transaction_id: eventProperties.orderId,
     value: eventProperties.total,
   };
 };

--- a/packages/react/src/analytics/integrations/index.ts
+++ b/packages/react/src/analytics/integrations/index.ts
@@ -6,7 +6,10 @@ export { Integration };
 
 export { default as GA, validationSchemaBuilder } from './GA/index.js';
 export { default as GTM } from './GTM/index.js';
-export { default as Castle } from './Castle/index.js';
+export {
+  default as Castle,
+  CASTLE_CLIENT_ID_HEADER_NAME,
+} from './Castle/index.js';
 export { default as GA4 } from './GA4/index.js';
 export { default as Omnitracking } from './Omnitracking/index.js';
 export { default as Riskified } from './Riskified/index.js';

--- a/tests/__fixtures__/analytics/track/checkoutAbandonedTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/checkoutAbandonedTrackData.fixtures.mts
@@ -5,12 +5,18 @@ const fixtures = {
   ...baseTrackData,
   event: EventTypes.CHECKOUT_ABANDONED,
   properties: {
-    orderId: '50314b8e9bcf000000000000',
-    total: 24.64,
-    shipping: 3.6,
-    tax: 2.04,
+    checkoutOrderId: 12345678,
     coupon: 'ACME2019',
     currency: 'USD',
+    deliveryType: 'Standard/Standard',
+    orderId: '50314b8e9bcf000000000000',
+    packagingType: 'foo',
+    paymentType: 'credit',
+    shipping: 10,
+    shippingTier: 'Next Day',
+    step: 2,
+    tax: 2.04,
+    total: 24.64,
   },
 };
 


### PR DESCRIPTION
## Description

- Added parameters to checkout_abandoned event, regarding the analytics package improvements.
- On checkout_started switched two parameters for a method (`getDeliveryInformationDetails`) that returns those same parameters.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
