### PR TITLE
feat(client): add legacy fetch user returns endpoint

### DIFF
--- a/packages/client/src/users/returns/__fixtures__/getUserReturnsLegacy.fixtures.ts
+++ b/packages/client/src/users/returns/__fixtures__/getUserReturnsLegacy.fixtures.ts
@@ -1,0 +1,17 @@
+import { rest, type RestHandler } from 'msw';
+import type { UserReturns } from '../types/index.js';
+
+const path = '/api/legacy/v1/users/:userId/returns';
+
+const fixtures = {
+  success: (response: UserReturns): RestHandler =>
+    rest.get(path, (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.get(path, (_req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
+};
+
+export default fixtures;

--- a/packages/client/src/users/returns/__tests__/__snapshots__/getUserReturnsLegacy.test.ts.snap
+++ b/packages/client/src/users/returns/__tests__/__snapshots__/getUserReturnsLegacy.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getUserReturnsLegacy should receive a client request error 1`] = `
+Object {
+  "code": "-1",
+  "message": "stub error",
+  "name": "AxiosError",
+  "status": 404,
+  "transportLayerErrorCode": "ERR_BAD_REQUEST",
+}
+`;

--- a/packages/client/src/users/returns/__tests__/getUserReturnsLegacy.test.ts
+++ b/packages/client/src/users/returns/__tests__/getUserReturnsLegacy.test.ts
@@ -1,0 +1,38 @@
+import { getUserReturnsLegacy } from '../index.js';
+import {
+  mockUserReturnsResponse,
+  userId,
+} from 'tests/__fixtures__/users/index.mjs';
+import client from '../../../helpers/client/index.js';
+import fixtures from '../__fixtures__/getUserReturnsLegacy.fixtures.js';
+import mswServer from '../../../../tests/mswServer.js';
+
+describe('getUserReturnsLegacy', () => {
+  const expectedConfig = undefined;
+  const spy = jest.spyOn(client, 'get');
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should handle a client request successfully', async () => {
+    mswServer.use(fixtures.success(mockUserReturnsResponse));
+
+    await expect(getUserReturnsLegacy(userId)).resolves.toStrictEqual(
+      mockUserReturnsResponse,
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      `/legacy/v1/users/${userId}/returns`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    mswServer.use(fixtures.failure());
+
+    await expect(getUserReturnsLegacy(userId)).rejects.toMatchSnapshot();
+    expect(spy).toHaveBeenCalledWith(
+      `/legacy/v1/users/${userId}/returns`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/client/src/users/returns/getUserReturnsLegacy.ts
+++ b/packages/client/src/users/returns/getUserReturnsLegacy.ts
@@ -1,0 +1,29 @@
+import { adaptError } from '../../helpers/client/formatError.js';
+import client from '../../helpers/client/index.js';
+import join from 'proper-url-join';
+import type { GetUserReturns } from './types/index.js';
+
+/**
+ * Method responsible for getting all the user returns.
+ *
+ * @param userId - The user's id.
+ * @param query - Query parameters.
+ * @param config - Custom configurations to send to the client instance (axios).
+ *
+ * @returns Promise that will resolve when the call to the endpoint finishes.
+ */
+
+const getUserReturnsLegacy: GetUserReturns = (userId, query, config) =>
+  client
+    .get(
+      join('legacy/v1/users', userId, '/returns', {
+        query,
+      }),
+      config,
+    )
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });
+
+export default getUserReturnsLegacy;

--- a/packages/client/src/users/returns/index.ts
+++ b/packages/client/src/users/returns/index.ts
@@ -1,2 +1,3 @@
 export { default as getUserReturns } from './getUserReturns.js';
+export { default as getUserReturnsLegacy } from './getUserReturnsLegacy.js';
 export * from './types/index.js';


### PR DESCRIPTION
## Description
Add legacy fetch user returns endpoint

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
