### PR TITLE
chore: fix release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Need to set the origin url with the GITHUB_TOKEN variable so lerna can push
+# the commit with the new version.
+git remote set-url origin "https://${GITHUB_TOKEN}@github.com/Farfetch/blackout.git"
+
 CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 CONTENTS="--contents dist"
 


### PR DESCRIPTION
## Description

This re-adds the setting of the origin url to include the `GITHUB_TOKEN` so that lerna can push as the `GH_TOKEN` variable is not enough as it will only be used for creating github releases.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
