### PR TITLE
feat(client): add package to unsubcribe action for `next`

### DIFF
--- a/packages/client/src/subscriptions/types/deleteSubscription.types.ts
+++ b/packages/client/src/subscriptions/types/deleteSubscription.types.ts
@@ -14,4 +14,8 @@ export type DeleteSubscriptionQuery = {
    * SHA256 hash of the user's email to be unsubscribed.
    */
   emailHash: string;
+  /**
+   * Package list to be unsubscribed
+   */
+  packageList?: Array<string>;
 };

--- a/tests/__fixtures__/subscriptions/subscriptions.fixtures.mts
+++ b/tests/__fixtures__/subscriptions/subscriptions.fixtures.mts
@@ -5,6 +5,7 @@ export const mockDeleteSubscription = {
     emailHash:
       '1ca9c02be7e27f42bdfdca1afef2618003bbdc7d08fe2e9b54d2ac5af8b37127',
     id: 'c3e39b1f-69a8-47e3-ab7f-743ddd1278bc',
+    packageList: ['Newsletters', 'Product_notifications'],
   },
   response: {},
 };


### PR DESCRIPTION
## Description

- update action and client of unsubcription to allow usage of parameter `package`

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
