### PR TITLE
feat(client|redux|react): add post guest orders endpoint

### DIFF
--- a/packages/client/src/orders/__fixtures__/getGuestOrderLegacy.fixtures.ts
+++ b/packages/client/src/orders/__fixtures__/getGuestOrderLegacy.fixtures.ts
@@ -5,11 +5,11 @@ const path = '/api/legacy/v1/guestorders/:id';
 
 const fixtures = {
   success: (response: Order): RestHandler =>
-    rest.get(path, (_req, res, ctx) =>
+    rest.post(path, (_req, res, ctx) =>
       res(ctx.status(200), ctx.json(response)),
     ),
   failure: (): RestHandler =>
-    rest.get(path, (_req, res, ctx) =>
+    rest.post(path, (_req, res, ctx) =>
       res(ctx.status(404), ctx.json({ message: 'stub error' })),
     ),
 };

--- a/packages/client/src/orders/__tests__/getGuestOrderLegacy.test.ts
+++ b/packages/client/src/orders/__tests__/getGuestOrderLegacy.test.ts
@@ -7,22 +7,25 @@ import client from '../../helpers/client/index.js';
 import fixtures from '../__fixtures__/getGuestOrderLegacy.fixtures.js';
 import mswServer from '../../../tests/mswServer.js';
 
-const email = 'dummy@email.com';
+const data = {
+  guestUserEmail: 'dummy@email.com',
+};
 const expectedConfig = undefined;
 
 beforeEach(() => jest.clearAllMocks());
 
 describe('getGuestOrderLegacy', () => {
-  const spy = jest.spyOn(client, 'get');
+  const spy = jest.spyOn(client, 'post');
 
   it('should handle a client request successfully', async () => {
     mswServer.use(fixtures.success(mockOrderDetailsResponse));
 
-    await expect(getGuestOrderLegacy(orderId, email)).resolves.toStrictEqual(
+    await expect(getGuestOrderLegacy(orderId, data)).resolves.toStrictEqual(
       mockOrderDetailsResponse,
     );
     expect(spy).toHaveBeenCalledWith(
-      `/legacy/v1/guestorders/${orderId}?guestUserEmail=dummy%40email.com`,
+      `/legacy/v1/guestorders/${orderId}`,
+      data,
       expectedConfig,
     );
   });
@@ -30,9 +33,10 @@ describe('getGuestOrderLegacy', () => {
   it('should receive a client request error', async () => {
     mswServer.use(fixtures.failure());
 
-    await expect(getGuestOrderLegacy(orderId, email)).rejects.toMatchSnapshot();
+    await expect(getGuestOrderLegacy(orderId, data)).rejects.toMatchSnapshot();
     expect(spy).toHaveBeenCalledWith(
-      `/legacy/v1/guestorders/${orderId}?guestUserEmail=dummy%40email.com`,
+      `/legacy/v1/guestorders/${orderId}`,
+      data,
       expectedConfig,
     );
   });

--- a/packages/client/src/orders/getGuestOrderLegacy.ts
+++ b/packages/client/src/orders/getGuestOrderLegacy.ts
@@ -11,23 +11,16 @@ import type { GetGuestOrderLegacy } from './types/index.js';
  * Uses the legacy method which requires cookies.
  *
  * @param orderId - The orderID to get the details.
- * @param guestUserEmail - The guest user email.
+ * @param data - Request data.
  * @param config - Custom configurations to send to the client
  * instance (axios).
  *
  * @returns Promise that will resolve when the call to the endpoint finishes.
  *
  */
-const getGuestOrderLegacy: GetGuestOrderLegacy = (
-  orderId,
-  guestUserEmail,
-  config,
-) => {
+const getGuestOrderLegacy: GetGuestOrderLegacy = (orderId, data, config) => {
   return client
-    .get(
-      join('/legacy/v1/guestorders/', orderId, { query: { guestUserEmail } }),
-      config,
-    )
+    .post(join('/legacy/v1/guestorders/', orderId), data, config)
     .then(response => response.data)
     .catch(error => {
       throw adaptError(error);

--- a/packages/client/src/orders/types/getGuestOrderLegacy.types.ts
+++ b/packages/client/src/orders/types/getGuestOrderLegacy.types.ts
@@ -1,8 +1,12 @@
 import type { Config } from '../../types/index.js';
 import type { OrderLegacy } from './index.js';
 
+export type GetGuestOrderLegacyData = {
+  guestUserEmail: string;
+};
+
 export type GetGuestOrderLegacy = (
   id: string,
-  guestUserEmail: string,
+  data: GetGuestOrderLegacyData,
   config?: Config,
 ) => Promise<OrderLegacy>;

--- a/packages/react/src/orders/hooks/__tests__/useOrders.test.tsx
+++ b/packages/react/src/orders/hooks/__tests__/useOrders.test.tsx
@@ -8,6 +8,7 @@ import {
   resetOrders,
 } from '@farfetch/blackout-redux';
 import {
+  mockGuestUserData,
   mockGuestUserEmail,
   mockState,
   orderEntityDenormalized,
@@ -424,7 +425,7 @@ describe('useOrders', () => {
 
           expect(fetchGuestOrderLegacy).toHaveBeenCalledWith(
             orderId,
-            mockGuestUserEmail,
+            mockGuestUserData,
             mockFetchConfig,
           );
         });

--- a/packages/react/src/orders/hooks/useOrders.ts
+++ b/packages/react/src/orders/hooks/useOrders.ts
@@ -99,7 +99,7 @@ function useOrders(options: UseOrdersOptions = {}) {
       const useLegacyEndpointForGuest = !!guestUserEmail;
 
       return useLegacyEndpointForGuest
-        ? fetchGuestOrderLegacy(orderId, guestUserEmail as string, config)
+        ? fetchGuestOrderLegacy(orderId, { guestUserEmail }, config)
         : fetchOrder(orderId, config);
     },
     [fetchGuestOrderLegacy, fetchOrder, isAuthenticated],

--- a/packages/redux/src/orders/actions/__tests__/fetchGuestOrderLegacy.test.ts
+++ b/packages/redux/src/orders/actions/__tests__/fetchGuestOrderLegacy.test.ts
@@ -3,7 +3,7 @@ import * as normalizr from 'normalizr';
 import { fetchGuestOrderLegacy } from '../index.js';
 import {
   getExpectedOrderDetailsNormalizedPayload,
-  mockGuestUserEmail,
+  mockGuestUserData,
   mockOrderDetailsResponse,
   orderId,
 } from 'tests/__fixtures__/orders/index.mjs';
@@ -47,7 +47,7 @@ describe('fetchGuestOrderLegacy() action creator', () => {
 
     await expect(
       async () =>
-        await fetchGuestOrderLegacy(orderId, mockGuestUserEmail)(
+        await fetchGuestOrderLegacy(orderId, mockGuestUserData)(
           store.dispatch,
           store.getState as () => StoreState,
           { getOptions },
@@ -57,7 +57,7 @@ describe('fetchGuestOrderLegacy() action creator', () => {
     expect(getGuestOrderLegacy).toHaveBeenCalledTimes(1);
     expect(getGuestOrderLegacy).toHaveBeenCalledWith(
       orderId,
-      mockGuestUserEmail,
+      mockGuestUserData,
       expectedConfig,
     );
     expect(store.getActions()).toEqual([
@@ -84,7 +84,7 @@ describe('fetchGuestOrderLegacy() action creator', () => {
 
     expectedPayload.entities.orders[orderId].totalItems = 3;
 
-    await fetchGuestOrderLegacy(orderId, mockGuestUserEmail)(
+    await fetchGuestOrderLegacy(orderId, mockGuestUserData)(
       store.dispatch,
       store.getState as () => StoreState,
       { getOptions },
@@ -96,7 +96,7 @@ describe('fetchGuestOrderLegacy() action creator', () => {
     expect(getGuestOrderLegacy).toHaveBeenCalledTimes(1);
     expect(getGuestOrderLegacy).toHaveBeenCalledWith(
       orderId,
-      mockGuestUserEmail,
+      mockGuestUserData,
       expectedConfig,
     );
     expect(store.getActions()).toEqual([
@@ -122,7 +122,7 @@ describe('fetchGuestOrderLegacy() action creator', () => {
 
     expectedPayload.entities.orders[orderId].totalItems = 3;
 
-    await fetchGuestOrderLegacy(orderId, mockGuestUserEmail)(
+    await fetchGuestOrderLegacy(orderId, mockGuestUserData)(
       store.dispatch,
       store.getState as () => StoreState,
       {} as GetOptionsArgument,
@@ -134,7 +134,7 @@ describe('fetchGuestOrderLegacy() action creator', () => {
     expect(getGuestOrderLegacy).toHaveBeenCalledTimes(1);
     expect(getGuestOrderLegacy).toHaveBeenCalledWith(
       orderId,
-      mockGuestUserEmail,
+      mockGuestUserData,
       expectedConfig,
     );
     expect(store.getActions()).toEqual([

--- a/packages/redux/src/orders/actions/factories/fetchGuestOrderLegacyFactory.ts
+++ b/packages/redux/src/orders/actions/factories/fetchGuestOrderLegacyFactory.ts
@@ -2,6 +2,7 @@ import * as actionTypes from '../../actionTypes.js';
 import {
   type Config,
   type GetGuestOrderLegacy,
+  type GetGuestOrderLegacyData,
   type OrderLegacy,
   toBlackoutError,
 } from '@farfetch/blackout-client';
@@ -19,7 +20,7 @@ import type { GetOptionsArgument, StoreState } from '../../../types/index.js';
  */
 const fetchGuestOrderLegacyFactory =
   (getGuestOrderLegacy: GetGuestOrderLegacy) =>
-  (orderId: string, guestUserEmail: string, config?: Config) =>
+  (orderId: string, data: GetGuestOrderLegacyData, config?: Config) =>
   async (
     dispatch: Dispatch<FetchOrderAction>,
     getState: () => StoreState,
@@ -34,7 +35,7 @@ const fetchGuestOrderLegacyFactory =
       });
 
       const { productImgQueryParam } = getOptions(getState);
-      const result = await getGuestOrderLegacy(orderId, guestUserEmail, config);
+      const result = await getGuestOrderLegacy(orderId, data, config);
       const normalizedResult = normalizeFetchOrderResponse(
         result,
         productImgQueryParam,

--- a/tests/__fixtures__/orders/orders.fixtures.mts
+++ b/tests/__fixtures__/orders/orders.fixtures.mts
@@ -50,6 +50,10 @@ export const trackingNumber2 = '4538009163';
 export const userId = 29521154;
 export const mockGuestUserEmail = 'qat5@farfetch.com';
 
+export const mockGuestUserData = {
+  guestUserEmail: mockGuestUserEmail,
+};
+
 export const mockOrdersResponse = {
   entries: [
     {


### PR DESCRIPTION
## Description

This updates the fetchGuestOrdersLegacy to be a POST.

BREAKING CHANGE: The fetchGuestOrdersLegacy is now a POST to prevent from leaking query data to google analytics. Now it accepts an object as data with the user email instead of passing the email as query.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->
None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
