### PR TITLE
feat(react): add legacy guest flow to useUserReturns hook

### DIFF
--- a/packages/react/src/returns/hooks/types/useUserReturns.ts
+++ b/packages/react/src/returns/hooks/types/useUserReturns.ts
@@ -1,7 +1,13 @@
-import type { Config, GetUserReturnsQuery } from '@farfetch/blackout-client';
+import type {
+  Config,
+  GetUserReturnsLegacyData,
+  GetUserReturnsQuery,
+} from '@farfetch/blackout-client';
 
 export type UseUserReturnsOptions = {
   enableAutoFetch?: boolean;
   fetchConfig?: Config;
   fetchQuery?: GetUserReturnsQuery;
+  useLegacyGuestFlow?: boolean;
+  guestUserEmail?: GetUserReturnsLegacyData['guestUserEmail'];
 };


### PR DESCRIPTION
## Description

This adds the legacy flow to useUserReturns hook

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->
None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
