### PR TITLE
feat: add checkout step to analytics event

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Omnitracking track events definitions \`Address Info Added\` return should match the snapshot 1`] = `
 Object {
   "checkoutOrderId": 12345678,
-  "checkoutStep": "1",
+  "checkoutStep": 1,
   "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\"}",
   "interactionType": "click",
   "orderCode": "50314b8e9bcf000000000000",

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -226,6 +226,7 @@ Array [
       "__blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
       "address_finder": undefined,
       "analytics_package_version": "0.1.0",
+      "checkout_step": 1,
       "coupon": "ACME2019",
       "currency": "USD",
       "delivery_type": "Standard/Standard",

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.ts
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.ts
@@ -395,6 +395,7 @@ const getCheckoutShippingStepParametersFromEvent = (
     delivery_type: eventProperties.deliveryType,
     packaging_type: eventProperties.packagingType,
     transaction_id: eventProperties.orderId,
+    checkout_step: eventProperties.step,
   };
 };
 

--- a/tests/__fixtures__/analytics/track/addressInfoAddedTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/addressInfoAddedTrackData.fixtures.mts
@@ -13,7 +13,7 @@ const fixtures = {
     coupon: 'ACME2019',
     shippingTier: 'Next Day',
     currency: 'USD',
-    step: '1',
+    step: 1,
     deliveryType: 'Standard/Standard',
     interactionType: 'click',
   },


### PR DESCRIPTION
## Description

- Added checkout step parameter to add_address_info event.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
