### PR TITLE
feat(client): add backorder types to order item

### DIFF
--- a/packages/client/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/client/src/__tests__/__snapshots__/index.test.ts.snap
@@ -645,9 +645,9 @@ Object {
     "Unverified": "Unverified",
   },
   "PublicationFeatureCode": Object {
-    "BACKORDER": "BACKORDER",
-    "IMMEDIATE_FULFILMENT": "IMMEDIATE_FULFILMENT",
-    "PREORDER": "PREORDER",
+    "Backorder": "BACKORDER",
+    "ImmediateFulfilment": "IMMEDIATE_FULFILMENT",
+    "Preorder": "PREORDER",
   },
   "PurchaseChannel": Object {
     "0": "AddToBag",
@@ -757,9 +757,9 @@ Object {
     "WaitingExternalApproval": "WaitingExternalApproval",
   },
   "SaleIntent": Object {
-    "BACKORDER": "BACKORDER",
-    "IMMEDIATE_FULFILMENT": "IMMEDIATE_FULFILMENT",
-    "PREORDER": "PREORDER",
+    "Backorder": "BACKORDER",
+    "ImmediateFulfilment": "IMMEDIATE_FULFILMENT",
+    "Preorder": "PREORDER",
   },
   "SearchIntentsTypeFilter": Object {
     "0": "ProductId",
@@ -808,11 +808,6 @@ Object {
     "Category": 1,
     "Merchant": 3,
     "Other": 4,
-  },
-  "SelectedSaleIntent": Object {
-    "BACKORDER": "BACKORDER",
-    "IMMEDIATE_FULFILMENT": "IMMEDIATE_FULFILMENT",
-    "PREORDER": "PREORDER",
   },
   "SeoPageType": Object {
     "0": "None",

--- a/packages/client/src/orders/types/orderItem.types.ts
+++ b/packages/client/src/orders/types/orderItem.types.ts
@@ -14,9 +14,7 @@ import type {
   ProductVariantAttribute,
 } from '../../index.js';
 
-import { SaleIntent as SelectedSaleIntent } from '../../types/common/index.js';
-
-export { SelectedSaleIntent };
+import { type SaleIntent } from '../../types/common/index.js';
 
 export type ShippingService = {
   description: string;
@@ -85,8 +83,9 @@ export type OrderItem = {
   customAttributes: string | null;
   shortDescription: string;
   productType: keyof typeof ProductType;
-  selectedSaleIntent?: SelectedSaleIntent | string;
   metadata?: Record<string, string>;
+  expectedFulfillmentDate?: string;
+  saleIntent?: SaleIntent | string;
 };
 
 // This type is for the `getGuestOrderLegacy` client

--- a/packages/client/src/types/common/saleIntent.types.ts
+++ b/packages/client/src/types/common/saleIntent.types.ts
@@ -1,5 +1,5 @@
 export enum SaleIntent {
-  IMMEDIATE_FULFILMENT = 'IMMEDIATE_FULFILMENT',
-  PREORDER = 'PREORDER',
-  BACKORDER = 'BACKORDER',
+  ImmediateFulfilment = 'IMMEDIATE_FULFILMENT',
+  Preorder = 'PREORDER',
+  Backorder = 'BACKORDER',
 }

--- a/tests/__fixtures__/orders/orders.fixtures.mts
+++ b/tests/__fixtures__/orders/orders.fixtures.mts
@@ -21,7 +21,7 @@ import {
   ReturnReferenceName,
   ReturnStatus,
   ReturnStatusCode,
-  SelectedSaleIntent,
+  SaleIntent,
   ShipmentTrackingEventType,
 } from '@farfetch/blackout-client';
 import { mockResponse as userEntity } from '../authentication/index.mjs';
@@ -454,7 +454,7 @@ export const mockOrderItem = {
     from: 'from',
     message: 'message',
   },
-  selectedSaleIntent: SelectedSaleIntent.IMMEDIATE_FULFILMENT,
+  saleIntent: SaleIntent.ImmediateFulfilment,
 };
 
 export const mockOrderItem2 = {
@@ -642,7 +642,7 @@ export const mockOrderItem2 = {
     from: 'from',
     message: 'message',
   },
-  selectedSaleIntent: SelectedSaleIntent.BACKORDER,
+  saleIntent: SaleIntent.Backorder,
 };
 
 export const mockOrderItem3 = {
@@ -805,7 +805,7 @@ export const mockOrderItem3 = {
     from: 'from',
     message: 'message',
   },
-  selectedSaleIntent: SelectedSaleIntent.IMMEDIATE_FULFILMENT,
+  saleIntent: SaleIntent.ImmediateFulfilment,
 };
 
 export const mockOrderDetailsResponse = {
@@ -2108,7 +2108,7 @@ export const getExpectedOrderDetailsNormalizedPayload = (
           customAttributes: null,
           id: orderItemId,
           productType: 'Standard',
-          selectedSaleIntent: SelectedSaleIntent.IMMEDIATE_FULFILMENT,
+          saleIntent: SaleIntent.ImmediateFulfilment,
           images: [
             {
               order: 1,
@@ -2231,7 +2231,7 @@ export const getExpectedOrderDetailsNormalizedPayload = (
           customAttributes: null,
           id: orderItemId2,
           productType: 'Standard',
-          selectedSaleIntent: SelectedSaleIntent.BACKORDER,
+          saleIntent: SaleIntent.Backorder,
           images: [
             {
               order: 1,
@@ -2354,7 +2354,7 @@ export const getExpectedOrderDetailsNormalizedPayload = (
           customAttributes: null,
           id: orderItemId3,
           productType: 'Standard',
-          selectedSaleIntent: SelectedSaleIntent.IMMEDIATE_FULFILMENT,
+          saleIntent: SaleIntent.ImmediateFulfilment,
           images: [
             {
               order: 1,
@@ -2725,7 +2725,7 @@ export const expectedGuestOrdersNormalizedPayload = {
       [orderItemId]: {
         customAttributes: null,
         productType: 'Standard',
-        selectedSaleIntent: SelectedSaleIntent.IMMEDIATE_FULFILMENT,
+        saleIntent: SaleIntent.ImmediateFulfilment,
         images: [
           {
             order: 1,
@@ -2862,7 +2862,7 @@ export const expectedGuestOrdersNormalizedPayload = {
       [orderItemId2]: {
         customAttributes: null,
         productType: 'Standard',
-        selectedSaleIntent: SelectedSaleIntent.BACKORDER,
+        saleIntent: SaleIntent.Backorder,
         images: [
           {
             order: 1,
@@ -2999,7 +2999,7 @@ export const expectedGuestOrdersNormalizedPayload = {
       [orderItemId3]: {
         customAttributes: null,
         productType: 'Standard',
-        selectedSaleIntent: SelectedSaleIntent.IMMEDIATE_FULFILMENT,
+        saleIntent: SaleIntent.ImmediateFulfilment,
         images: [
           {
             order: 1,

--- a/tests/__fixtures__/products/productVariantsMerchantsLocations.fixtures.mts
+++ b/tests/__fixtures__/products/productVariantsMerchantsLocations.fixtures.mts
@@ -41,7 +41,7 @@ export const mockProductVariants: VariantsAdapted = [
     isOneSize: true,
     publicationFeatures: [
       {
-        code: PublicationFeatureCode.IMMEDIATE_FULFILMENT,
+        code: PublicationFeatureCode.ImmediateFulfilment,
       },
     ],
   },
@@ -91,7 +91,7 @@ export const mockProductVariantsMerchantsLocationsNormalizedResponse = {
             purchaseChannel: PurchaseChannel.EmailOnly,
             publicationFeatures: [
               {
-                code: PublicationFeatureCode.IMMEDIATE_FULFILMENT,
+                code: PublicationFeatureCode.ImmediateFulfilment,
               },
             ],
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,7 +250,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
 
-"@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
+"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
   integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
@@ -1051,7 +1051,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.16.0", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.6.1", "@babel/types@^7.7.0":
+"@babel/types@^7.0.0", "@babel/types@^7.16.0", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.21.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.2.tgz#92246f6e00f91755893c2876ad653db70c8310d1"
   integrity sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==
@@ -5831,11 +5831,6 @@ has-symbols@^1.0.2, has-symbols@^1.0.3:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
-has-symbols@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
-  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
-
 has-tostringtag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
@@ -7278,11 +7273,6 @@ load-json-file@^6.2.0:
     parse-json "^5.0.0"
     strip-bom "^4.0.0"
     type-fest "^0.6.0"
-
-load-script@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
-  integrity sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==
 
 load-script@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description

- This adds `expectedFulfillmentDate` and `saleIntent` types to order item.
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->
None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
