### PR TITLE
fix: fix possible infinite loop in `useCheckoutOrderDetails`

### DIFF
--- a/packages/react/src/checkout/hooks/__tests__/useCheckoutOrderDetails.test.tsx
+++ b/packages/react/src/checkout/hooks/__tests__/useCheckoutOrderDetails.test.tsx
@@ -9,7 +9,7 @@ import {
 import { cleanup, renderHook } from '@testing-library/react';
 import {
   fetchCheckoutOrderDetails,
-  resetCheckoutOrderDetailsState,
+  resetCheckout,
 } from '@farfetch/blackout-redux';
 import { withStore } from '../../../../tests/helpers/index.js';
 import useCheckoutOrderDetails from '../useCheckoutOrderDetails.js';
@@ -19,8 +19,8 @@ jest.mock('@farfetch/blackout-redux', () => ({
   fetchCheckoutOrderDetails: jest.fn(() => ({
     type: 'fetch_checkout_order_details',
   })),
-  resetCheckoutOrderDetailsState: jest.fn(() => ({
-    type: 'reset_checkout_order_details_state',
+  resetCheckout: jest.fn(() => ({
+    type: 'reset_checkout',
   })),
 }));
 
@@ -103,7 +103,7 @@ describe('useCheckoutOrderDetails', () => {
         wrapper: withStore(mockCheckoutState),
       });
 
-      expect(resetCheckoutOrderDetailsState).toHaveBeenCalled();
+      expect(resetCheckout).toHaveBeenCalled();
     });
 
     it('should not call reset if the passed checkoutOrderId does not differ from the checkoutOrderId that is in state', () => {
@@ -111,7 +111,7 @@ describe('useCheckoutOrderDetails', () => {
         wrapper: withStore(mockCheckoutState),
       });
 
-      expect(resetCheckoutOrderDetailsState).not.toHaveBeenCalled();
+      expect(resetCheckout).not.toHaveBeenCalled();
     });
 
     it('should not call reset if the checkoutOrderId hook parameter is passed but there is no checkout details data in state', () => {
@@ -119,7 +119,7 @@ describe('useCheckoutOrderDetails', () => {
         wrapper: withStore(mockInitialState),
       });
 
-      expect(resetCheckoutOrderDetailsState).not.toHaveBeenCalled();
+      expect(resetCheckout).not.toHaveBeenCalled();
     });
   });
 
@@ -323,7 +323,7 @@ describe('useCheckoutOrderDetails', () => {
 
         await reset();
 
-        expect(resetCheckoutOrderDetailsState).toHaveBeenCalled();
+        expect(resetCheckout).toHaveBeenCalled();
       });
     });
   });

--- a/packages/react/src/checkout/hooks/useCheckoutOrderDetails.ts
+++ b/packages/react/src/checkout/hooks/useCheckoutOrderDetails.ts
@@ -4,7 +4,7 @@ import {
   fetchCheckoutOrderDetails,
   getCheckoutOrderDetails,
   getCheckoutOrderDetailsError,
-  resetCheckoutOrderDetailsState,
+  resetCheckout,
 } from '@farfetch/blackout-redux';
 import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
@@ -22,7 +22,7 @@ function useCheckoutOrderDetails(
   const isFetched = useSelector(areCheckoutOrderDetailsFetched);
   const details = useSelector(getCheckoutOrderDetails);
   const fetchCheckoutOrderDetailsAction = useAction(fetchCheckoutOrderDetails);
-  const reset = useAction(resetCheckoutOrderDetailsState);
+  const reset = useAction(resetCheckout);
 
   const fetch = useCallback(
     (config: Config | undefined = fetchConfig) => {


### PR DESCRIPTION
## Description

This fixes a possible infinite loop in `useCheckoutOrderDetails` when the redux store contains the details of another checkout order than the one the hook is requested to fetch, it will try infinitely to reset the details state because the reset action that is being used does not clear that particular state. To fix this, we use the `resetCheckout` to clear all checkout data instead.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
