### PR TITLE
fix: fix `useBag` wrong call to `handleFullUpdate`

### DIFF
--- a/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
+++ b/packages/react/src/bags/hooks/__tests__/useBag.test.tsx
@@ -24,6 +24,7 @@ import {
 import {
   mockBrandId,
   mockMerchantId,
+  mockMerchantId2,
   mockProductId,
   mockSizeScaleId,
 } from 'tests/__fixtures__/products/ids.fixtures.mjs';
@@ -773,7 +774,7 @@ describe('useBag', () => {
           {
             authCode: undefined,
             customAttributes: '',
-            merchantId: 545,
+            merchantId: mockMerchantId2,
             productAggregatorId: undefined,
             productId: mockProductId,
             quantity: 3,
@@ -824,7 +825,7 @@ describe('useBag', () => {
           {
             authCode: undefined,
             customAttributes: '',
-            merchantId: 545,
+            merchantId: mockMerchantId2,
             productId: mockProductId,
             productAggregatorId: undefined,
             quantity: 3,
@@ -851,7 +852,7 @@ describe('useBag', () => {
 
         await updateItem(
           mockBagItemId,
-          { sizeId: 2, quantity: 2 },
+          { sizeId: 2, quantity: 10 },
           metadata,
           myConfig,
         );
@@ -867,6 +868,25 @@ describe('useBag', () => {
             merchantId: mockMerchantId,
             productId: mockProductId,
             quantity: 2,
+            scale: mockSizeScaleId,
+            size: 2,
+            metadata: externalMetadata,
+          },
+          undefined,
+          metadata,
+          myConfig,
+        );
+
+        expect(addBagItem).toHaveBeenCalledTimes(1);
+        expect(addBagItem).toHaveBeenCalledWith(
+          mockState.entities.user.bagId,
+          {
+            authCode: undefined,
+            customAttributes: '',
+            productAggregatorId: undefined,
+            merchantId: mockMerchantId2,
+            productId: mockProductId,
+            quantity: 8,
             scale: mockSizeScaleId,
             size: 2,
             metadata: externalMetadata,

--- a/packages/react/src/bags/hooks/useBag.ts
+++ b/packages/react/src/bags/hooks/useBag.ts
@@ -685,8 +685,8 @@ const useBag = (options: UseBagOptions = {}) => {
       if (newQuantity !== bagItem.quantity && newSizeId !== bagItem.size.id) {
         return handleFullUpdate(
           bagItem,
-          newQuantity,
           newSizeId,
+          newQuantity,
           metadata,
           config,
         );

--- a/packages/react/src/returns/hooks/__tests__/useUserReturns.test.ts
+++ b/packages/react/src/returns/hooks/__tests__/useUserReturns.test.ts
@@ -286,7 +286,7 @@ describe('useUserReturns', () => {
         } = renderHook(
           () =>
             useUserReturns({
-              enableAutoFetch: true,
+              enableAutoFetch: false,
               fetchQuery: mockFetchQuery,
               fetchConfig: mockFetchConfig,
               useLegacyGuestFlow: true,
@@ -300,7 +300,7 @@ describe('useUserReturns', () => {
           },
         );
 
-        return expect(() => fetch()).rejects.toThrow(
+        return expect(fetch()).rejects.toThrow(
           'The user must be a guest to use the legacy flow',
         );
       });
@@ -315,7 +315,7 @@ describe('useUserReturns', () => {
         } = renderHook(
           () =>
             useUserReturns({
-              enableAutoFetch: true,
+              enableAutoFetch: false,
               fetchQuery: { ...mockFetchQuery, orderId: undefined },
               fetchConfig: mockFetchConfig,
               useLegacyGuestFlow: true,
@@ -343,7 +343,7 @@ describe('useUserReturns', () => {
         } = renderHook(
           () =>
             useUserReturns({
-              enableAutoFetch: true,
+              enableAutoFetch: false,
               fetchQuery: { ...mockFetchQuery, orderId: undefined },
               fetchConfig: mockFetchConfig,
               useLegacyGuestFlow: true,
@@ -372,7 +372,7 @@ describe('useUserReturns', () => {
         } = renderHook(
           () =>
             useUserReturns({
-              enableAutoFetch: true,
+              enableAutoFetch: false,
               fetchQuery: mockFetchQuery,
               fetchConfig: mockFetchConfig,
               useLegacyGuestFlow: true,

--- a/tests/__fixtures__/products/ids.fixtures.mts
+++ b/tests/__fixtures__/products/ids.fixtures.mts
@@ -1,5 +1,6 @@
 export const mockBrandId = 6326412;
 export const mockMerchantId = 10973;
+export const mockMerchantId2 = 545;
 export const mockProductId = 11766695;
 export const mockProductTypeToExclude = 3;
 export const mockSetId = 1050;

--- a/tests/__fixtures__/products/productSizes.fixtures.mts
+++ b/tests/__fixtures__/products/productSizes.fixtures.mts
@@ -1,5 +1,6 @@
 import {
   mockMerchantId,
+  mockMerchantId2,
   mockProductId,
   mockSizeScaleId,
 } from './ids.fixtures.mjs';
@@ -86,7 +87,7 @@ export const mockProductSizesAdapted = [
         purchaseChannel: null,
       },
       {
-        merchantId: 545,
+        merchantId: mockMerchantId2,
         quantity: 20,
         barcodes: [],
         price: {
@@ -158,7 +159,7 @@ export const mockProductSizesAdapted = [
     scaleDescription: 'italian',
     stock: [
       {
-        merchantId: 545,
+        merchantId: mockMerchantId2,
         quantity: 0,
         barcodes: [],
         price: {


### PR DESCRIPTION
## Description

This fixes the call to `handleFullUpdate` method in `useBag` to use the
correct parameters and changed the unit test to make sure this bug gets
caught.

 Also, changed `enableAutoFetch` value to false in some tests from
`useUserReturns` tests to remove a warning of PromiseUnhandledException.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
