### PR TITLE
fix(redux|client): add promocodes prop in bag types

### DIFF
--- a/packages/client/src/bags/types/bag.types.ts
+++ b/packages/client/src/bags/types/bag.types.ts
@@ -30,4 +30,5 @@ export type Bag = {
   '@controls'?: {
     [key: string]: HypermediaLink;
   };
+  promocodes: string[];
 };

--- a/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
@@ -85,6 +85,7 @@ describe('useBag', () => {
           formattedTotalProductPromotionDiscount: '$0',
         },
         count: 7,
+        promocodes: ['code-1'],
         isEmpty: false,
         items: [
           {

--- a/packages/redux/src/bags/actions/__tests__/__snapshots__/addBagItem.test.ts.snap
+++ b/packages/redux/src/bags/actions/__tests__/__snapshots__/addBagItem.test.ts.snap
@@ -291,6 +291,9 @@ Object {
       "items": Array [
         134,
       ],
+      "promocodes": Array [
+        "code-1",
+      ],
     },
   },
   "type": "@farfetch/blackout-redux/ADD_BAG_ITEM_SUCCESS",
@@ -590,6 +593,9 @@ Object {
       "id": "7894746",
       "items": Array [
         134,
+      ],
+      "promocodes": Array [
+        "code-1",
       ],
     },
   },

--- a/packages/redux/src/bags/actions/__tests__/__snapshots__/fetchBag.test.ts.snap
+++ b/packages/redux/src/bags/actions/__tests__/__snapshots__/fetchBag.test.ts.snap
@@ -283,6 +283,9 @@ Object {
       "items": Array [
         134,
       ],
+      "promocodes": Array [
+        "code-1",
+      ],
     },
   },
   "type": "@farfetch/blackout-redux/FETCH_BAG_SUCCESS",
@@ -571,6 +574,9 @@ Object {
       "id": "7894746",
       "items": Array [
         134,
+      ],
+      "promocodes": Array [
+        "code-1",
       ],
     },
   },

--- a/packages/redux/src/bags/actions/__tests__/__snapshots__/removeBagItem.test.ts.snap
+++ b/packages/redux/src/bags/actions/__tests__/__snapshots__/removeBagItem.test.ts.snap
@@ -287,6 +287,9 @@ Object {
       "items": Array [
         134,
       ],
+      "promocodes": Array [
+        "code-1",
+      ],
     },
   },
   "type": "@farfetch/blackout-redux/REMOVE_BAG_ITEM_SUCCESS",
@@ -582,6 +585,9 @@ Object {
       "id": "7894746",
       "items": Array [
         134,
+      ],
+      "promocodes": Array [
+        "code-1",
       ],
     },
   },

--- a/packages/redux/src/bags/actions/__tests__/__snapshots__/updateBagItem.test.ts.snap
+++ b/packages/redux/src/bags/actions/__tests__/__snapshots__/updateBagItem.test.ts.snap
@@ -292,6 +292,9 @@ Object {
       "items": Array [
         134,
       ],
+      "promocodes": Array [
+        "code-1",
+      ],
     },
   },
   "type": "@farfetch/blackout-redux/UPDATE_BAG_ITEM_SUCCESS",
@@ -592,6 +595,9 @@ Object {
       "id": "7894746",
       "items": Array [
         134,
+      ],
+      "promocodes": Array [
+        "code-1",
       ],
     },
   },

--- a/tests/__fixtures__/bags/bag.fixtures.mts
+++ b/tests/__fixtures__/bags/bag.fixtures.mts
@@ -188,6 +188,7 @@ export const mockState = {
       count: 7,
       items: [mockBagItemId, 101, 102, 103, 104],
       hadUnavailableItems: false,
+      promocodes: ['code-1'],
       '@controls': {
         BagGet_operation: {
           href: `/v1/bags/${mockBagId}/operations/${mockBagOperationId}`,
@@ -461,6 +462,7 @@ export const mockResponse = {
       href: `/v1/bags/${mockBagId}/operations/${mockBagOperationId}`,
     },
   },
+  promocodes: ['code-1'],
 };
 
 export const mockNormalizedPayload = {


### PR DESCRIPTION
## Description

- Added `promocodes` prop in bag client types.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
