### PR TITLE
chore: update github release title format

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -55,7 +55,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: ${{ github.ref }}
           body: ${{ steps.extract_release_notes.outputs.release_notes }}
           draft: false
           prerelease: false

--- a/.github/workflows/SendEmail.yml
+++ b/.github/workflows/SendEmail.yml
@@ -21,7 +21,7 @@ jobs:
           # Required password
           password: ${{ secrets.EMAIL_ACCOUNT_PASSWORD }}
           # Required mail subject. Will be the release name.
-          subject: ${{ github.event.release.name }}
+          subject: Release ${{ github.event.release.name }}
           # Required recipients' addresses:
           to: ${{ secrets.EMAIL_RECIPIENTS }}
           # Required sender full name (address can be skipped):


### PR DESCRIPTION
## Description

This updates the github release title format to remove the `Release` string from it and use only the tag name as it will be the new default for the `main` releases.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
