### PR TITLE
chore: prevent automatic major version bumps to `main`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,14 +51,18 @@ jobs:
       # This is needed for lerna to commit and push the
       # new version when making a release
       - name: Checkout the source branch in a pull request for lerna
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         if: ${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'rc/') }}
-        run: git checkout "${{ github.head_ref }}"
+        run: git checkout "$HEAD_REF"
 
       # This is needed for lerna to commit and push the
       # new version when making a release
       - name: Checkout the branch for pushes to a branch for lerna
+        env:
+          REF_NAME: ${{ github.ref_name }}
         if: ${{ github.event_name == 'push' }}
-        run: git checkout "${{ github.ref_name }}"
+        run: git checkout "$REF_NAME"
 
       # Retrieves the commit message to be used in the
       # make release step
@@ -86,8 +90,7 @@ jobs:
       - name: Make release
         if: |
           github.ref_name == 'main' ||
-          github.ref_name == 'next' ||
-          (github.event_name == 'pull_request' && startsWith(github.head_ref, 'rc/'))
+          github.ref_name == 'next'
         env:
           MAKE_RELEASE_COMMIT_MESSAGE: 'chore: make release'
           PUBLISH_COMMIT_MESSAGE: 'chore: publish [skip build]'

--- a/patches/@lerna+conventional-commits+5.6.2.patch
+++ b/patches/@lerna+conventional-commits+5.6.2.patch
@@ -1,0 +1,27 @@
+diff --git a/node_modules/@lerna/conventional-commits/lib/recommend-version.js b/node_modules/@lerna/conventional-commits/lib/recommend-version.js
+index a982adf..1482fe3 100644
+--- a/node_modules/@lerna/conventional-commits/lib/recommend-version.js
++++ b/node_modules/@lerna/conventional-commits/lib/recommend-version.js
+@@ -12,7 +12,7 @@ module.exports.recommendVersion = recommendVersion;
+  * @param {import("..").VersioningStrategy} type
+  * @param {import("..").BaseChangelogOptions & { prereleaseId?: string }} commandOptions
+  */
+-function recommendVersion(pkg, type, { changelogPreset, rootPath, tagPrefix, prereleaseId }) {
++function recommendVersion(pkg, type, { changelogPreset, rootPath, tagPrefix, prereleaseId, forceMajorBumpsIntoMinor }) {
+   log.silly(type, "for %s at %s", pkg.name, pkg.location);
+ 
+   const options = {
+@@ -58,6 +58,13 @@ function recommendVersion(pkg, type, { changelogPreset, rootPath, tagPrefix, pre
+         // we still need to bump _something_ because lerna saw a change here
+         let releaseType = data.releaseType || "patch";
+ 
++        // if recommended release type is major and --force-major-bumps-into-minor
++        // option is passed, change it to minor to prevent updating the major
++        // when not desired
++        if (releaseType === 'major' && forceMajorBumpsIntoMinor) {
++          releaseType = 'minor';
++        }
++
+         if (prereleaseId) {
+           const shouldBump = shouldBumpPrerelease(releaseType, pkg.version);
+           const prereleaseType = shouldBump ? `pre${releaseType}` : "prerelease";

--- a/patches/@lerna+version+5.6.2.patch
+++ b/patches/@lerna+version+5.6.2.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/@lerna/version/command.js b/node_modules/@lerna/version/command.js
+index d82bd24..73c4736 100644
+--- a/node_modules/@lerna/version/command.js
++++ b/node_modules/@lerna/version/command.js
+@@ -165,6 +165,10 @@ exports.builder = (yargs, composed) => {
+       alias: "yes",
+       type: "boolean",
+     },
++    "force-major-bumps-into-minor": {
++      describe: "When using `--conventional-commits` option, this flag converts recommended major version bumps to minor",
++      type: "boolean",
++    },
+   };
+ 
+   if (composed) {
+diff --git a/node_modules/@lerna/version/index.js b/node_modules/@lerna/version/index.js
+index e4fbf24..5c3488f 100644
+--- a/node_modules/@lerna/version/index.js
++++ b/node_modules/@lerna/version/index.js
+@@ -367,7 +367,7 @@ class VersionCommand extends Command {
+ 
+   recommendVersions(resolvePrereleaseId) {
+     const independentVersions = this.project.isIndependent();
+-    const { changelogPreset, conventionalGraduate } = this.options;
++    const { changelogPreset, conventionalGraduate, forceMajorBumpsIntoMinor } = this.options;
+     const rootPath = this.project.manifest.location;
+     const type = independentVersions ? "independent" : "fixed";
+     const prereleasePackageNames = this.getPrereleasePackageNames();
+@@ -394,6 +394,7 @@ class VersionCommand extends Command {
+           rootPath,
+           tagPrefix: this.tagPrefix,
+           prereleaseId: getPrereleaseId(node),
++          forceMajorBumpsIntoMinor,
+         })
+       )
+     );

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,18 +2,53 @@
 
 git remote set-url origin "https://${GITHUB_TOKEN}@github.com/Farfetch/blackout.git"
 
-SOURCE_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 CONTENTS="--contents dist"
 
-if [[ ${SOURCE_BRANCH_NAME} = main || ${SOURCE_BRANCH_NAME} = next ]]; then    
-    if [[ ${SOURCE_BRANCH_NAME} = next ]]; then
+if [[ ${CURRENT_BRANCH_NAME} = main || ${CURRENT_BRANCH_NAME} = next ]]; then    
+    if [[ ${CURRENT_BRANCH_NAME} = next ]]; then
         PRE_ID_NAME='next'
         PRE_ID="--preid ${PRE_ID_NAME}"
         PRE_DIST_TAG="--pre-dist-tag ${PRE_ID_NAME}"
         CONVENTIONAL_PRERELEASE="--conventional-prerelease"
     fi
 
-    npx lerna version --conventional-commits --yes --message "${PUBLISH_COMMIT_MESSAGE}" ${PRE_ID} ${CONVENTIONAL_PRERELEASE} --loglevel=verbose
+    if [[ ${CURRENT_BRANCH_NAME} = main ]]; then
+        # If the current branch is main, we need to check if the commit
+        # came from next branch. If it did not, then we will not allow
+        # bumps to major version as those should only happen when
+        # next branch is merged to main.
+
+        # Get the second parent commit hash if it exists
+        SECOND_PARENT_COMMIT=$(git log --pretty=%P -n 1 | awk '{print $2}')
+
+        if [[ -n $SECOND_PARENT_COMMIT ]]; then
+            # If there is a second parent commit, it means this commit is a merge commit.
+            # In that case, we check if the `next` branch contains that commit.
+            # This should be the case only when the merge commit was obtained from merging
+            # the next branch onto the main branch.
+            IS_FROM_NEXT_BRANCH=$(git branch --format "%(refname:short)" --contains "$SECOND_PARENT_COMMIT" --merge | grep -q "next" && echo "0" || echo "1")
+        else 
+            # If there is not a second parent commit, this could mean that the main
+            # branch could have been fast-forwarded to point to the same commit as
+            # next, so we check for that case as well.
+            IS_FROM_NEXT_BRANCH=$([[ $(git rev-parse main) = $(git rev-parse next) ]] && echo "0" || echo "1")
+        fi
+
+        # If this commit did not come from "next", then set `--force-major-bumps-into-minor`
+        # flag for lerna version.
+        if [[ $IS_FROM_NEXT_BRANCH -ne 0 ]]; then
+            FORCE_MAJOR_BUMPS_INTO_MINOR='--force-major-bumps-into-minor'
+        fi
+    fi
+
+    # First, calculate the next version and generate changelog but
+    # do not publish to npm as the packages need to be built only
+    # after the next version is calculated because there is a babel
+    # transform which will replace any imports to `version` from `package.json` 
+    # with the literal version obtained from the `package.json` so to
+    # avoid setting the wrong version, the packages __MUST__ be built only after this step.
+    npx lerna version --conventional-commits --yes --message "${PUBLISH_COMMIT_MESSAGE}" ${PRE_ID} ${CONVENTIONAL_PRERELEASE} ${FORCE_MAJOR_BUMPS_INTO_MINOR} --loglevel=verbose
 
     yarn build
 


### PR DESCRIPTION
## Description

This changes the pipeline to prevent commits that contain breaking changes from updating the major version of the packages as those are only supposed to be created when next is merged into main.

Unfortunately, the only was to make this work with lerna is to apply a patch to the version command to look for a specific flag parameter that was added for it.

This also applies some best practices to load github context variables into run scripts in CI workflow.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [ ] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
