### PR TITLE
fix(client): add isExchangeAvailable to orderItem property

### DIFF
--- a/packages/client/src/orders/types/orderItem.types.ts
+++ b/packages/client/src/orders/types/orderItem.types.ts
@@ -44,6 +44,7 @@ export type OrderItem = {
   tags: string[];
   isExclusive?: boolean;
   isReturnAvailable: boolean;
+  isExchangeAvailable?: boolean;
   isPreOrder: boolean;
   preOrder?: {
     expectedFulfillmentDate?: {

--- a/tests/__fixtures__/orders/orders.fixtures.mts
+++ b/tests/__fixtures__/orders/orders.fixtures.mts
@@ -402,6 +402,7 @@ export const mockOrderItem = {
   orderItemStatus: OrderItemStatus.None,
   orderStatus: MerchantOrderStatus.CheckingStock,
   isReturnAvailable: false,
+  isExchangeAvailable: false,
   merchantOrderCode: merchantOrderCode,
   productSummary: {
     productId: '12091686',
@@ -590,6 +591,7 @@ export const mockOrderItem2 = {
   orderItemStatus: OrderItemStatus.None,
   orderStatus: MerchantOrderStatus.CheckingStock,
   isReturnAvailable: false,
+  isExchangeAvailable: false,
   merchantOrderCode: merchantOrderCode2,
   productSummary: {
     productId: '12511241',
@@ -753,6 +755,7 @@ export const mockOrderItem3 = {
   orderItemStatus: OrderItemStatus.None,
   orderStatus: MerchantOrderStatus.CheckingStock,
   isReturnAvailable: false,
+  isExchangeAvailable: false,
   merchantOrderCode: merchantOrderCode3,
   productSummary: {
     productId: '12092633',
@@ -1037,6 +1040,7 @@ export const mockOrderDetailsResponse2 = {
       },
       customAttributes: '',
       isReturnAvailable: false,
+      isExchangeAvailable: false,
       returnRestriction: 'BlockedByWorkflow',
       isCustomizable: false,
       isExclusive: false,
@@ -2167,6 +2171,7 @@ export const getExpectedOrderDetailsNormalizedPayload = (
           orderItemStatus: OrderItemStatus.None,
           orderStatus: MerchantOrderStatus.CheckingStock,
           isReturnAvailable: false,
+          isExchangeAvailable: false,
           merchantOrderCode: merchantOrderCode,
           productSummary: {
             productId: '12091686',
@@ -2290,6 +2295,7 @@ export const getExpectedOrderDetailsNormalizedPayload = (
           orderItemStatus: OrderItemStatus.None,
           orderStatus: MerchantOrderStatus.CheckingStock,
           isReturnAvailable: false,
+          isExchangeAvailable: false,
           merchantOrderCode: merchantOrderCode2,
           productSummary: {
             productId: '12511241',
@@ -2397,6 +2403,7 @@ export const getExpectedOrderDetailsNormalizedPayload = (
           orderItemStatus: OrderItemStatus.None,
           orderStatus: MerchantOrderStatus.CheckingStock,
           isReturnAvailable: false,
+          isExchangeAvailable: false,
           merchantOrderCode: merchantOrderCode3,
           productSummary: {
             productId: '12092633',
@@ -2836,6 +2843,7 @@ export const expectedGuestOrdersNormalizedPayload = {
         orderItemStatus: 'None',
         orderStatus: 'CheckingStock',
         isReturnAvailable: false,
+        isExchangeAvailable: false,
         merchantOrderCode: merchantOrderCode,
         productSummary: {
           productId: '12091686',
@@ -2973,6 +2981,7 @@ export const expectedGuestOrdersNormalizedPayload = {
         orderItemStatus: 'None',
         orderStatus: 'CheckingStock',
         isReturnAvailable: false,
+        isExchangeAvailable: false,
         merchantOrderCode: merchantOrderCode2,
         productSummary: {
           productId: '12511241',
@@ -3092,6 +3101,7 @@ export const expectedGuestOrdersNormalizedPayload = {
         orderItemStatus: 'None',
         orderStatus: 'CheckingStock',
         isReturnAvailable: false,
+        isExchangeAvailable: false,
         merchantOrderCode: merchantOrderCode3,
         productSummary: {
           productId: '12511241',
@@ -3424,6 +3434,7 @@ export const expectedGuestOrdersNormalizedPayload = {
           trackingCodes: [],
         },
         isReturnAvailable: false,
+        isExchangeAvailable: false,
         returnRestriction: 'BlockedByWorkflow',
         isCustomizable: false,
         isExclusive: false,


### PR DESCRIPTION
## Description

This adds the missing isExchangeAvailable to the orderItem property
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
