### PR TITLE
feat: add config parameter to `useBag` and `useBagItem` actions

### DIFF
--- a/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
@@ -39,6 +39,7 @@ jest.mock('@farfetch/blackout-redux', () => ({
 }));
 
 const metadata = { from: 'plp' };
+const myConfig = { headers: { Accept: 'application/vnd.mason+json' } };
 
 describe('useBag', () => {
   beforeEach(jest.clearAllMocks);
@@ -254,7 +255,12 @@ describe('useBag', () => {
         wrapper: withStore(mockState),
       });
 
-      await addItem(mockProductId, { quantity: 1, sizeId: 1 }, metadata);
+      await addItem(
+        mockProductId,
+        { quantity: 1, sizeId: 1 },
+        metadata,
+        myConfig,
+      );
 
       expect(addBagItem).toHaveBeenCalledWith(
         {
@@ -269,6 +275,7 @@ describe('useBag', () => {
         },
         undefined,
         metadata,
+        myConfig,
       );
     });
 
@@ -283,9 +290,14 @@ describe('useBag', () => {
         wrapper: withStore(mockState),
       });
 
-      await removeItem(mockBagItemId);
+      await removeItem(mockBagItemId, undefined, undefined, myConfig);
 
-      expect(removeBagItem).toHaveBeenCalledWith(mockBagItemId);
+      expect(removeBagItem).toHaveBeenCalledWith(
+        mockBagItemId,
+        undefined,
+        undefined,
+        myConfig,
+      );
     });
 
     it('should call `updateBagItem` action on quantity decrement', async () => {
@@ -299,7 +311,7 @@ describe('useBag', () => {
         wrapper: withStore(mockState),
       });
 
-      await updateItem(mockBagItemId, { quantity: 1 }, metadata);
+      await updateItem(mockBagItemId, { quantity: 1 }, metadata, myConfig);
 
       expect(updateBagItem).toHaveBeenCalledTimes(1);
       expect(updateBagItem).toHaveBeenCalledWith(
@@ -313,6 +325,7 @@ describe('useBag', () => {
         },
         undefined,
         metadata,
+        myConfig,
       );
     });
 
@@ -327,7 +340,7 @@ describe('useBag', () => {
         wrapper: withStore(mockState),
       });
 
-      await updateItem(mockBagItemId, { quantity: 6 }, metadata);
+      await updateItem(mockBagItemId, { quantity: 6 }, metadata, myConfig);
 
       expect(updateBagItem).toHaveBeenCalledTimes(1);
       expect(updateBagItem).toHaveBeenCalledWith(
@@ -344,6 +357,7 @@ describe('useBag', () => {
         },
         undefined,
         metadata,
+        myConfig,
       );
     });
 
@@ -358,7 +372,7 @@ describe('useBag', () => {
         wrapper: withStore(mockState),
       });
 
-      await updateItem(mockBagItemId, { sizeId: 4 }, metadata);
+      await updateItem(mockBagItemId, { sizeId: 4 }, metadata, myConfig);
 
       expect(updateBagItem).toHaveBeenCalledTimes(1);
       expect(addBagItem).not.toHaveBeenCalled();
@@ -373,6 +387,7 @@ describe('useBag', () => {
         },
         undefined,
         metadata,
+        myConfig,
       );
     });
 
@@ -387,7 +402,7 @@ describe('useBag', () => {
         wrapper: withStore(mockState),
       });
 
-      await updateItem(mockBagItemId, { sizeId: 2 }, metadata);
+      await updateItem(mockBagItemId, { sizeId: 2 }, metadata, myConfig);
 
       expect(updateBagItem).toHaveBeenCalledTimes(1);
       expect(addBagItem).toHaveBeenCalledTimes(1);
@@ -402,6 +417,7 @@ describe('useBag', () => {
         },
         undefined,
         metadata,
+        myConfig,
       );
       expect(addBagItem).toHaveBeenCalledWith(
         {
@@ -416,6 +432,7 @@ describe('useBag', () => {
         },
         undefined,
         metadata,
+        myConfig,
       );
     });
 
@@ -430,7 +447,12 @@ describe('useBag', () => {
         wrapper: withStore(mockState),
       });
 
-      await addItem(mockProductId, { sizeId: 23, quantity: 1 }, metadata);
+      await addItem(
+        mockProductId,
+        { sizeId: 23, quantity: 1 },
+        metadata,
+        myConfig,
+      );
 
       expect(addBagItem).not.toHaveBeenCalled();
       expect(updateBagItem).toHaveBeenCalledTimes(1);
@@ -448,6 +470,7 @@ describe('useBag', () => {
         },
         undefined,
         metadata,
+        myConfig,
       );
     });
 
@@ -462,7 +485,7 @@ describe('useBag', () => {
         wrapper: withStore(mockState),
       });
 
-      await updateItem(mockBagItemId, { sizeId: 2 }, metadata);
+      await updateItem(mockBagItemId, { sizeId: 2 }, metadata, myConfig);
 
       expect(updateBagItem).toHaveBeenCalledTimes(1);
       expect(updateBagItem).toHaveBeenCalledWith(
@@ -476,6 +499,7 @@ describe('useBag', () => {
         },
         undefined,
         metadata,
+        myConfig,
       );
     });
 
@@ -490,7 +514,12 @@ describe('useBag', () => {
         wrapper: withStore(mockState),
       });
 
-      await updateItem(mockBagItemId, { sizeId: 2, quantity: 2 }, metadata);
+      await updateItem(
+        mockBagItemId,
+        { sizeId: 2, quantity: 2 },
+        metadata,
+        myConfig,
+      );
 
       expect(updateBagItem).toHaveBeenCalledTimes(1);
       expect(updateBagItem).toHaveBeenCalledWith(
@@ -507,6 +536,7 @@ describe('useBag', () => {
         },
         undefined,
         metadata,
+        myConfig,
       );
     });
 
@@ -521,7 +551,7 @@ describe('useBag', () => {
         wrapper: withStore(mockState),
       });
 
-      await updateItem(mockBagItemId, { sizeId: 24 }, metadata);
+      await updateItem(mockBagItemId, { sizeId: 24 }, metadata, myConfig);
 
       expect(removeBagItem).toHaveBeenCalledTimes(1);
       expect(addBagItem).toHaveBeenCalledTimes(1);
@@ -529,6 +559,7 @@ describe('useBag', () => {
         mockBagItemId,
         undefined,
         metadata,
+        myConfig,
       );
       expect(addBagItem).toHaveBeenCalledWith(
         {
@@ -543,6 +574,7 @@ describe('useBag', () => {
         },
         undefined,
         metadata,
+        myConfig,
       );
     });
 

--- a/packages/react/src/bags/hooks/__tests__/useBagItem.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useBagItem.test.tsx
@@ -20,6 +20,8 @@ jest.mock('@farfetch/blackout-redux', () => ({
   removeBagItem: jest.fn(() => () => Promise.resolve()),
 }));
 
+const myConfig = { headers: { Accept: 'application/vnd.mason+json' } };
+
 describe('useBagItem', () => {
   beforeEach(jest.clearAllMocks);
 
@@ -124,12 +126,13 @@ describe('useBagItem', () => {
         wrapper: withStore(mockState),
       });
 
-      await remove();
+      await remove(undefined, myConfig);
 
       expect(removeBagItem).toHaveBeenCalledWith(
         mockBagItemId,
         undefined,
         undefined,
+        myConfig,
       );
     });
 
@@ -146,7 +149,7 @@ describe('useBagItem', () => {
 
       const metadata = { from: 'bag' };
 
-      await update({ sizeId: 2, quantity: 2 }, metadata);
+      await update({ sizeId: 2, quantity: 2 }, metadata, myConfig);
 
       expect(updateBagItem).toHaveBeenCalledTimes(1);
       expect(updateBagItem).toHaveBeenCalledWith(
@@ -163,6 +166,7 @@ describe('useBagItem', () => {
         },
         undefined,
         metadata,
+        myConfig,
       );
     });
   });

--- a/packages/react/src/bags/hooks/types/useBag.ts
+++ b/packages/react/src/bags/hooks/types/useBag.ts
@@ -1,33 +1,4 @@
-import type {
-  BagItemActionMetadata,
-  BagItemDenormalized,
-  CustomAttributesAdapted,
-  ProductEntityDenormalized,
-  SizeAdapted,
-} from '@farfetch/blackout-redux';
 import type { Config, GetBagQuery } from '@farfetch/blackout-client';
-
-export type HandleAddOrUpdateItem = (
-  {
-    customAttributes,
-    from,
-    product,
-    productAggregatorId,
-    quantity,
-    size,
-  }: {
-    customAttributes?: CustomAttributesAdapted | string;
-    from?: string;
-    product: ProductEntityDenormalized;
-    productAggregatorId?: Exclude<
-      BagItemDenormalized['productAggregator'],
-      null
-    >['id'];
-    quantity: number;
-    size: SizeAdapted;
-  },
-  metadata?: BagItemActionMetadata,
-) => Promise<void>;
 
 export type UseBagOptions = {
   enableAutoFetch?: boolean;

--- a/packages/react/src/bags/hooks/useBagItem.ts
+++ b/packages/react/src/bags/hooks/useBagItem.ts
@@ -13,6 +13,7 @@ import { useBag } from './/index.js';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import type { BagItemId, HandleUpdateBagItemData } from './types/index.js';
+import type { Config } from '@farfetch/blackout-client';
 
 /**
  * Provides Redux actions and state access, as well as handlers for dealing with
@@ -37,14 +38,17 @@ const useBagItem = (bagItemId: BagItemId) => {
   );
 
   const update = useCallback(
-    (data: HandleUpdateBagItemData, metadata?: BagItemActionMetadata) =>
-      updateItem(bagItemId, data, metadata),
+    (
+      data: HandleUpdateBagItemData,
+      metadata?: BagItemActionMetadata,
+      config?: Config,
+    ) => updateItem(bagItemId, data, metadata, config),
     [updateItem, bagItemId],
   );
 
   const remove = useCallback(
-    (metadata?: BagItemActionMetadata) =>
-      removeItem(bagItemId, undefined, metadata),
+    (metadata?: BagItemActionMetadata, config?: Config) =>
+      removeItem(bagItemId, undefined, metadata, config),
     [removeItem, bagItemId],
   );
 


### PR DESCRIPTION
## Description

This adds a config parameter to all actions that were missing it from `useBag` and `useBagItem` actions. Also, removed the `HandleAddOrUpdateItem` from the exported types as it is an internal type.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
