### PR TITLE
fix: fix `patchCheckoutOrderItems` types

### DIFF
--- a/packages/client/src/checkout/types/patchCheckoutOrderItems.types.ts
+++ b/packages/client/src/checkout/types/patchCheckoutOrderItems.types.ts
@@ -1,5 +1,6 @@
 import type { AddPatch, RemovePatch, ReplacePatch } from 'json-patch';
 import type { CheckoutOrder } from './checkoutOrder.types.js';
+import type { CheckoutOrderItem } from './checkoutOrderItem.types.js';
 import type { Config } from '../../types/index.js';
 
 export type GiftMessage = {
@@ -22,10 +23,8 @@ export type PatchCheckoutOrderItemsOperation =
   | RemovePatch;
 
 export type PatchCheckoutOrderItemsData = {
-  checkoutOrderItemId: number;
-  checkoutItemPatchDocument: {
-    operations: PatchCheckoutOrderItemsOperation[];
-  };
+  checkoutOrderItemId: CheckoutOrderItem['id'];
+  checkoutItemPatchDocument: PatchCheckoutOrderItemsOperation[];
 }[];
 
 export type PatchCheckoutOrderItems = (

--- a/packages/redux/src/checkout/actions/__tests__/updateCheckoutOrderItems.test.ts
+++ b/packages/redux/src/checkout/actions/__tests__/updateCheckoutOrderItems.test.ts
@@ -21,34 +21,30 @@ describe('updateCheckoutOrderItems() action creator', () => {
   const data: PatchCheckoutOrderItemsData = [
     {
       checkoutOrderItemId: 1,
-      checkoutItemPatchDocument: {
-        operations: [
-          {
-            value: {
-              from: 'string',
-              to: 'string',
-              message: 'string',
-            },
-            path: 'string',
-            op: 'replace',
+      checkoutItemPatchDocument: [
+        {
+          value: {
+            from: 'string',
+            to: 'string',
+            message: 'string',
           },
-        ],
-      },
+          path: 'string',
+          op: 'replace',
+        },
+      ],
     },
     {
       checkoutOrderItemId: 2,
-      checkoutItemPatchDocument: {
-        operations: [
-          {
-            value: {
-              from: 'string',
-              to: 'string',
-            },
-            path: 'string',
-            op: 'add',
+      checkoutItemPatchDocument: [
+        {
+          value: {
+            from: 'string',
+            to: 'string',
           },
-        ],
-      },
+          path: 'string',
+          op: 'add',
+        },
+      ],
     },
   ];
   let store: ReturnType<typeof checkoutMockStore>;

--- a/tests/__fixtures__/checkout/checkout.fixtures.mts
+++ b/tests/__fixtures__/checkout/checkout.fixtures.mts
@@ -851,35 +851,31 @@ export const mockResponsePatchOrderItemsGiftMessage: PatchCheckoutOrderItemsData
   [
     {
       checkoutOrderItemId: 1,
-      checkoutItemPatchDocument: {
-        operations: [
-          {
-            value: {
-              from: 'string',
-              to: 'string',
-              message: 'string',
-            },
-            path: 'string',
-            op: 'replace',
+      checkoutItemPatchDocument: [
+        {
+          value: {
+            from: 'string',
+            to: 'string',
+            message: 'string',
           },
-        ],
-      },
+          path: 'string',
+          op: 'replace',
+        },
+      ],
     },
     {
       checkoutOrderItemId: 2,
-      checkoutItemPatchDocument: {
-        operations: [
-          {
-            value: {
-              from: 'string',
-              to: 'string',
-              message: 'string',
-            },
-            path: 'string',
-            op: 'add',
+      checkoutItemPatchDocument: [
+        {
+          value: {
+            from: 'string',
+            to: 'string',
+            message: 'string',
           },
-        ],
-      },
+          path: 'string',
+          op: 'add',
+        },
+      ],
     },
   ];
 


### PR DESCRIPTION
## Description

This fixes the type `PatchCheckoutOrderItemsData` which should not require an object with an `operations` property inside the `checkoutItemPatchDocument` property but instead receive the array of operations directly.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
