### PR TITLE
feat(core): shared wishlists client and redux

### DIFF
--- a/packages/core/src/entities/schemas/sharedWishlist.js
+++ b/packages/core/src/entities/schemas/sharedWishlist.js
@@ -1,0 +1,6 @@
+import { schema } from 'normalizr';
+import sharedWishlistItem from './sharedWishlistItem';
+
+export default new schema.Entity('sharedWishlists', {
+  items: [sharedWishlistItem],
+});

--- a/packages/core/src/entities/schemas/sharedWishlistItem.js
+++ b/packages/core/src/entities/schemas/sharedWishlistItem.js
@@ -1,0 +1,55 @@
+import { adaptAttributes, adaptDate, adaptPrice } from '../../helpers/adapters';
+import { schema } from 'normalizr';
+import product from './product';
+
+export default new schema.Entity(
+  'sharedWishlistsItems',
+  { product },
+  {
+    processStrategy: value => {
+      const {
+        attributes,
+        brandId,
+        brandName,
+        categories,
+        colors,
+        dateCreated,
+        images,
+        productImgQueryParam,
+        labels,
+        price,
+        productDescription,
+        productId,
+        productName,
+        productSlug,
+        sizes,
+        variants,
+        ...item
+      } = value;
+
+      item.attributes = attributes;
+      item.dateCreated = adaptDate(dateCreated);
+      item.price = adaptPrice(price);
+      item.size = adaptAttributes(attributes, sizes);
+      item.product = {
+        brand: {
+          id: brandId,
+          name: brandName,
+        },
+        description: productDescription,
+        id: productId,
+        name: productName,
+        productImgQueryParam,
+        slug: productSlug,
+        categories,
+        colors,
+        images,
+        labels,
+        sizes,
+        variants,
+      };
+
+      return item;
+    },
+  },
+);

--- a/packages/core/src/sharedWishlists/client/__fixtures__/deleteSharedWishlist.fixtures.js
+++ b/packages/core/src/sharedWishlists/client/__fixtures__/deleteSharedWishlist.fixtures.js
@@ -1,0 +1,17 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: params => {
+    moxios.stubRequest(
+      join('/api/commerce/v1/sharedWishlists', params.sharedWishlistId),
+      { method: 'delete', status: 204 },
+    );
+  },
+  failure: params => {
+    moxios.stubRequest(
+      join('/api/commerce/v1/sharedWishlists', params.sharedWishlistId),
+      { method: 'delete', response: 'stub error', status: 404 },
+    );
+  },
+};

--- a/packages/core/src/sharedWishlists/client/__fixtures__/getSharedWishlist.fixtures.js
+++ b/packages/core/src/sharedWishlists/client/__fixtures__/getSharedWishlist.fixtures.js
@@ -1,0 +1,17 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: params => {
+    moxios.stubRequest(
+      join('/api/commerce/v1/sharedWishlists', params.sharedWishlistId),
+      { method: 'get', response: params.response, status: 200 },
+    );
+  },
+  failure: params => {
+    moxios.stubRequest(
+      join('/api/commerce/v1/sharedWishlists', params.sharedWishlistId),
+      { method: 'get', response: 'stub error', status: 404 },
+    );
+  },
+};

--- a/packages/core/src/sharedWishlists/client/__fixtures__/postSharedWishlist.fixtures.js
+++ b/packages/core/src/sharedWishlists/client/__fixtures__/postSharedWishlist.fixtures.js
@@ -1,0 +1,18 @@
+import moxios from 'moxios';
+
+export default {
+  success: params => {
+    moxios.stubRequest('/api/commerce/v1/sharedWishlists', {
+      method: 'post',
+      response: params.response,
+      status: 201,
+    });
+  },
+  failure: () => {
+    moxios.stubRequest('/api/commerce/v1/sharedWishlists', {
+      method: 'post',
+      response: 'stub error',
+      status: 404,
+    });
+  },
+};

--- a/packages/core/src/sharedWishlists/client/__fixtures__/putSharedWishlist.fixtures.js
+++ b/packages/core/src/sharedWishlists/client/__fixtures__/putSharedWishlist.fixtures.js
@@ -1,0 +1,17 @@
+import join from 'proper-url-join';
+import moxios from 'moxios';
+
+export default {
+  success: params => {
+    moxios.stubRequest(
+      join('/api/commerce/v1/sharedWishlists', params.sharedWishlistId),
+      { method: 'put', response: params.response, status: 200 },
+    );
+  },
+  failure: params => {
+    moxios.stubRequest(
+      join('/api/commerce/v1/sharedWishlists', params.sharedWishlistId),
+      { method: 'put', response: 'stub error', status: 404 },
+    );
+  },
+};

--- a/packages/core/src/sharedWishlists/client/__tests__/__snapshots__/deleteSharedWishlist.test.js.snap
+++ b/packages/core/src/sharedWishlists/client/__tests__/__snapshots__/deleteSharedWishlist.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deleteSharedWishlist should receive client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/sharedWishlists/client/__tests__/__snapshots__/getSharedWishlist.test.js.snap
+++ b/packages/core/src/sharedWishlists/client/__tests__/__snapshots__/getSharedWishlist.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getSharedWishlist should receive client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/sharedWishlists/client/__tests__/__snapshots__/postSharedWishlist.test.js.snap
+++ b/packages/core/src/sharedWishlists/client/__tests__/__snapshots__/postSharedWishlist.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`postSharedWishlist should receive a client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/sharedWishlists/client/__tests__/__snapshots__/putSharedWishlist.test.js.snap
+++ b/packages/core/src/sharedWishlists/client/__tests__/__snapshots__/putSharedWishlist.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`putSharedWishlist should receive client request error 1`] = `
+Object {
+  "code": -1,
+  "message": "stub error",
+  "status": 404,
+}
+`;

--- a/packages/core/src/sharedWishlists/client/__tests__/deleteSharedWishlist.test.js
+++ b/packages/core/src/sharedWishlists/client/__tests__/deleteSharedWishlist.test.js
@@ -1,0 +1,44 @@
+import { mockSharedWishlistId } from 'tests/__fixtures__/sharedWishlists';
+import client from '../../../helpers/client';
+import deleteSharedWishlist from '../deleteSharedWishlist';
+import fixtures from '../__fixtures__/deleteSharedWishlist.fixtures';
+import moxios from 'moxios';
+
+describe('deleteSharedWishlist', () => {
+  const expectedConfig = undefined;
+  const sharedWishlistId = mockSharedWishlistId;
+  const spy = jest.spyOn(client, 'delete');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    fixtures.success({ sharedWishlistId });
+
+    await expect(deleteSharedWishlist(sharedWishlistId)).resolves.toEqual(
+      expect.objectContaining({ status: 204 }),
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/sharedWishlists/${sharedWishlistId}`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive client request error', async () => {
+    fixtures.failure({ sharedWishlistId });
+
+    await expect(
+      deleteSharedWishlist(sharedWishlistId),
+    ).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/sharedWishlists/${sharedWishlistId}`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/sharedWishlists/client/__tests__/getSharedWishlist.test.js
+++ b/packages/core/src/sharedWishlists/client/__tests__/getSharedWishlist.test.js
@@ -1,0 +1,45 @@
+import { getSharedWishlist } from '..';
+import {
+  mockSharedWishlistId,
+  mockSharedWishlistsResponse,
+} from 'tests/__fixtures__/sharedWishlists';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/getSharedWishlist.fixtures';
+import moxios from 'moxios';
+
+describe('getSharedWishlist', () => {
+  const expectedConfig = undefined;
+  const sharedWishlistId = mockSharedWishlistId;
+  const spy = jest.spyOn(client, 'get');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = mockSharedWishlistsResponse;
+
+    fixtures.success({ sharedWishlistId, response });
+
+    await expect(getSharedWishlist(sharedWishlistId)).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/sharedWishlists/${sharedWishlistId}`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive client request error', async () => {
+    fixtures.failure({ sharedWishlistId });
+
+    await expect(getSharedWishlist(sharedWishlistId)).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/sharedWishlists/${sharedWishlistId}`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/sharedWishlists/client/__tests__/postSharedWishlist.test.js
+++ b/packages/core/src/sharedWishlists/client/__tests__/postSharedWishlist.test.js
@@ -1,0 +1,49 @@
+import {
+  mockSharedWishlistPostData,
+  mockSharedWishlistsResponse,
+} from 'tests/__fixtures__/sharedWishlists';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/postSharedWishlist.fixtures';
+import moxios from 'moxios';
+import postSharedWishlist from '../postSharedWishlist';
+
+describe('postSharedWishlist', () => {
+  const expectedConfig = undefined;
+  const data = mockSharedWishlistPostData;
+  const spy = jest.spyOn(client, 'post');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    moxios.uninstall(client);
+  });
+
+  it('should handle a client request successfully', async () => {
+    const response = mockSharedWishlistsResponse;
+
+    fixtures.success({ response });
+
+    await expect(postSharedWishlist(data)).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      '/commerce/v1/sharedWishlists',
+      data,
+      expectedConfig,
+    );
+  });
+
+  it('should receive a client request error', async () => {
+    fixtures.failure();
+
+    await expect(postSharedWishlist(data)).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      '/commerce/v1/sharedWishlists',
+      data,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/sharedWishlists/client/__tests__/putSharedWishlist.test.js
+++ b/packages/core/src/sharedWishlists/client/__tests__/putSharedWishlist.test.js
@@ -1,0 +1,45 @@
+import {
+  mockSharedWishlistId,
+  mockSharedWishlistsResponse,
+} from 'tests/__fixtures__/sharedWishlists';
+import { putSharedWishlist } from '..';
+import client from '../../../helpers/client';
+import fixtures from '../__fixtures__/putSharedWishlist.fixtures';
+import moxios from 'moxios';
+
+describe('putSharedWishlist', () => {
+  const expectedConfig = undefined;
+  const sharedWishlistId = mockSharedWishlistId;
+  const spy = jest.spyOn(client, 'put');
+
+  beforeEach(() => {
+    moxios.install(client);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => moxios.uninstall(client));
+
+  it('should handle a client request successfully', async () => {
+    const response = mockSharedWishlistsResponse;
+
+    fixtures.success({ sharedWishlistId, response });
+
+    await expect(putSharedWishlist(sharedWishlistId)).resolves.toBe(response);
+
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/sharedWishlists/${sharedWishlistId}`,
+      expectedConfig,
+    );
+  });
+
+  it('should receive client request error', async () => {
+    fixtures.failure({ sharedWishlistId });
+
+    await expect(putSharedWishlist(sharedWishlistId)).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(
+      `/commerce/v1/sharedWishlists/${sharedWishlistId}`,
+      expectedConfig,
+    );
+  });
+});

--- a/packages/core/src/sharedWishlists/client/deleteSharedWishlist.js
+++ b/packages/core/src/sharedWishlists/client/deleteSharedWishlist.js
@@ -1,0 +1,22 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * Method responsible for deleting a shared wishlist.
+ *
+ * @function deleteSharedWishlist
+ * @memberof module:sharedWishlists/client
+ *
+ * @param {string} id - Universal identifier of the shared wishlist.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Promise} Promise that will be resolved when the call to the
+ * endpoint finishes.
+ */
+export default (id, config) =>
+  client
+    .delete(join('/commerce/v1/sharedWishlists', id), config)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/sharedWishlists/client/getSharedWishlist.js
+++ b/packages/core/src/sharedWishlists/client/getSharedWishlist.js
@@ -1,0 +1,23 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * Method responsible for loading the shared wishlist.
+ *
+ * @function getSharedWishlist
+ * @memberof module:sharedWishlists/client
+ *
+ * @param {string} id - Universal identifier of the shared wishlist.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Promise} Promise that will be resolved when the call to the
+ * endpoint finishes.
+ */
+export default (id, config) =>
+  client
+    .get(join('/commerce/v1/sharedWishlists', id), config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/sharedWishlists/client/index.js
+++ b/packages/core/src/sharedWishlists/client/index.js
@@ -1,0 +1,12 @@
+/**
+ * Shared wishlists clients.
+ *
+ * @module sharedWishlist/client
+ * @category Shared Wishlist
+ * @subcategory Clients
+ */
+
+export { default as getSharedWishlist } from './getSharedWishlist';
+export { default as deleteSharedWishlist } from './deleteSharedWishlist';
+export { default as postSharedWishlist } from './postSharedWishlist';
+export { default as putSharedWishlist } from './putSharedWishlist';

--- a/packages/core/src/sharedWishlists/client/postSharedWishlist.js
+++ b/packages/core/src/sharedWishlists/client/postSharedWishlist.js
@@ -1,0 +1,34 @@
+import client, { adaptError } from '../../helpers/client';
+
+/**
+ * @typedef {object} PostSharedWishlistData
+ *
+ * @alias PostSharedWishlistData
+ * @memberof module:sharedWishlists/client
+ *
+ * @property {string} id - Universal identifier of the shared wishlist.
+ * @property {string} setId - Global identifier of the set to retrieve information
+ * from.
+ */
+
+/**
+ * Method responsible for creating a snapshot of the wishlist set to allow share it.
+ *
+ * @function postSharedWishlist
+ * @memberof module:sharedWishlists/client
+ *
+ * @param {PostSharedWishlistData} data - Details of the information of which wishlist
+ * set is going to be shared.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Promise} Promise that will be resolved when the call to
+ * the endpoint finishes.
+ */
+export default (data, config) =>
+  client
+    .post('/commerce/v1/sharedWishlists', data, config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/sharedWishlists/client/putSharedWishlist.js
+++ b/packages/core/src/sharedWishlists/client/putSharedWishlist.js
@@ -1,0 +1,22 @@
+import client, { adaptError } from '../../helpers/client';
+import join from 'proper-url-join';
+
+/**
+ * Method responsible for updating a shared wishlist, syncronizing the prior
+ * snapshot with the current state of the related wishlist set.
+ *
+ * @function putSharedWishlist
+ * @memberof module:sharedWishlists/client
+ *
+ * @param {string} id - Universal identifier of the shared wishlist.
+ * @param {object} [config] - Custom configurations to send to the client instance (axios).
+ *
+ * @returns {Promise} Promise that will be resolved when the call to the endpoint finishes.
+ */
+export default (id, config) =>
+  client
+    .put(join('/commerce/v1/sharedWishlists', id), config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });

--- a/packages/core/src/sharedWishlists/redux/__tests__/__snapshots__/doCreateSharedWishlist.test.js.snap
+++ b/packages/core/src/sharedWishlists/redux/__tests__/__snapshots__/doCreateSharedWishlist.test.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doCreateSharedWishlist() should create the correct actions for when the create a shared wishlist procedure is successful: create shared wishlist success payload 1`] = `
+Object {
+  "payload": Object {
+    "entities": Object {
+      "brands": Object {
+        "10533": Object {
+          "id": 10533,
+          "name": "Valentino",
+        },
+      },
+      "products": Object {
+        "11766695": Object {
+          "DEPRECATED_images": undefined,
+          "brand": 10533,
+          "categories": undefined,
+          "colorGrouping": undefined,
+          "colors": undefined,
+          "customAttributes": undefined,
+          "description": "Modern Sneakers",
+          "groupedEntries": undefined,
+          "grouping": undefined,
+          "groupingProperties": undefined,
+          "id": 11766695,
+          "images": undefined,
+          "labels": undefined,
+          "merchant": undefined,
+          "name": "251 sneakers",
+          "price": undefined,
+          "prices": undefined,
+          "sizes": undefined,
+          "slug": "string",
+          "tag": Object {
+            "id": undefined,
+            "name": undefined,
+          },
+          "variants": undefined,
+        },
+      },
+      "sharedWishlists": Object {
+        "3fa85f64-5717-4562-b3fc-2c963f66afa6": Object {
+          "dateCreated": "2022-11-24T15:14:43.319Z",
+          "description": "string",
+          "hasMissingItems": false,
+          "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "items": Array [
+            481426747,
+          ],
+          "name": "string",
+        },
+      },
+      "sharedWishlistsItems": Object {
+        "481426747": Object {
+          "attributes": undefined,
+          "dateCreated": 1669302883319,
+          "id": 481426747,
+          "isCustomizable": false,
+          "isExclusive": false,
+          "price": undefined,
+          "product": 11766695,
+          "quantity": 2,
+          "size": Object {},
+        },
+      },
+    },
+    "result": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  },
+  "type": "@farfetch/blackout-core/CREATE_SHARED_WISHLIST_SUCCESS",
+}
+`;

--- a/packages/core/src/sharedWishlists/redux/__tests__/__snapshots__/doDeleteSharedWishlist.test.js.snap
+++ b/packages/core/src/sharedWishlists/redux/__tests__/__snapshots__/doDeleteSharedWishlist.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doDeleteSharedWishlist() should create the correct actions for when the remove shared wishlist procedure is successful: delete shared wishlist success payload 1`] = `
+Object {
+  "type": "@farfetch/blackout-core/REMOVE_SHARED_WISHLIST_SUCCESS",
+}
+`;

--- a/packages/core/src/sharedWishlists/redux/__tests__/__snapshots__/doFetchSharedWishlist.test.js.snap
+++ b/packages/core/src/sharedWishlists/redux/__tests__/__snapshots__/doFetchSharedWishlist.test.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doFetchSharedWishlist() should create the correct actions for when fetch a shared wishlist procedure is successful: get shared wishlist success payload 1`] = `
+Object {
+  "payload": Object {
+    "entities": Object {
+      "brands": Object {
+        "10533": Object {
+          "id": 10533,
+          "name": "Valentino",
+        },
+      },
+      "products": Object {
+        "11766695": Object {
+          "DEPRECATED_images": undefined,
+          "brand": 10533,
+          "categories": undefined,
+          "colorGrouping": undefined,
+          "colors": undefined,
+          "customAttributes": undefined,
+          "description": "Modern Sneakers",
+          "groupedEntries": undefined,
+          "grouping": undefined,
+          "groupingProperties": undefined,
+          "id": 11766695,
+          "images": undefined,
+          "labels": undefined,
+          "merchant": undefined,
+          "name": "251 sneakers",
+          "price": undefined,
+          "prices": undefined,
+          "sizes": undefined,
+          "slug": "string",
+          "tag": Object {
+            "id": undefined,
+            "name": undefined,
+          },
+          "variants": undefined,
+        },
+      },
+      "sharedWishlists": Object {
+        "3fa85f64-5717-4562-b3fc-2c963f66afa6": Object {
+          "dateCreated": "2022-11-24T15:14:43.319Z",
+          "description": "string",
+          "hasMissingItems": false,
+          "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "items": Array [
+            481426747,
+          ],
+          "name": "string",
+        },
+      },
+      "sharedWishlistsItems": Object {
+        "481426747": Object {
+          "attributes": undefined,
+          "dateCreated": 1669302883319,
+          "id": 481426747,
+          "isCustomizable": false,
+          "isExclusive": false,
+          "price": undefined,
+          "product": 11766695,
+          "quantity": 2,
+          "size": Object {},
+        },
+      },
+    },
+    "result": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  },
+  "type": "@farfetch/blackout-core/FETCH_SHARED_WISHLIST_SUCCESS",
+}
+`;

--- a/packages/core/src/sharedWishlists/redux/__tests__/__snapshots__/doUpdateSharedWishlist.test.js.snap
+++ b/packages/core/src/sharedWishlists/redux/__tests__/__snapshots__/doUpdateSharedWishlist.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doUpdateSharedWishlist() should create the correct actions for when the update shared wishlist procedure is successful: update shared wishlist success payload 1`] = `undefined`;

--- a/packages/core/src/sharedWishlists/redux/__tests__/doCreateSharedWishlist.test.js
+++ b/packages/core/src/sharedWishlists/redux/__tests__/doCreateSharedWishlist.test.js
@@ -1,0 +1,77 @@
+import * as actionTypes from '../actionTypes';
+import { find } from 'lodash';
+import { INITIAL_STATE } from '../reducer';
+import {
+  mockSharedWishlistId,
+  mockSharedWishlistNormalizedPayload,
+  mockSharedWishlistPostData,
+  mockSharedWishlistsResponse,
+} from 'tests/__fixtures__/sharedWishlists';
+import { mockStore } from '../../../../tests';
+import doCreateSharedWishlist from '../actions/doCreateSharedWishlist';
+import thunk from 'redux-thunk';
+
+const mockMiddlewares = [
+  thunk.withExtraArgument({
+    getOptions: () => ({ productImgQueryParam: '?c=2' }),
+  }),
+];
+
+const sharedWishlistMockStore = (state = {}) =>
+  mockStore({ sharedWishlist: INITIAL_STATE }, state, mockMiddlewares);
+
+describe('doCreateSharedWishlist()', () => {
+  let store;
+  const postSharedWishlist = jest.fn();
+  const action = doCreateSharedWishlist(postSharedWishlist);
+  const data = mockSharedWishlistPostData;
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    store = sharedWishlistMockStore({
+      sharedWishlist: {},
+    });
+  });
+
+  it('should create the correct actions for when create a shared wishlist procedure fails', async () => {
+    const expectedError = new Error('post shared wishlist error');
+
+    postSharedWishlist.mockRejectedValueOnce(expectedError);
+
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(data));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(postSharedWishlist).toHaveBeenCalledTimes(1);
+      expect(postSharedWishlist).toHaveBeenCalledWith(data, expectedConfig);
+      expect(store.getActions()).toHaveLength(2);
+    }
+  });
+
+  it('should create the correct actions for when the create a shared wishlist procedure is successful', async () => {
+    postSharedWishlist.mockResolvedValueOnce(mockSharedWishlistsResponse);
+    await store.dispatch(action(data));
+
+    const actionResults = store.getActions();
+
+    expect(postSharedWishlist).toHaveBeenCalledTimes(1);
+    expect(postSharedWishlist).toHaveBeenCalledWith(data, expectedConfig);
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.CREATE_SHARED_WISHLIST_REQUEST },
+      {
+        payload: {
+          ...mockSharedWishlistNormalizedPayload,
+          result: mockSharedWishlistId,
+        },
+        type: actionTypes.CREATE_SHARED_WISHLIST_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, { type: actionTypes.CREATE_SHARED_WISHLIST_SUCCESS }),
+    ).toMatchSnapshot('create shared wishlist success payload');
+  });
+});

--- a/packages/core/src/sharedWishlists/redux/__tests__/doDeleteSharedWishlist.test.js
+++ b/packages/core/src/sharedWishlists/redux/__tests__/doDeleteSharedWishlist.test.js
@@ -1,0 +1,87 @@
+import * as actionTypes from '../actionTypes';
+import { find } from 'lodash';
+import { INITIAL_STATE } from '../reducer';
+import {
+  mockSharedWishlistId,
+  mockSharedWishlistState,
+} from '../../../../../../tests/__fixtures__/sharedWishlists/sharedWishlist.fixtures';
+import { mockStore } from '../../../../tests';
+import doDeleteSharedWishlist from '../actions/doDeleteSharedWishlist';
+import thunk from 'redux-thunk';
+
+const mockMiddlewares = [
+  thunk.withExtraArgument({
+    getOptions: () => ({ productImgQueryParam: '?c=2' }),
+  }),
+];
+
+const sharedWishlistMockStore = (state = {}) =>
+  mockStore({ sharedWishlist: INITIAL_STATE }, state, mockMiddlewares);
+
+describe('doDeleteSharedWishlist()', () => {
+  let store;
+  const deleteSharedWishlist = jest.fn();
+  const action = doDeleteSharedWishlist(deleteSharedWishlist);
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    store = sharedWishlistMockStore(mockSharedWishlistState);
+  });
+
+  it('should create the correct actions for when the remove shared wishlist procedure fails', async () => {
+    const expectedError = new Error('delete shared wishlist error');
+
+    deleteSharedWishlist.mockRejectedValueOnce(expectedError);
+
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(mockSharedWishlistId));
+    } catch (error) {
+      expect(error).toEqual(expectedError);
+      expect(deleteSharedWishlist).toHaveBeenCalledTimes(1);
+      expect(deleteSharedWishlist).toHaveBeenCalledWith(
+        mockSharedWishlistId,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          {
+            type: actionTypes.REMOVE_SHARED_WISHLIST_REQUEST,
+          },
+          {
+            payload: { error: expectedError },
+            type: actionTypes.REMOVE_SHARED_WISHLIST_FAILURE,
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the remove shared wishlist procedure is successful', async () => {
+    deleteSharedWishlist.mockResolvedValueOnce(200);
+
+    await store.dispatch(action(mockSharedWishlistId));
+
+    const actionResults = store.getActions();
+
+    expect(deleteSharedWishlist).toHaveBeenCalledTimes(1);
+    expect(deleteSharedWishlist).toHaveBeenCalledWith(
+      mockSharedWishlistId,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      {
+        type: actionTypes.REMOVE_SHARED_WISHLIST_REQUEST,
+      },
+      {
+        type: actionTypes.REMOVE_SHARED_WISHLIST_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, { type: actionTypes.REMOVE_SHARED_WISHLIST_SUCCESS }),
+    ).toMatchSnapshot('delete shared wishlist success payload');
+  });
+});

--- a/packages/core/src/sharedWishlists/redux/__tests__/doFetchSharedWishlist.test.js
+++ b/packages/core/src/sharedWishlists/redux/__tests__/doFetchSharedWishlist.test.js
@@ -1,0 +1,88 @@
+import * as actionTypes from '../actionTypes';
+import { find } from 'lodash';
+import { INITIAL_STATE } from '../reducer';
+import {
+  mockSharedWishlistId,
+  mockSharedWishlistNormalizedPayload,
+  mockSharedWishlistsResponse,
+} from '../../../../../../tests/__fixtures__/sharedWishlists/sharedWishlist.fixtures';
+import { mockStore } from '../../../../tests';
+import doFetchSharedWishlist from '../actions/doFetchSharedWishlist';
+import thunk from 'redux-thunk';
+
+const mockMiddlewares = [
+  thunk.withExtraArgument({
+    getOptions: () => ({ productImgQueryParam: '?c=2' }),
+  }),
+];
+
+const sharedWishlistMockStore = (state = {}) =>
+  mockStore({ sharedWishlist: INITIAL_STATE }, state, mockMiddlewares);
+
+describe('doFetchSharedWishlist()', () => {
+  let store;
+  const normalizeSpy = jest.spyOn(require('normalizr'), 'normalize');
+  const getSharedWishlist = jest.fn();
+  const action = doFetchSharedWishlist(getSharedWishlist);
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    store = sharedWishlistMockStore();
+  });
+
+  it('should create the correct actions for when fetch a shared wishlist procedure fails', async () => {
+    const expectedError = new Error('get shared wishlist error');
+
+    getSharedWishlist.mockRejectedValueOnce(expectedError);
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(mockSharedWishlistId));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(getSharedWishlist).toHaveBeenCalledTimes(1);
+      expect(getSharedWishlist).toHaveBeenCalledWith(
+        mockSharedWishlistId,
+        expectedConfig,
+      );
+      expect(store.getActions()).toMatchObject([
+        {
+          type: actionTypes.FETCH_SHARED_WISHLIST_REQUEST,
+        },
+        {
+          type: actionTypes.FETCH_SHARED_WISHLIST_FAILURE,
+          payload: { error: expectedError },
+        },
+      ]);
+    }
+  });
+
+  it('should create the correct actions for when fetch a shared wishlist procedure is successful', async () => {
+    getSharedWishlist.mockResolvedValueOnce(mockSharedWishlistsResponse);
+    await store.dispatch(action(mockSharedWishlistId));
+
+    const actionResults = store.getActions();
+
+    expect(normalizeSpy).toHaveBeenCalledTimes(1);
+    expect(getSharedWishlist).toHaveBeenCalledTimes(1);
+    expect(getSharedWishlist).toHaveBeenCalledWith(
+      mockSharedWishlistId,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.FETCH_SHARED_WISHLIST_REQUEST },
+      {
+        payload: {
+          ...mockSharedWishlistNormalizedPayload,
+          result: mockSharedWishlistId,
+        },
+        type: actionTypes.FETCH_SHARED_WISHLIST_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, { type: actionTypes.FETCH_SHARED_WISHLIST_SUCCESS }),
+    ).toMatchSnapshot('get shared wishlist success payload');
+  });
+});

--- a/packages/core/src/sharedWishlists/redux/__tests__/doUpdateSharedWishlist.test.js
+++ b/packages/core/src/sharedWishlists/redux/__tests__/doUpdateSharedWishlist.test.js
@@ -1,0 +1,87 @@
+import * as actionTypes from '../actionTypes';
+import { find } from 'lodash';
+import { INITIAL_STATE } from '../reducer';
+import {
+  mockSharedWishlistId,
+  mockSharedWishlistNormalizedPayload,
+  mockSharedWishlistsResponse,
+  mockSharedWishlistState,
+} from '../../../../../../tests/__fixtures__/sharedWishlists/sharedWishlist.fixtures';
+import { mockStore } from '../../../../tests';
+import doUpdateSharedWishlist from '../actions/doUpdateSharedWishlist';
+import thunk from 'redux-thunk';
+
+const mockMiddlewares = [
+  thunk.withExtraArgument({
+    getOptions: () => ({ productImgQueryParam: '?c=2' }),
+  }),
+];
+
+const sharedWishlistMockStore = (state = {}) =>
+  mockStore({ sharedWishlist: INITIAL_STATE }, state, mockMiddlewares);
+
+describe('doUpdateSharedWishlist()', () => {
+  let store;
+  const putSharedWishlist = jest.fn();
+  const action = doUpdateSharedWishlist(putSharedWishlist);
+  const expectedConfig = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    store = sharedWishlistMockStore(mockSharedWishlistState);
+  });
+
+  it('should create the correct actions for when updating a shared wishlist procedure fails', async () => {
+    const expectedError = new Error('update shared wishlist error');
+
+    putSharedWishlist.mockRejectedValueOnce(expectedError);
+
+    expect.assertions(4);
+
+    try {
+      await store.dispatch(action(mockSharedWishlistId));
+    } catch (error) {
+      expect(error).toBe(expectedError);
+      expect(putSharedWishlist).toHaveBeenCalledTimes(1);
+      expect(putSharedWishlist).toHaveBeenCalledWith(
+        mockSharedWishlistId,
+        expectedConfig,
+      );
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          {
+            type: actionTypes.UPDATE_SHARED_WISHLIST_REQUEST,
+          },
+          {
+            type: actionTypes.UPDATE_SHARED_WISHLIST_FAILURE,
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
+  });
+
+  it('should create the correct actions for when the update shared wishlist procedure is successful', async () => {
+    putSharedWishlist.mockResolvedValueOnce(mockSharedWishlistsResponse);
+    await store.dispatch(action(mockSharedWishlistId));
+
+    const actionResults = store.getActions();
+
+    expect(putSharedWishlist).toHaveBeenCalledTimes(1);
+    expect(putSharedWishlist).toHaveBeenLastCalledWith(
+      mockSharedWishlistId,
+      expectedConfig,
+    );
+    expect(actionResults).toMatchObject([
+      { type: actionTypes.UPDATE_SHARED_WISHLIST_REQUEST },
+      {
+        payload: mockSharedWishlistNormalizedPayload,
+        type: actionTypes.UPDATE_SHARED_WISHLIST_SUCCESS,
+      },
+    ]);
+    expect(
+      find(actionResults, { type: actionTypes.CREATE_SHARED_WISHLIST_SUCCESS }),
+    ).toMatchSnapshot('update shared wishlist success payload');
+  });
+});

--- a/packages/core/src/sharedWishlists/redux/__tests__/reset.test.js
+++ b/packages/core/src/sharedWishlists/redux/__tests__/reset.test.js
@@ -1,0 +1,21 @@
+import * as actionTypes from '../actionTypes';
+import { mockStore } from '../../../../tests';
+import { reset } from '../actions';
+
+let store;
+
+describe('reset()', () => {
+  beforeEach(() => {
+    store = mockStore();
+  });
+
+  it('should dispatch the correct action when there are no fields to reset', () => {
+    store.dispatch(reset());
+    const actionResults = store.getActions();
+
+    expect(actionResults).toMatchObject([
+      { payload: {}, type: actionTypes.RESET_SHARED_WISHLIST_STATE },
+      { type: actionTypes.RESET_SHARED_WISHLIST_ENTITIES },
+    ]);
+  });
+});

--- a/packages/core/src/sharedWishlists/redux/__tests__/resetState.test.js
+++ b/packages/core/src/sharedWishlists/redux/__tests__/resetState.test.js
@@ -1,0 +1,25 @@
+import * as actionTypes from '../actionTypes';
+import { mockStore } from '../../../../tests';
+import { resetState } from '../actions';
+
+let store;
+
+describe('resetState()', () => {
+  beforeEach(() => {
+    store = mockStore();
+  });
+
+  it('should dispatch the correct action with fields to reset', () => {
+    const fieldsToReset = ['error'];
+
+    store.dispatch(resetState(fieldsToReset));
+    const actionResults = store.getActions();
+
+    expect(actionResults).toMatchObject([
+      {
+        payload: { fieldsToReset },
+        type: actionTypes.RESET_SHARED_WISHLIST_STATE,
+      },
+    ]);
+  });
+});

--- a/packages/core/src/sharedWishlists/redux/actionTypes.js
+++ b/packages/core/src/sharedWishlists/redux/actionTypes.js
@@ -1,0 +1,52 @@
+/**
+ * @module sharedWishlists/actionTypes
+ * @category sharedWishlists
+ * @subcategory Action types
+ */
+
+/** Action type dispatched when the add shared wishlist request fails. */
+export const CREATE_SHARED_WISHLIST_FAILURE =
+  '@farfetch/blackout-core/CREATE_SHARED_WISHLIST_FAILURE';
+/** Action type dispatched when the add shared wishlist request starts. */
+export const CREATE_SHARED_WISHLIST_REQUEST =
+  '@farfetch/blackout-core/CREATE_SHARED_WISHLIST_REQUEST';
+/** Action type dispatched when the add shared wishlist request succeeds. */
+export const CREATE_SHARED_WISHLIST_SUCCESS =
+  '@farfetch/blackout-core/CREATE_SHARED_WISHLIST_SUCCESS';
+
+/** Action type dispatched when the remove shared wishlist request fails. */
+export const REMOVE_SHARED_WISHLIST_FAILURE =
+  '@farfetch/blackout-core/REMOVE_SHARED_WISHLIST_FAILURE';
+/** Action type dispatched when the remove shared wishlist request starts. */
+export const REMOVE_SHARED_WISHLIST_REQUEST =
+  '@farfetch/blackout-core/REMOVE_SHARED_WISHLIST_REQUEST';
+/** Action type dispatched when the remove shared wishlist request succeeds. */
+export const REMOVE_SHARED_WISHLIST_SUCCESS =
+  '@farfetch/blackout-core/REMOVE_SHARED_WISHLIST_SUCCESS';
+
+/** Action type dispatched when the fetch shared wishlist request fails. */
+export const FETCH_SHARED_WISHLIST_FAILURE =
+  '@farfetch/blackout-core/FETCH_SHARED_WISHLIST_FAILURE';
+/** Action type dispatched when the fetch shared wishlist request starts. */
+export const FETCH_SHARED_WISHLIST_REQUEST =
+  '@farfetch/blackout-core/FETCH_SHARED_WISHLIST_REQUEST';
+/** Action type dispatched when the fetch shared wishlist request succeeds. */
+export const FETCH_SHARED_WISHLIST_SUCCESS =
+  '@farfetch/blackout-core/FETCH_SHARED_WISHLIST_SUCCESS';
+
+/** Action type dispatched when the reset shared wishlist state occurs. */
+export const RESET_SHARED_WISHLIST_STATE =
+  '@farfetch/blackout-core/RESET_SHARED_WISHLIST_STATE';
+/** Action type dispatched when the reset shared wishlist entities occurs. */
+export const RESET_SHARED_WISHLIST_ENTITIES =
+  '@farfetch/blackout-core/RESET_SHARED_WISHLIST_ENTITIES';
+
+/** Action type dispatched when the update shared wishlist request fails. */
+export const UPDATE_SHARED_WISHLIST_FAILURE =
+  '@farfetch/blackout-core/UPDATE_SHARED_WISHLIST_FAILURE';
+/** Action type dispatched when the update shared wishlist request starts. */
+export const UPDATE_SHARED_WISHLIST_REQUEST =
+  '@farfetch/blackout-core/UPDATE_SHARED_WISHLIST_REQUEST';
+/** Action type dispatched when the update shared wishlist request succeeds. */
+export const UPDATE_SHARED_WISHLIST_SUCCESS =
+  '@farfetch/blackout-core/UPDATE_SHARED_WISHLIST_SUCCESS';

--- a/packages/core/src/sharedWishlists/redux/actions/doCreateSharedWishlist.js
+++ b/packages/core/src/sharedWishlists/redux/actions/doCreateSharedWishlist.js
@@ -1,0 +1,56 @@
+import * as actionTypes from '../actionTypes';
+import { normalize } from 'normalizr';
+import sharedWishlistSchema from '../../../entities/schemas/sharedWishlist';
+
+/**
+ * @callback CreateSharedWishlistThunkFactory
+ *
+ * @param {object} data - Details of the information of which wishlist
+ * set is going to be shared.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Create a new shared wishlist.
+ *
+ * @function doCreateSharedWishlist
+ * @memberof module:wishlists/actions
+ *
+ * @param {Function} postSharedWishlist - Post shared wishlist client.
+ *
+ * @returns {CreateSharedWishlistThunkFactory} Thunk factory.
+ */
+
+export default postSharedWishlist =>
+  (data, config) =>
+  async (dispatch, getState, { getOptions = arg => ({ arg }) }) => {
+    try {
+      dispatch({ type: actionTypes.CREATE_SHARED_WISHLIST_REQUEST });
+
+      const result = await postSharedWishlist(data, config);
+      const { productImgQueryParam } = getOptions(getState);
+      const newItems = result.items.map(item => ({
+        ...item,
+        productImgQueryParam,
+      }));
+
+      dispatch({
+        payload: normalize(
+          { ...result, items: newItems },
+          sharedWishlistSchema,
+        ),
+        type: actionTypes.CREATE_SHARED_WISHLIST_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: actionTypes.CREATE_SHARED_WISHLIST_FAILURE,
+      });
+      throw error;
+    }
+  };

--- a/packages/core/src/sharedWishlists/redux/actions/doDeleteSharedWishlist.js
+++ b/packages/core/src/sharedWishlists/redux/actions/doDeleteSharedWishlist.js
@@ -1,0 +1,45 @@
+import * as actionTypes from '../actionTypes';
+
+/**
+ * @callback DeleteSharedWishlistThunkFactory
+ * @param {string} sharedWishlistId - Shared wislist id to remove.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Remove a shared wishlist.
+ *
+ * @function doRemoveSharedWishlist
+ * @memberof module:sharedWishlists/actions
+ *
+ * @param {Function} deleteSharedWishlist - Delete shared wishlist client.
+ *
+ *  @returns {DeleteSharedWishlistThunkFactory} Thunk factory.
+ */
+export default deleteSharedWishlist =>
+  (sharedWishlistId, config) =>
+  async dispatch => {
+    try {
+      dispatch({
+        type: actionTypes.REMOVE_SHARED_WISHLIST_REQUEST,
+      });
+
+      const result = await deleteSharedWishlist(sharedWishlistId, config);
+
+      dispatch({
+        type: actionTypes.REMOVE_SHARED_WISHLIST_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: actionTypes.REMOVE_SHARED_WISHLIST_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/core/src/sharedWishlists/redux/actions/doFetchSharedWishlist.js
+++ b/packages/core/src/sharedWishlists/redux/actions/doFetchSharedWishlist.js
@@ -1,0 +1,58 @@
+import * as actionTypes from '../actionTypes';
+import { normalize } from 'normalizr';
+import sharedWishlistSchema from '../../../entities/schemas/sharedWishlist';
+
+/**
+ * @callback GetSharedWishlistThunkFactory
+ * @param {string} sharedWishlistId - Universal identifier of the shared wishlist.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Load shared wishlist with given id.
+ *
+ * @function doFetchSharedWishlist
+ * @memberof module:wishlists/actions
+ *
+ * @param {Function} getSharedWishlist - Get shared wishlist client.
+ *
+ * @returns {GetSharedWishlistThunkFactory} Thunk factory.
+ */
+
+export default getSharedWishlist =>
+  (sharedWishlistId, config) =>
+  async (dispatch, getState, { getOptions = arg => ({ arg }) }) => {
+    try {
+      dispatch({
+        meta: { sharedWishlistId },
+        type: actionTypes.FETCH_SHARED_WISHLIST_REQUEST,
+      });
+
+      const result = await getSharedWishlist(sharedWishlistId, config);
+      const { productImgQueryParam } = getOptions(getState);
+      const newItems = result.items.map(item => ({
+        ...item,
+        productImgQueryParam,
+      }));
+
+      dispatch({
+        payload: normalize(
+          { ...result, items: newItems },
+          sharedWishlistSchema,
+        ),
+        type: actionTypes.FETCH_SHARED_WISHLIST_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: actionTypes.FETCH_SHARED_WISHLIST_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/core/src/sharedWishlists/redux/actions/doUpdateSharedWishlist.js
+++ b/packages/core/src/sharedWishlists/redux/actions/doUpdateSharedWishlist.js
@@ -1,0 +1,56 @@
+import * as actionTypes from '../actionTypes';
+import { normalize } from 'normalizr';
+import sharedWishlistSchema from '../../../entities/schemas/sharedWishlist';
+
+/**
+ * @callback UpdateSharedWishlistThunkFactory
+ * @param {string} sharedWishlistId - Universal identifier of the shared wishlist.
+ * @param {object} [config] - Custom configurations to send to the client
+ * instance (axios).
+ *
+ * @returns {Function} Thunk to be dispatched to the redux store.
+ */
+
+/**
+ * Update a shared wishlist.
+ *
+ * @function doUpdateSharedWishlist
+ * @memberof module:sharedWishlists/actions
+ *
+ * @param {Function} putSharedWishlist - Put shared wishlist client.
+ *
+ * @returns {UpdateSharedWishlistThunkFactory} Thunk factory.
+ */
+export default putSharedWishlist =>
+  (sharedWishlistId, config) =>
+  async (dispatch, getState, { getOptions = arg => ({ arg }) }) => {
+    try {
+      dispatch({
+        type: actionTypes.UPDATE_SHARED_WISHLIST_REQUEST,
+      });
+
+      const result = await putSharedWishlist(sharedWishlistId, config);
+      const { productImgQueryParam } = getOptions(getState);
+      const newItems = result.items.map(item => ({
+        ...item,
+        productImgQueryParam,
+      }));
+
+      dispatch({
+        payload: normalize(
+          { ...result, items: newItems },
+          sharedWishlistSchema,
+        ),
+        type: actionTypes.UPDATE_SHARED_WISHLIST_SUCCESS,
+      });
+
+      return result;
+    } catch (error) {
+      dispatch({
+        payload: { error },
+        type: actionTypes.UPDATE_SHARED_WISHLIST_FAILURE,
+      });
+
+      throw error;
+    }
+  };

--- a/packages/core/src/sharedWishlists/redux/actions/index.js
+++ b/packages/core/src/sharedWishlists/redux/actions/index.js
@@ -1,0 +1,13 @@
+/**
+ * Shared wishlists actions.
+ *
+ * @module sharedWishlists/actions
+ * @category Shared Wishlists
+ * @subcategory Actions
+ */
+export { default as doCreateSharedWishlist } from './doCreateSharedWishlist';
+export { default as doDeleteSharedWishlist } from './doDeleteSharedWishlist';
+export { default as doFetchSharedWishlist } from './doFetchSharedWishlist';
+export { default as doUpdateSharedWishlist } from './doUpdateSharedWishlist';
+export { default as reset } from './reset';
+export { default as resetState } from './resetState';

--- a/packages/core/src/sharedWishlists/redux/actions/reset.js
+++ b/packages/core/src/sharedWishlists/redux/actions/reset.js
@@ -1,0 +1,47 @@
+import { RESET_SHARED_WISHLIST_ENTITIES } from '../actionTypes';
+import resetState from './resetState';
+
+/**
+ * Reset shared wishlist related entities to its initial value.
+ *
+ * @private
+ * @function
+ * @memberof module:sharedWishlists/actions
+ *
+ * @returns {Function} Dispatch reset state and entities action.
+ */
+const resetEntities = () => dispatch => {
+  dispatch({
+    type: RESET_SHARED_WISHLIST_ENTITIES,
+  });
+};
+
+/**
+ * Reset shared wishlist state and related entities to its initial value.
+ *
+ * @function reset
+ * @memberof module:sharedWishlists/actions
+ *
+ * @example
+ * import { reset } from '@farfetch/blackout-core/shareWishlists/redux';
+ *
+ * // State object before executing action
+ * const state = { result: '123', error: null, isLoading: false};
+ *
+ * // Store: { entities: {
+ *  sharedWishlist: { 123: {...} },
+ *  sharedWishlistItems: { 1: {...} }
+ * } }
+ *
+ * // Result:
+ *  State: { result: null, error: null, isLoading: false,} }
+ *  Store: { entities: { } }
+ *
+ * dispatch(resetSharedWishlist());
+ *
+ * @returns {Function} Dispatch reset state and entities action.
+ */
+export default () => dispatch => {
+  dispatch(resetState());
+  dispatch(resetEntities());
+};

--- a/packages/core/src/sharedWishlists/redux/actions/resetState.js
+++ b/packages/core/src/sharedWishlists/redux/actions/resetState.js
@@ -1,0 +1,38 @@
+import { RESET_SHARED_WISHLIST_STATE } from '../actionTypes';
+
+/**
+ * Reset shared wishist state to its initial value.
+ *
+ * @function resetState
+ * @memberof module:sharedWishlists/actions
+ *
+ * @param {Array} [fieldsToReset=[]] - List of fields to reset during the reset
+ * operation.
+ *
+ * @example <caption>Reset with no fields to reset, resetting all</caption>
+ *
+ * import { resetState } from '@farfetch/blackout-core/sharedWishlist/redux';
+ *
+ * dispatch(resetWishlistState(["error"]));
+ *
+ * // State object before executing action
+ * const state = {
+ *  result: '123-456-789',
+ *  error: { message: 'error },
+ *  isLoading: false,
+ * };
+ *
+ * // Result:
+ *  {
+ *   result: '123-456-789',
+ *   error: null,
+ *   isLoading: false,
+ *  };
+ */
+
+export default fieldsToReset => dispatch => {
+  dispatch({
+    payload: { fieldsToReset },
+    type: RESET_SHARED_WISHLIST_STATE,
+  });
+};

--- a/packages/core/src/sharedWishlists/redux/middlewares/__tests__/updateSharedWishlistUponItemsChanges.test.js
+++ b/packages/core/src/sharedWishlists/redux/middlewares/__tests__/updateSharedWishlistUponItemsChanges.test.js
@@ -1,0 +1,74 @@
+import {
+  ADD_ITEM_TO_WISHLIST_SUCCESS,
+  DELETE_WISHLIST_ITEM_SUCCESS,
+  UPDATE_WISHLIST_ITEM_SUCCESS,
+} from '../../../../wishlists/redux/actionTypes';
+import { mockSharedWishlistState } from 'tests/__fixtures__/sharedWishlists';
+import { mockStore } from '../../../../../tests';
+import INITIAL_STATE from '../../reducer';
+import updateSharedWishlistUponItemsChanges from '../updateSharedWishlistUponItemsChanges';
+
+jest.mock('../../actions', () => ({
+  ...jest.requireActual('../../actions'),
+  doUpdateSharedWishlist: jest.fn(() => () => ({ type: 'foo' })),
+}));
+const mockState = {
+  ...mockSharedWishlistState,
+  entities: {
+    ...mockSharedWishlistState.entities,
+    user: { isGuest: false },
+  },
+};
+
+describe('updateSharedWishlistUponItemsChanges', () => {
+  it('should do nothing if the action is not adding, deleting or updating a wishlist item', () => {
+    const store = mockStore({ sharedWishlist: INITIAL_STATE }, mockState, [
+      updateSharedWishlistUponItemsChanges,
+    ]);
+
+    store.dispatch({ type: 'foo' });
+
+    const actions = store.getActions();
+
+    expect(actions).toEqual(expect.arrayContaining([{ type: 'foo' }]));
+  });
+
+  it.each([
+    ADD_ITEM_TO_WISHLIST_SUCCESS,
+    DELETE_WISHLIST_ITEM_SUCCESS,
+    UPDATE_WISHLIST_ITEM_SUCCESS,
+  ])('should intercept %s, and do nothing for a guest user', actionType => {
+    const store = mockStore(
+      { sharedWishlist: INITIAL_STATE },
+      { entities: { user: { isGuest: true } } },
+      [updateSharedWishlistUponItemsChanges],
+    );
+
+    store.dispatch({ type: actionType });
+
+    const actions = store.getActions();
+
+    expect(actions).toEqual(expect.arrayContaining([{ type: actionType }]));
+  });
+
+  it.each([
+    UPDATE_WISHLIST_ITEM_SUCCESS,
+    ADD_ITEM_TO_WISHLIST_SUCCESS,
+    DELETE_WISHLIST_ITEM_SUCCESS,
+  ])(
+    'should intercept %s, and update the shared wishlist for a non-guest user',
+    actionType => {
+      const store = mockStore({ sharedWishlist: INITIAL_STATE }, mockState, [
+        updateSharedWishlistUponItemsChanges,
+      ]);
+
+      store.dispatch({ type: actionType });
+
+      const actions = store.getActions();
+
+      expect(actions).toEqual(
+        expect.arrayContaining([{ type: 'foo' }, { type: actionType }]),
+      );
+    },
+  );
+});

--- a/packages/core/src/sharedWishlists/redux/middlewares/index.js
+++ b/packages/core/src/sharedWishlists/redux/middlewares/index.js
@@ -1,0 +1,8 @@
+/**
+ * Shared wishlists middlewares.
+ *
+ * @module sharedWishlists/middlewares
+ * @category Shared Wishlists
+ * @subcategory Middlewares
+ */
+export { default as updateSharedWishlistUponItemsChanges } from './updateSharedWishlistUponItemsChanges';

--- a/packages/core/src/sharedWishlists/redux/middlewares/updateSharedWishlistUponItemsChanges.js
+++ b/packages/core/src/sharedWishlists/redux/middlewares/updateSharedWishlistUponItemsChanges.js
@@ -1,0 +1,39 @@
+import {
+  ADD_ITEM_TO_WISHLIST_SUCCESS,
+  DELETE_WISHLIST_ITEM_SUCCESS,
+  UPDATE_WISHLIST_ITEM_SUCCESS,
+} from '../../../wishlists/redux/actionTypes';
+import { doUpdateSharedWishlist } from '../actions';
+import { getSharedWishlistId } from '../selectors';
+import { getUser, getUserIsGuest } from '../../../entities/redux/selectors';
+import { putSharedWishlist as putSharedWishlistClient } from '../../client';
+
+const updateSharedWishlist = doUpdateSharedWishlist(putSharedWishlistClient);
+
+/**
+ * Middleware to update the shared wishlist if a wishlist item is added, edited or deleted.
+ *
+ * @function updateSharedWishlistUponItemsChanges
+ * @memberof module:sharedWishlists/middlewares
+ *
+ * @param {object} store - Redux store at the moment.
+ *
+ * @returns {Function} Redux middleware.
+ */
+export default store => next => action => {
+  if (
+    action.type === UPDATE_WISHLIST_ITEM_SUCCESS ||
+    action.type === ADD_ITEM_TO_WISHLIST_SUCCESS ||
+    action.type === DELETE_WISHLIST_ITEM_SUCCESS
+  ) {
+    const user = getUser(store.getState());
+    const isGuestUser = getUserIsGuest(user);
+
+    if (!isGuestUser) {
+      const sharedWishlistId = getSharedWishlistId(store.getState());
+
+      store.dispatch(updateSharedWishlist(sharedWishlistId));
+    }
+  }
+  return next(action);
+};

--- a/packages/core/src/sharedWishlists/redux/reducer.js
+++ b/packages/core/src/sharedWishlists/redux/reducer.js
@@ -1,0 +1,135 @@
+import * as actionTypes from './actionTypes';
+import { combineReducers } from 'redux';
+import { LOGOUT_SUCCESS } from '../../authentication/redux/actionTypes';
+
+const INITIAL_STATE = {
+  error: null,
+  id: null,
+  result: null,
+};
+const result = (state = INITIAL_STATE.result, action = {}) => {
+  switch (action.type) {
+    case actionTypes.CREATE_SHARED_WISHLIST_SUCCESS:
+    case actionTypes.FETCH_SHARED_WISHLIST_SUCCESS:
+    case actionTypes.UPDATE_SHARED_WISHLIST_SUCCESS:
+      return action.payload.result;
+    default:
+      return state;
+  }
+};
+
+const error = (state = INITIAL_STATE.error, action = {}) => {
+  switch (action.type) {
+    case actionTypes.CREATE_SHARED_WISHLIST_FAILURE:
+    case actionTypes.FETCH_SHARED_WISHLIST_FAILURE:
+    case actionTypes.REMOVE_SHARED_WISHLIST_FAILURE:
+    case actionTypes.UPDATE_SHARED_WISHLIST_FAILURE:
+      return action.payload.error;
+    case actionTypes.CREATE_SHARED_WISHLIST_REQUEST:
+    case actionTypes.FETCH_SHARED_WISHLIST_REQUEST:
+    case actionTypes.REMOVE_SHARED_WISHLIST_REQUEST:
+    case actionTypes.UPDATE_SHARED_WISHLIST_REQUEST:
+      return INITIAL_STATE.error;
+    default:
+      return state;
+  }
+};
+
+const isLoading = (state = INITIAL_STATE.isLoading, action = {}) => {
+  switch (action.type) {
+    case actionTypes.CREATE_SHARED_WISHLIST_REQUEST:
+    case actionTypes.FETCH_SHARED_WISHLIST_REQUEST:
+    case actionTypes.REMOVE_SHARED_WISHLIST_REQUEST:
+    case actionTypes.UPDATE_SHARED_WISHLIST_REQUEST:
+      return true;
+    case actionTypes.CREATE_SHARED_WISHLIST_FAILURE:
+    case actionTypes.CREATE_SHARED_WISHLIST_SUCCESS:
+    case actionTypes.FETCH_SHARED_WISHLIST_FAILURE:
+    case actionTypes.FETCH_SHARED_WISHLIST_SUCCESS:
+    case actionTypes.REMOVE_SHARED_WISHLIST_FAILURE:
+    case actionTypes.REMOVE_SHARED_WISHLIST_SUCCESS:
+    case actionTypes.UPDATE_SHARED_WISHLIST_FAILURE:
+    case actionTypes.UPDATE_SHARED_WISHLIST_SUCCESS:
+      return INITIAL_STATE.isLoading;
+    default:
+      return state;
+  }
+};
+
+//
+// Entities mapper
+//
+
+export const entitiesMapper = {
+  [actionTypes.RESET_SHARED_WISHLIST_ENTITIES]: state => {
+    if (!state) {
+      return state;
+    }
+
+    const { sharedWishlists, sharedWishlistItems, ...rest } = state;
+
+    return rest;
+  },
+  [actionTypes.LOGOUT_SUCCESS]: state => {
+    if (!state) {
+      return state;
+    }
+
+    const { sharedWishlists, sharedWishlistItems, ...rest } = state;
+
+    return rest;
+  },
+};
+
+//
+// Selectors from reducer
+//
+
+export const getError = state => state.error;
+export const getResult = state => state.result;
+export const getIsLoading = state => state.isLoading;
+
+//
+// Combining and exporting
+//
+
+const reducer = combineReducers({
+  error,
+  isLoading,
+  result,
+});
+
+/**
+ * Reducer for shared wishlists state.
+ *
+ * @function sharedWishlistReducer
+ * @static
+ * @memberof module:sharedWishlist/reducer
+ *
+ * @param {object} state - Current redux state.
+ * @param {object} action - Action dispatched.
+ *
+ * @returns {object} New state.
+ */
+export default (state, action = {}) => {
+  if (action.type === LOGOUT_SUCCESS) {
+    return INITIAL_STATE;
+  }
+
+  if (action.type === actionTypes.RESET_SHARED_WISHLIST_ENTITIES) {
+    const fieldsToReset = action.payload.fieldsToReset;
+
+    if (!fieldsToReset) {
+      return INITIAL_STATE;
+    }
+
+    const reducerFn = (acc, field) => {
+      if (!state) {
+        return state;
+      }
+      return { ...acc, [field]: INITIAL_STATE[field] };
+    };
+    return fieldsToReset.reduce(reducerFn, state);
+  }
+  return reducer(state, action);
+};

--- a/packages/core/src/sharedWishlists/redux/selectors.js
+++ b/packages/core/src/sharedWishlists/redux/selectors.js
@@ -1,0 +1,234 @@
+import * as fromSharedWishlistReducer from './reducer';
+import { createSelector } from 'reselect';
+import { getEntity } from '../../entities/redux/selectors';
+
+/**
+ * Retrieves current user's shared wishlist id.
+ *
+ * @function
+ * @memberof module:sharedWishlists/selectors
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {string} Universal idenfier of the shared wishlist.
+ *
+ * @example
+ * import { getSharedWishlistId } from '@farfetch/blackout-core/sharedWishlists/redux';
+ *
+ * const mapStateToProps = state => ({
+ *    sharedWishlistId: getSharedWishlist(state)
+ * });
+ */
+export const getSharedWishlistId = state =>
+  fromSharedWishlistReducer.getResult(state.sharedWishlist);
+
+/**
+ * Retrieves the error state of the current user's shared wishlist.
+ *
+ * @function
+ * @memberof module:sharedWishlists/selectors
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {object|undefined} Error information, `undefined` if there are no errors.
+ *
+ * @example
+ * import { getSharedWishlistError } from '@farfetch/blackout-core/sharedWishlists/redux';
+ *
+ * const mapStateToProps = state => ({
+ *    error: getSharedWishlistError(state)
+ * });
+ */
+export const getSharedWishlistError = state =>
+  fromSharedWishlistReducer.getError(state.sharedWishlist);
+
+/**
+ * Retrieves the loading status of the shared wishlist.
+ *
+ * @function
+ * @memberof module:sharedWishlists/selectors
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {boolean} Loading status of the shared wishlist.
+ *
+ * @example
+ * import { isSharedWishlistLoading } from '@farfetch/blackout-core/sharedWishlists/redux';
+ *
+ * const mapStateToProps = state => ({
+ *    isLoading: isSharedWishlistLoading(state)
+ * });
+ */
+export const isSharedWishlistLoading = state =>
+  fromSharedWishlistReducer.getIsLoading(state.sharedWishlist);
+
+/**
+ * Retrieves a specific shared wishlist by its id, with all properties populated(ie,
+ * the product).
+ *
+ * @function
+ * @memberof module:sharedWishlists/selectors
+ *
+ * @param {object} state - Application state.
+ * @param {string} sharedWishlistId - Numeric identifier of the shared wishlist.
+ *
+ * @returns {object} - Shared wishlist entity for the given id.
+ *
+ * @example
+ * import { getSharedWishlist } from '@farfetch/blackout-core/sharedWishlists/redux';
+ *
+ * const mapStateToProps = (state, { sharedWishlists: { id } }) => ({
+ *    sharedWishlist: getSharedWishlist(state, id)
+ * });
+ */
+export const getSharedWishlist = (state, sharedWishlistId) => {
+  return getEntity(state, 'sharedWishlists', sharedWishlistId);
+};
+
+/**
+ * Denormalizes a shared wishlist item.
+ *
+ * @function
+ * @memberof module:sharedWishlists/selectors
+ *
+ * @param {number} sharedWishlistItemId - Shared wishlist item id.
+ * @param {object} sharedWishlistItems - Shared wishlist item entities as obtained with getEntity(state, 'sharedWishlistItems').
+ * @param {object} products - Product entities as obtained with getEntity(state, 'products').
+ * @param {object} brands - Brand entities as obtained with getEntity(state, 'brands').
+ * @param {object} categories  - Category entities as obtained with getEntity(state, 'categories').
+ *
+ * @returns {object} Shared wishlist item object containing product information.
+ */
+const denormalizeSharedWishlistItem = (
+  sharedWishlistItemId,
+  sharedWishlistItems,
+  products,
+  brands,
+  categories,
+) => {
+  const sharedWishlistItemEntity = sharedWishlistItems[sharedWishlistItemId];
+
+  if (!sharedWishlistItemEntity) {
+    return undefined;
+  }
+
+  const productEntity = products[sharedWishlistItemEntity.product];
+  const productBrand = productEntity.brand;
+  const brand = productBrand ? brands[productBrand] : undefined;
+  const productCategories =
+    categories && productEntity.categories.map(id => categories[id]);
+
+  const product = productEntity
+    ? {
+        ...productEntity,
+        brand,
+        categories: productCategories,
+      }
+    : undefined;
+
+  const sharedWishlistItem = {
+    ...sharedWishlistItemEntity,
+    product,
+  };
+
+  return sharedWishlistItem;
+};
+
+/**
+ * Retrieves a specific shared wishlist item by its id, with all properties
+ * populated (ie, the product).
+ *
+ * @function
+ * @memberof module:sharedWishlists/selectors
+ *
+ * @param {object} state - Application state.
+ * @param {number} sharedWishlistItemId - Numeric identifier of the shared wishlist item.
+ *
+ * @returns {object} - Shared wishlist item entity for the given id.
+ *
+ * @example
+ * import { getSharedWishlistItem } from '@farfetch/blackout-core/sharedWishlists/redux';
+ *
+ * const mapStateToProps = (state, { sharedWishlistItem: { id } }) => ({
+ *    sharedWishlistItem: getSharedWishlistItem(state, id)
+ * });
+ */
+export const getSharedWishlistItem = createSelector(
+  [
+    (state, sharedWishlistItemId) => sharedWishlistItemId,
+    state => getEntity(state, 'sharedWishlists'),
+    state => getEntity(state, 'sharedWishlistsItems'),
+    state => getEntity(state, 'products'),
+    state => getEntity(state, 'brands'),
+    state => getEntity(state, 'categories'),
+  ],
+  (
+    sharedWishlistItemId,
+    sharedWishlistsItems,
+    products,
+    brands,
+    categories,
+  ) => {
+    return denormalizeSharedWishlistItem(
+      sharedWishlistItemId,
+      sharedWishlistsItems,
+      products,
+      brands,
+      categories,
+    );
+  },
+);
+
+/**
+ * Retrieves shared wishlist items for a specific wishlist.
+ *
+ * @function
+ * @memberof module:sharedWishlists/selectors
+ *
+ * @param {object} state - Application state.
+ * @param {number} sharedWishlistId - Numeric identifier of the shared wishlist.
+ *
+ * @returns {object} - Shared wishlist items entity for the given id.
+ *
+ * @example
+ * import { getSharedWishlistItem } from '@farfetch/blackout-core/sharedWishlists/redux';
+ *
+ * const mapStateToProps = (state, { sharedWishlists: { id } }) => ({
+ *    sharedWishlistItems: getSharedWishlistItems(state, id)
+ * });
+ */
+
+export const getSharedWishlistItems = createSelector(
+  [
+    (_, sharedWishlistId) => sharedWishlistId,
+    state => getEntity(state, 'sharedWishlists'),
+    state => getEntity(state, 'sharedWishlistItems'),
+    state => getEntity(state, 'products'),
+    state => getEntity(state, 'brands'),
+    state => getEntity(state, 'categories'),
+  ],
+  (
+    sharedWishlistId,
+    sharedWishlists,
+    sharedWishlistItems,
+    products,
+    brands,
+    categories,
+  ) => {
+    const sharedWishlistEntity = sharedWishlists[sharedWishlistId];
+
+    if (!sharedWishlistEntity) {
+      return undefined;
+    }
+
+    return sharedWishlistEntity.items.map(itemId =>
+      denormalizeSharedWishlistItem(
+        itemId,
+        sharedWishlistItems,
+        products,
+        brands,
+        categories,
+      ),
+    );
+  },
+);

--- a/tests/__fixtures__/sharedWishlists/index.js
+++ b/tests/__fixtures__/sharedWishlists/index.js
@@ -1,0 +1,1 @@
+export * from './sharedWishlist.fixtures';

--- a/tests/__fixtures__/sharedWishlists/sharedWishlist.fixtures.js
+++ b/tests/__fixtures__/sharedWishlists/sharedWishlist.fixtures.js
@@ -1,0 +1,206 @@
+export const mockSharedWishlistId = '3fa85f64-5717-4562-b3fc-2c963f66afa6';
+export const mockSharedWishlistItemId = 481426747;
+export const mockProductId = 11766695;
+export const mockProductImgQueryParam = '?c=2';
+
+export const mockSharedWishlistItem = {
+  id: mockSharedWishlistItemId,
+  productId: mockProductId,
+  productName: '251 sneakers',
+  productDescription: 'Modern Sneakers',
+  quantity: 2,
+  dateCreated: '2022-11-24T15:14:43.319Z',
+  brandId: 10533,
+  brandName: 'Valentino',
+  productSlug: 'string',
+  isExclusive: false,
+  isCustomizable: false,
+};
+
+export const mockSharedWishlistsResponse = {
+  id: mockSharedWishlistId,
+  name: 'string',
+  description: 'string',
+  hasMissingItems: false,
+  dateCreated: '2022-11-24T15:14:43.319Z',
+  items: [mockSharedWishlistItem],
+};
+
+export const mockSharedWishlistPostData = {
+  wishlistId: 'b1a13891-6084-489f-96ed-300eed45b948',
+  wishlistSetId: '77fae745-7608-4b7d-8e7d-4f6923e032ef',
+};
+
+const mockSharedWishlistItemEntity = {
+  attributes: undefined,
+  dateCreated: 1669302883319,
+  id: 481426747,
+  isCustomizable: false,
+  isExclusive: false,
+  price: undefined,
+  product: 11766695,
+  quantity: 2,
+  size: {},
+};
+
+export const mockSharedWishlistNormalizedPayload = {
+  entities: {
+    brands: {
+      10533: {
+        id: 10533,
+        name: 'Valentino',
+      },
+    },
+    products: {
+      [mockProductId]: {
+        DEPRECATED_images: undefined,
+        brand: 10533,
+        categories: undefined,
+        colorGrouping: undefined,
+        colors: undefined,
+        customAttributes: undefined,
+        description: 'Modern Sneakers',
+        groupedEntries: undefined,
+        grouping: undefined,
+        groupingProperties: undefined,
+        id: 11766695,
+        images: undefined,
+        labels: undefined,
+        merchant: undefined,
+        name: '251 sneakers',
+        price: undefined,
+        prices: undefined,
+        sizes: undefined,
+        slug: 'string',
+        tag: {
+          id: undefined,
+          name: undefined,
+        },
+        variants: undefined,
+      },
+    },
+    sharedWishlists: {
+      [mockSharedWishlistId]: {
+        dateCreated: '2022-11-24T15:14:43.319Z',
+        description: 'string',
+        hasMissingItems: false,
+        id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+        items: [mockSharedWishlistItemId],
+        name: 'string',
+      },
+    },
+    sharedWishlistsItems: {
+      [mockSharedWishlistItemId]: {
+        attributes: undefined,
+        dateCreated: 1669302883319,
+        id: 481426747,
+        isCustomizable: false,
+        isExclusive: false,
+        price: undefined,
+        product: 11766695,
+        quantity: 2,
+        size: {},
+      },
+    },
+  },
+};
+
+export const mockSharedWishlistState = {
+  sharedWishlist: {
+    error: null,
+    isLoading: false,
+    result: mockSharedWishlistId,
+  },
+  entities: {
+    sharedWishlists: {
+      [mockSharedWishlistId]: {
+        ...mockSharedWishlistsResponse,
+        items: [mockSharedWishlistItemId, 102],
+      },
+    },
+    sharedWishlistItems: {
+      [mockSharedWishlistItemId]: {
+        ...mockSharedWishlistItemEntity,
+        dateCreated: 1669302883319,
+        product: mockProductId,
+        merchant: 123,
+        size: {},
+        price: {
+          formatted: {
+            includingTaxes: '$129.74',
+            includingTaxesWithoutDiscount: '$129.74',
+          },
+          includingTaxes: 129.7446,
+          includingTaxesWithoutDiscount: 129.7446,
+          isFormatted: true,
+          taxes: {
+            rate: undefined,
+            amount: undefined,
+            type: undefined,
+          },
+        },
+      },
+      102: {
+        ...mockSharedWishlistItemEntity,
+        dateCreated: 1669302883319,
+        id: 102,
+        product: 1002,
+        quantity: 2,
+        merchant: 123,
+        size: {},
+        price: {
+          formatted: {
+            includingTaxes: '$129.74',
+            includingTaxesWithoutDiscount: '$129.74',
+          },
+          includingTaxes: 129.7446,
+          includingTaxesWithoutDiscount: 129.7446,
+          isFormatted: true,
+          taxes: {
+            rate: undefined,
+            amount: undefined,
+            type: undefined,
+          },
+        },
+      },
+    },
+    products: {
+      [mockProductId]: {
+        DEPRECATED_images: undefined,
+        brand: 12579,
+        categories: undefined,
+        colorGrouping: undefined,
+        colors: undefined,
+        customAttributes: undefined,
+        description: 'Classic Sneakers',
+        groupedEntries: undefined,
+        grouping: undefined,
+        groupingProperties: undefined,
+        id: 11766695,
+        images: undefined,
+        labels: undefined,
+        merchant: undefined,
+        name: '505 shoes',
+        price: undefined,
+        prices: undefined,
+        sizes: undefined,
+        slug: 'string',
+        tag: {
+          id: undefined,
+          name: undefined,
+        },
+        variants: undefined,
+      },
+    },
+    brands: {
+      2450: {
+        description:
+          'Demna Gvasalia brings Balenciaga back to its creative roots.',
+        id: 2450,
+        name: 'Balenciaga',
+        priceType: 0,
+        slug: 'rockstud-sling-back-flats-12854475',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Description

- Added shared whislists client endpoints
- Added shared whislists redux
- Added shared wishlist middleware to update the snapshot of a shared wishlist when a wishlist item is updated, added or deleted.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
