### PR TITLE
feat(react): remove castle pageview event tracking for `next`

### DIFF
--- a/packages/react/src/analytics/integrations/Castle/Castle.ts
+++ b/packages/react/src/analytics/integrations/Castle/Castle.ts
@@ -49,10 +49,8 @@ import type { CastleIntegrationOptions } from './types/index.js';
 import type {
   ConfigureOptions,
   FormParams,
-  PageParams,
   UserParams,
 } from '@castleio/castle-js';
-import type { WebContextType } from '../../context.js';
 
 export const CLIENT_ID_HEADER_NAME = 'X-Castle-Request-Token';
 export const CASTLE_MESSAGE_PREFIX = 'Castle 2.x -';
@@ -259,16 +257,11 @@ class Castle extends integrations.Integration<CastleIntegrationOptions> {
    * @returns - Promise that will resolve when the method finishes.
    */
   override track(data: EventData<TrackTypesValues>) {
-    switch (data.type) {
-      case TrackTypes.PAGE:
-        return this.trackPage(data as PageviewEventData);
-
-      case TrackTypes.TRACK:
-        return this.trackEvent(data as TrackEventData);
-      /* istanbul ignore next */
-      default:
-        return;
+    if (data.type === TrackTypes.TRACK) {
+      return this.trackEvent(data as TrackEventData);
     }
+
+    return;
   }
 
   /**
@@ -311,38 +304,6 @@ class Castle extends integrations.Integration<CastleIntegrationOptions> {
     }
 
     return null;
-  }
-
-  /**
-   * Method that will handle page events to be tracked.
-   *
-   * @param data - Data Track event data.
-   *
-   * @returns - The resolved promise of each castle call method.
-   */
-  trackPage(data: PageviewEventData) {
-    const user = this.getUserData(data);
-    const dataWithWebEventType = data as PageviewEventData & {
-      context: WebContextType;
-    };
-
-    const pageData: PageParams = {
-      url: dataWithWebEventType.context.web.window.location.href,
-      name: dataWithWebEventType.context.web.document.title,
-      referrer: dataWithWebEventType.context.web.document.referrer,
-      user,
-    };
-
-    return this.castleJS
-      .page(pageData)
-      .then(
-        () =>
-          this.debugModeOn &&
-          utils.logger.info(
-            `${CASTLE_MESSAGE_PREFIX} Page track success. Payload:`,
-            pageData,
-          ),
-      );
   }
 }
 

--- a/packages/react/src/analytics/integrations/Castle/__tests__/Castle.test.ts
+++ b/packages/react/src/analytics/integrations/Castle/__tests__/Castle.test.ts
@@ -9,7 +9,6 @@ import {
   integrations,
   type LoadIntegrationEventData,
   PageTypes,
-  type PageviewEventData,
   type StrippedDownAnalytics,
   type TrackEventData,
   type TrackTypesValues,
@@ -164,28 +163,17 @@ describe('Castle integration', () => {
   });
 
   describe('Tracking', () => {
-    it('Should track page views', async () => {
+    it('Should not track page views', async () => {
       instance = createInstance();
 
-      const castlePageSpy = jest.spyOn(instance.castleJS, 'page');
+      const castleFormSpy = jest.spyOn(instance.castleJS, 'form');
       const mockPageEvent = analyticsPageData[
         PageTypes.HOMEPAGE
       ] as EventData<TrackTypesValues> & { context: WebContextType };
-      const expectedCallPayload = {
-        referrer: mockPageEvent.context.web.document.referrer,
-        name: mockPageEvent.context.web.document.title,
-        url: mockPageEvent.context.web.window.location.href,
-        user: instance.getUserData(mockPageEvent as PageviewEventData),
-      };
 
       await instance.track(mockPageEvent);
 
-      expect(castlePageSpy).toHaveBeenCalledWith(expectedCallPayload);
-
-      expect(utils.logger.info).toHaveBeenCalledWith(
-        `${CASTLE_MESSAGE_PREFIX} Page track success. Payload:`,
-        expectedCallPayload,
-      );
+      expect(castleFormSpy).not.toHaveBeenCalled();
     });
 
     it.each([


### PR DESCRIPTION


## Description

- removed castle pageview event.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
