### PR TITLE
feat: add parameters add shipping info event next

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -251,9 +251,11 @@ Object {
 
 exports[`Omnitracking track events definitions \`Shipping Info Added\` return should match the snapshot 1`] = `
 Object {
+  "checkoutOrderId": 15338048,
   "checkoutStep": "2",
   "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\"}",
   "interactionType": "click",
+  "orderCode": "50314b8e9bcf000000000000",
   "selectedPaymentMethod": "credit",
   "tid": 2914,
 }

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -482,6 +482,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     tid: 2912,
   }),
   [EventTypes.SHIPPING_INFO_ADDED]: data => ({
+    ...getCheckoutEventGenericProperties(data),
     ...getCommonCheckoutStepTrackingData(data),
     tid: 2914,
   }),

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -934,7 +934,7 @@ Array [
     "add_shipping_info",
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
-      "address_finder": undefined,
+      "checkout_step": "2",
       "coupon": "ACME2019",
       "currency": "USD",
       "delivery_type": "Standard/Standard",
@@ -964,6 +964,7 @@ Array [
       "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
       "path_clean": "/en-pt/",
       "shipping_tier": "Next Day",
+      "transaction_id": "50314b8e9bcf000000000000",
       "value": 24.64,
     },
   ],

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.ts
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.ts
@@ -471,9 +471,10 @@ const getShippingInfoAddedParametersFromEvent = (
   return {
     ...getCheckoutParametersFromEvent(eventProperties),
     shipping_tier: eventProperties.shippingTier,
-    address_finder: eventProperties.addressFinder,
     delivery_type: eventProperties.deliveryType,
     packaging_type: eventProperties.packagingType,
+    checkout_step: eventProperties.step,
+    transaction_id: eventProperties.orderId,
   };
 };
 

--- a/tests/__fixtures__/analytics/track/shippingInfoAddedTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/shippingInfoAddedTrackData.fixtures.mts
@@ -6,6 +6,7 @@ const fixtures = {
   event: EventTypes.SHIPPING_INFO_ADDED,
   properties: {
     orderId: '50314b8e9bcf000000000000',
+    checkoutOrderId: 15338048,
     total: 24.64,
     shipping: 3.6,
     tax: 2.04,


### PR DESCRIPTION
## Description

Changes made on add_shipping_info regarding analytics package improvements.
- Removed address_finder parameter
- Added checkout_step and checkoutOrderId. 

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
