### PR TITLE
fix(redux): exchanges result reducer

### DIFF
--- a/packages/redux/src/exchanges/__tests__/reducer.test.ts
+++ b/packages/redux/src/exchanges/__tests__/reducer.test.ts
@@ -148,6 +148,38 @@ describe('exchanges reducer', () => {
     });
   });
 
+  describe('result() reducer', () => {
+    it('should return the initial state', () => {
+      const state = reducer(undefined, randomAction).result;
+
+      expect(state).toBe(initialState.result);
+    });
+
+    it.each([
+      actionTypes.CREATE_EXCHANGE_SUCCESS,
+      actionTypes.FETCH_EXCHANGE_SUCCESS,
+    ])('should handle %s action type', actionType => {
+      const expectedResult = mockState.exchanges.result;
+      const state = {
+        ...initialState,
+        isLoading: true,
+      };
+
+      expect(
+        reducer(state, {
+          payload: expectedResult,
+          type: actionType,
+        }).result,
+      ).toBe(expectedResult);
+    });
+
+    it('should handle other actions by returning the previous state', () => {
+      const state = mockState?.exchanges;
+
+      expect(reducer(state, randomAction).result).toBe(state.result);
+    });
+  });
+
   describe('exchangeFilter() reducer', () => {
     it('should return the initial state', () => {
       const state = reducer(undefined, randomAction).exchangeFilter;

--- a/packages/redux/src/exchanges/reducer.ts
+++ b/packages/redux/src/exchanges/reducer.ts
@@ -52,7 +52,7 @@ const result = (state = INITIAL_STATE.result, action: AnyAction) => {
   switch (action.type) {
     case actionTypes.CREATE_EXCHANGE_SUCCESS:
     case actionTypes.FETCH_EXCHANGE_SUCCESS:
-      return action.payload.result;
+      return action.payload;
     default:
       return state;
   }


### PR DESCRIPTION
## Description

This fixes the exchanges result reducer by changing the return from action.payload.result to action.payload.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
