### PR TITLE
fix(core): add missing index file in shared wishlists redux

### DIFF
--- a/packages/core/src/sharedWishlists/redux/index.js
+++ b/packages/core/src/sharedWishlists/redux/index.js
@@ -1,0 +1,10 @@
+import * as actionTypes from './actionTypes';
+import * as middlewares from './middlewares';
+import reducer, { entitiesMapper } from './reducer';
+
+export * from './actions';
+export * from './selectors';
+
+export { actionTypes, middlewares, entitiesMapper };
+
+export default reducer;

--- a/packages/core/src/sharedWishlists/redux/reducer.js
+++ b/packages/core/src/sharedWishlists/redux/reducer.js
@@ -4,7 +4,7 @@ import { LOGOUT_SUCCESS } from '../../authentication/redux/actionTypes';
 
 const INITIAL_STATE = {
   error: null,
-  id: null,
+  isLoading: false,
   result: null,
 };
 const result = (state = INITIAL_STATE.result, action = {}) => {


### PR DESCRIPTION
## Description

- Add an index missing file in shared wishlists redux.
- It also adjusts the initial state property from `id` to `isLoading`.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
