### PR TITLE
feat(analytics|react): update order completed analytics event

### DIFF
--- a/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
@@ -150,6 +150,7 @@ Object {
     "LOAD_INTEGRATION_TRACK_TYPE": "loadIntegration",
     "ON_SET_USER_TRACK_TYPE": "onSetUser",
     "StorageWrapper": [Function],
+    "getCheckoutOrderIdentificationProperties": [Function],
     "getCheckoutProperties": [Function],
     "getContextDefaults": [Function],
     "getCookie": [Function],

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -372,7 +372,7 @@ describe('Omnitracking', () => {
           await omnitracking.track(data);
 
           data = generateTrackMockData({
-            event: EventType.PlaceOrderStarted,
+            event: EventType.Share,
           });
           await omnitracking.track(data);
 

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -118,8 +118,12 @@ Object {
 
 exports[`Omnitracking track events definitions \`Order Completed\` return should match the snapshot 1`] = `
 Object {
+  "addressFinder": false,
   "checkoutOrderId": 21312312,
+  "checkoutStep": 5,
+  "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\",\\"packagingType\\":\\"foo\\"}",
   "orderCode": "ABC12",
+  "paymentType": "credit card",
   "tid": 2831,
 }
 `;

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -495,6 +495,10 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
   [EventType.OrderCompleted]: data => ({
     tid: 2831,
     ...getCheckoutEventGenericProperties(data),
+    addressFinder: data.properties?.addressFinder,
+    checkoutStep: data.properties?.step,
+    paymentType: data.properties?.paymentType,
+    deliveryInformationDetails: getDeliveryInformationDetails(data),
   }),
   [EventType.Logout]: () => ({
     tid: 431,

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -1,4 +1,9 @@
-import { ANALYTICS_UNIQUE_EVENT_ID } from '../../utils/constants.js';
+import {
+  ANALYTICS_UNIQUE_EVENT_ID,
+  getCheckoutOrderIdentificationProperties,
+  getProductId,
+  logger,
+} from '../../utils/index.js';
 import {
   type AnalyticsProduct,
   type EventData,
@@ -12,7 +17,6 @@ import {
   DEFAULT_SEARCH_QUERY_PARAMETERS,
 } from './constants.js';
 import { get, pick } from 'lodash-es';
-import { getProductId, logger } from '../../utils/index.js';
 import {
   isPageEventType,
   isScreenEventType,
@@ -522,19 +526,19 @@ export const getProductLineItems = (data: EventData<TrackTypesValues>) => {
 export const getCheckoutEventGenericProperties = (
   data: EventData<TrackTypesValues>,
 ) => {
-  const validOrderCode = isNaN(Number(data.properties?.orderId));
+  const orderInfo = getCheckoutOrderIdentificationProperties(data.properties);
 
-  if (!validOrderCode) {
+  if (orderInfo.orderCode === undefined) {
     logger.error(
       `[Omnitracking] - Event ${data.event} property "orderId" should be an alphanumeric value.
-                        If you send the internal "orderId", please use "orderId" (e.g.: 5H5QYB)
+                        If you want to send the internal "orderId", please use "orderId" (e.g.: 5H5QYB)
                         and 'checkoutOrderId' (e.g.:123123123)`,
     );
   }
 
   return {
-    orderCode: data.properties?.orderId,
-    checkoutOrderId: data.properties?.checkoutOrderId,
+    orderCode: orderInfo.orderCode,
+    checkoutOrderId: orderInfo.orderId,
   };
 };
 

--- a/packages/analytics/src/types/analytics.types.ts
+++ b/packages/analytics/src/types/analytics.types.ts
@@ -94,7 +94,7 @@ export type ExtendedTrackTypes =
   | typeof ON_SET_USER_TRACK_TYPE
   | typeof LOAD_INTEGRATION_TRACK_TYPE;
 
-export type UserTraits = Omit<User | UserLegacy, 'id'>;
+export type UserTraits = Omit<User, 'id'> | Omit<UserLegacy, 'id'>;
 
 export type UserData = {
   id: number | null | undefined;

--- a/packages/analytics/src/utils/__tests__/getters.test.ts
+++ b/packages/analytics/src/utils/__tests__/getters.test.ts
@@ -1,0 +1,99 @@
+import * as getters from '../getters.js';
+
+describe('getters', () => {
+  describe('getCheckoutOrderIdentificationProperties', () => {
+    it('Should retrieve order data with multiple test cases', () => {
+      const checkoutOrderId = 123;
+
+      expect(
+        getters.getCheckoutOrderIdentificationProperties({
+          orderId: null,
+          checkoutOrderId: checkoutOrderId,
+        }),
+      ).toEqual({
+        orderCode: undefined,
+        orderId: checkoutOrderId,
+      });
+
+      expect(
+        getters.getCheckoutOrderIdentificationProperties({
+          orderId: undefined,
+          checkoutOrderId: checkoutOrderId,
+        }),
+      ).toEqual({
+        orderCode: undefined,
+        orderId: checkoutOrderId,
+      });
+
+      expect(
+        getters.getCheckoutOrderIdentificationProperties({
+          orderId: 0,
+          checkoutOrderId: checkoutOrderId,
+        }),
+      ).toEqual({
+        orderCode: undefined,
+        orderId: checkoutOrderId,
+      });
+
+      expect(
+        getters.getCheckoutOrderIdentificationProperties({
+          orderId: '0',
+          checkoutOrderId: checkoutOrderId,
+        }),
+      ).toEqual({
+        orderCode: undefined,
+        orderId: checkoutOrderId,
+      });
+
+      expect(
+        getters.getCheckoutOrderIdentificationProperties({
+          orderId: 12345,
+          checkoutOrderId: checkoutOrderId,
+        }),
+      ).toEqual({
+        orderCode: undefined,
+        orderId: checkoutOrderId,
+      });
+
+      expect(
+        getters.getCheckoutOrderIdentificationProperties({
+          orderId: '12345',
+          checkoutOrderId: checkoutOrderId,
+        }),
+      ).toEqual({
+        orderCode: undefined,
+        orderId: checkoutOrderId,
+      });
+
+      expect(
+        getters.getCheckoutOrderIdentificationProperties({
+          orderId: 'A12345',
+          checkoutOrderId: checkoutOrderId,
+        }),
+      ).toEqual({
+        orderCode: 'A12345',
+        orderId: checkoutOrderId,
+      });
+
+      expect(
+        getters.getCheckoutOrderIdentificationProperties({
+          orderId: NaN,
+          checkoutOrderId: checkoutOrderId,
+        }),
+      ).toEqual({
+        orderCode: undefined,
+        orderId: checkoutOrderId,
+      });
+
+      expect(
+        getters.getCheckoutOrderIdentificationProperties({
+          orderId: 123,
+          checkoutOrderId: undefined,
+        }),
+      ).toEqual({
+        orderCode: undefined,
+        orderId: 123,
+      });
+    });
+  });
+});

--- a/packages/analytics/src/utils/getters.ts
+++ b/packages/analytics/src/utils/getters.ts
@@ -126,3 +126,44 @@ export const getCookie = (name: string): string | void => {
     return parts.pop()?.split(';').shift();
   }
 };
+
+/**
+ * Obtain checkout order generic fields from analytics properties.
+ *
+ * @param dataProperties - The event's properties data.
+ * @param orderIdFieldName - The name of orderId field. Default as `checkoutOrderId`.
+ * @returns The checkout generic order data result.
+ */
+export const getCheckoutOrderIdentificationProperties = (
+  eventProperties: EventProperties,
+) => {
+  const checkoutOrderId = eventProperties?.checkoutOrderId;
+  const orderId = eventProperties?.orderId;
+  const orderIdAsNumber = Number(orderId);
+  // Valid order code should be an alphanumeric value.
+  // Should be used 'orderId' values like e.g.: 5H5QYB
+  // and for 'checkoutOrderId' values like e.g.:123123123
+  const isOrderCodeValid =
+    typeof orderId === 'string' && isNaN(orderIdAsNumber);
+  const isOrderIdValid =
+    typeof checkoutOrderId === 'number' && !isNaN(checkoutOrderId);
+
+  const orderCode = isOrderCodeValid ? orderId : undefined;
+
+  let finalOrderId;
+
+  // If we have a valid order id, i.e., the property checkoutOrderId from the
+  // event properties is a number, then we always use it.
+  if (isOrderIdValid) {
+    finalOrderId = checkoutOrderId;
+  } else if (!isOrderCodeValid) {
+    // If we do not have a valid order code and checkoutOrderId is not valid
+    // we use the orderId from the payload if it is not NaN
+    finalOrderId = !isNaN(orderIdAsNumber) ? orderIdAsNumber : undefined;
+  }
+
+  return {
+    orderCode,
+    orderId: finalOrderId,
+  };
+};

--- a/packages/analytics/src/utils/hashUserData.ts
+++ b/packages/analytics/src/utils/hashUserData.ts
@@ -38,7 +38,7 @@ const hashUserData = (userData: UserData): UserData => {
           name: hashPlainTextString(traits.name) as string,
           phoneNumber: hashPlainTextString(traits.phoneNumber),
           username: hashPlainTextString(traits.username) as string,
-        },
+        } as UserTraits,
       };
     }
 

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -472,10 +472,13 @@ Array [
     "purchase",
     Object {
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
+      "address_finder": false,
       "affiliation": undefined,
       "analytics_package_version": "0.1.0",
+      "checkout_step": 5,
       "coupon": "ACME2019",
       "currency": "USD",
+      "delivery_type": "Standard/Standard",
       "items": Array [
         Object {
           "affiliation": undefined,
@@ -498,9 +501,12 @@ Array [
           "size": "L",
         },
       ],
+      "packaging_type": "foo",
       "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
       "path_clean": "/en-pt/",
+      "payment_type": "credit card",
       "shipping": 3.6,
+      "shipping_tier": "Next Day",
       "tax": 2.04,
       "transaction_id": "ABC12",
       "value": 24.64,

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.ts
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.ts
@@ -572,7 +572,7 @@ const getLoginAndSignupParametersFromEvent = (
  *
  * @returns Properties formatted for the GA4's order completed/refunded ecommerce events.
  */
-const getOrderPurchaseOrRefundParametersFromEvent = (
+const getOrderPurchaseOrRefundGenericParametersFromEvent = (
   eventProperties: EventProperties,
 ) => {
   return {
@@ -581,6 +581,33 @@ const getOrderPurchaseOrRefundParametersFromEvent = (
     affiliation: eventProperties.affiliation,
     shipping: eventProperties.shipping,
     tax: eventProperties.tax,
+  };
+};
+
+/**
+ * Returns the checkout order completed event properties formatted for the GA4 ecommerce events with some custom parameters.
+ *
+ * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/ecommerce#purchases_checkouts_and_refunds}
+ *
+ * @param eventProperties - Properties from a track event.
+ *
+ * @returns Properties formatted for the GA4's order completed/refunded ecommerce events.
+ */
+const getOrderPurchaseParametersFromEvent = (
+  eventProperties: EventProperties,
+) => {
+  const orderInfo =
+    utils.getCheckoutOrderIdentificationProperties(eventProperties);
+
+  return {
+    ...getOrderPurchaseOrRefundGenericParametersFromEvent(eventProperties),
+    address_finder: eventProperties.addressFinder,
+    checkout_step: eventProperties.step,
+    delivery_type: eventProperties.deliveryType,
+    payment_type: eventProperties.paymentType,
+    packaging_type: eventProperties.packagingType,
+    shipping_tier: eventProperties.shippingTier,
+    transaction_id: orderInfo.orderCode,
   };
 };
 
@@ -844,8 +871,11 @@ export function getEventProperties(
       return getViewItemParametersFromEvent(eventProperties);
 
     case EventType.OrderCompleted:
+      return getOrderPurchaseParametersFromEvent(eventProperties);
     case EventType.OrderRefunded:
-      return getOrderPurchaseOrRefundParametersFromEvent(eventProperties);
+      return getOrderPurchaseOrRefundGenericParametersFromEvent(
+        eventProperties,
+      );
 
     case PageType.Search:
       return getSearchParametersFromEvent(eventProperties);

--- a/tests/__fixtures__/analytics/track/orderCompletedTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/orderCompletedTrackData.fixtures.mts
@@ -12,6 +12,12 @@ const fixtures = {
     tax: 2.04,
     coupon: 'ACME2019',
     currency: 'USD',
+    addressFinder: false,
+    step: 5,
+    deliveryType: 'Standard/Standard',
+    packagingType: 'foo',
+    shippingTier: 'Next Day',
+    paymentType: 'credit card',
     products: [
       {
         id: '507f1f77bcf86cd799439011',

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,7 +250,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
 
-"@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
+"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
   integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
@@ -1051,7 +1051,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.16.0", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.6.1", "@babel/types@^7.7.0":
+"@babel/types@^7.0.0", "@babel/types@^7.16.0", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.21.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.2.tgz#92246f6e00f91755893c2876ad653db70c8310d1"
   integrity sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==
@@ -5831,11 +5831,6 @@ has-symbols@^1.0.2, has-symbols@^1.0.3:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
-has-symbols@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
-  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
-
 has-tostringtag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
@@ -7278,11 +7273,6 @@ load-json-file@^6.2.0:
     parse-json "^5.0.0"
     strip-bom "^4.0.0"
     type-fest "^0.6.0"
-
-load-script@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
-  integrity sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==
 
 load-script@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description

- update fields on `order_completed` event contract of GA4 and Omnitracking integration to add new fields.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
