### PR TITLE
fix(react): add missing orderId parameter on order_completed event

### DIFF
--- a/packages/react/src/analytics/integrations/GTM/eventsMapper.js
+++ b/packages/react/src/analytics/integrations/GTM/eventsMapper.js
@@ -123,6 +123,7 @@ const eventsMapper = {
       shipping: properties.shipping,
       coupon: properties.coupon,
       currency: properties.currency,
+      orderId: properties.orderId,
     };
   },
   [eventTypes.ORDER_REFUNDED]: data => {

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GTM.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GTM.test.js.snap
@@ -57,6 +57,7 @@ exports[`GTM EventsMapper Should match the snapshot for the event: Order Complet
 Object {
   "coupon": undefined,
   "currency": undefined,
+  "orderId": "OFH1213",
   "products": Array [
     Object {
       "brand": "RALPH LAUREN",


### PR DESCRIPTION
## Description
This PR fixes a bug with the analytics GTM integration which was not passing the `orderId` parameter on the `order_completed` event.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
