### PR TITLE
feat: add postPaymentSession client

### DIFF
--- a/packages/client/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/client/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1188,6 +1188,7 @@ Object {
   "postPasswordReset": [Function],
   "postPaymentIntentCharge": [Function],
   "postPaymentIntentInstrument": [Function],
+  "postPaymentSession": [Function],
   "postPhoneNumberValidation": [Function],
   "postPhoneToken": [Function],
   "postPhoneTokenValidation": [Function],

--- a/packages/client/src/payments/__fixtures__/postPaymentSession.fixtures.ts
+++ b/packages/client/src/payments/__fixtures__/postPaymentSession.fixtures.ts
@@ -1,0 +1,17 @@
+import { rest, type RestHandler } from 'msw';
+import type { PaymentSession } from '../index.js';
+
+const path = '/api/payment/v1/paymentsession';
+
+const fixtures = {
+  success: (response: PaymentSession): RestHandler =>
+    rest.post(path, (_req, res, ctx) =>
+      res(ctx.status(201), ctx.json(response)),
+    ),
+  failure: (): RestHandler =>
+    rest.post(path, (_req, res, ctx) =>
+      res(ctx.status(404), ctx.json({ message: 'stub error' })),
+    ),
+};
+
+export default fixtures;

--- a/packages/client/src/payments/__tests__/__snapshots__/postPaymentSession.test.ts.snap
+++ b/packages/client/src/payments/__tests__/__snapshots__/postPaymentSession.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`postPaymentSession should receive a client request error 1`] = `
+Object {
+  "code": "-1",
+  "message": "stub error",
+  "name": "AxiosError",
+  "status": 404,
+  "transportLayerErrorCode": "ERR_BAD_REQUEST",
+}
+`;

--- a/packages/client/src/payments/__tests__/postPaymentSession.test.ts
+++ b/packages/client/src/payments/__tests__/postPaymentSession.test.ts
@@ -1,0 +1,37 @@
+import { mockPaymentSession } from 'tests/__fixtures__/payments/index.mjs';
+import client from '../../helpers/client/index.js';
+import fixtures from '../__fixtures__/postPaymentSession.fixtures.js';
+import mswServer from '../../../tests/mswServer.js';
+import postPaymentSession from '../postPaymentSession.js';
+import type { PostPaymentSessionData } from '../index.js';
+
+describe('postPaymentSession', () => {
+  const expectedConfig = undefined;
+
+  const data: PostPaymentSessionData = {
+    paymentIntentId: '25cfbb10-f4d1-4684-8e52-45e4d3b001d3',
+  };
+
+  const spy = jest.spyOn(client, 'post');
+  const urlToBeCalled = '/payment/v1/paymentsession';
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should handle a client request successfully', async () => {
+    mswServer.use(fixtures.success(mockPaymentSession));
+
+    await expect(postPaymentSession(data)).resolves.toMatchObject(
+      mockPaymentSession,
+    );
+
+    expect(spy).toHaveBeenCalledWith(urlToBeCalled, data, expectedConfig);
+  });
+
+  it('should receive a client request error', async () => {
+    mswServer.use(fixtures.failure());
+
+    await expect(postPaymentSession(data)).rejects.toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith(urlToBeCalled, data, expectedConfig);
+  });
+});

--- a/packages/client/src/payments/index.ts
+++ b/packages/client/src/payments/index.ts
@@ -14,6 +14,7 @@ export { default as putPaymentIntentInstrument } from './putPaymentIntentInstrum
 export { default as getPaymentIntent } from './getPaymentIntent.js';
 export { default as getPaymentIntentCharge } from './getPaymentIntentCharge.js';
 export { default as postPaymentIntentCharge } from './postPaymentIntentCharge.js';
+export { default as postPaymentSession } from './postPaymentSession.js';
 export { default as getUserCreditBalance } from './getUserCreditBalance.js';
 
 export * from './types/index.js';

--- a/packages/client/src/payments/postPaymentSession.ts
+++ b/packages/client/src/payments/postPaymentSession.ts
@@ -1,0 +1,21 @@
+import { adaptError } from '../helpers/client/formatError.js';
+import client from '../helpers/client/index.js';
+import type { PostPaymentSession } from './types/index.js';
+
+/**
+ * Method responsible for creating a payment session.
+ *
+ * @param data            - Request data.
+ * @param config          - Custom configurations to send to the client instance (axios).
+ *
+ * @returns Promise that will resolve when the call to the endpoint finishes.
+ */
+const postPaymentSession: PostPaymentSession = (data, config) =>
+  client
+    .post('/payment/v1/paymentsession', data, config)
+    .then(response => response.data)
+    .catch(error => {
+      throw adaptError(error);
+    });
+
+export default postPaymentSession;

--- a/packages/client/src/payments/types/index.ts
+++ b/packages/client/src/payments/types/index.ts
@@ -23,4 +23,5 @@ export * from './postPaymentIntentCharge.types.js';
 export * from './getUserCreditBalance.types.js';
 export * from './getGiftCardBalance.types.js';
 export * from './postPaymentIntentInstrument.types.js';
+export * from './postPaymentSession.types.js';
 export * from './putPaymentIntentInstrument.types.js';

--- a/packages/client/src/payments/types/paymentInstrument.types.ts
+++ b/packages/client/src/payments/types/paymentInstrument.types.ts
@@ -2,7 +2,6 @@ import type {
   Amounts,
   Payer,
   PaymentInstrumentData,
-  PaymentMethod,
   ShopperInteraction,
 } from './index.js';
 
@@ -17,7 +16,7 @@ export enum PaymentInstrumentStatus {
 
 export type PaymentInstrument = {
   id: string;
-  method: PaymentMethod;
+  method: string;
   option: string;
   amounts: Amounts[];
   status: PaymentInstrumentStatus;

--- a/packages/client/src/payments/types/postPaymentIntentInstrument.types.ts
+++ b/packages/client/src/payments/types/postPaymentIntentInstrument.types.ts
@@ -42,7 +42,7 @@ export enum PaymentMethod {
 }
 
 export type PostPaymentIntentInstrumentData = {
-  method: PaymentMethod;
+  method: string;
   option?: string;
   token?: string;
   createToken?: boolean;

--- a/packages/client/src/payments/types/postPaymentSession.types.ts
+++ b/packages/client/src/payments/types/postPaymentSession.types.ts
@@ -1,0 +1,27 @@
+import type { CheckoutAddress, Config } from '../../types/index.js';
+import type { PaymentIntent } from './paymentIntent.types.js';
+
+export type PostPaymentSessionForCheckoutData = {
+  paymentIntentId: PaymentIntent['id'];
+};
+
+export type PostPaymentSessionForCardTokenData = {
+  shippingAddresses: CheckoutAddress[];
+  billingAddress: CheckoutAddress;
+  redirectUrl: string;
+};
+
+export type PostPaymentSessionData =
+  | PostPaymentSessionForCheckoutData
+  | PostPaymentSessionForCardTokenData;
+
+export type PaymentSession = {
+  id: string;
+  paymentUrl: string;
+  expiresIn: number;
+};
+
+export type PostPaymentSession = (
+  data: PostPaymentSessionData,
+  config?: Config,
+) => Promise<PaymentSession>;

--- a/tests/__fixtures__/payments/payments.fixtures.mts
+++ b/tests/__fixtures__/payments/payments.fixtures.mts
@@ -8,6 +8,7 @@ import {
   PaymentIntentLineItemType,
   PaymentIntentStatus,
   PaymentMethod,
+  type PaymentSession,
   type PaymentToken,
   ShopperInteraction,
 } from '@farfetch/blackout-client';
@@ -587,6 +588,13 @@ export const mockPaymentsResponse = {
 export const mockPaymentIntentInstrumentResponse = {
   data: {},
   headers: { location: 'https://somelocation.com' },
+};
+
+export const mockPaymentSession: PaymentSession = {
+  id: 'a6cf8be4-0941-42de-8f23-c231fa081c37',
+  paymentUrl:
+    'http://payment-gateway.com?sessionId=9abc5129-0d4f-4693-bce8-647b1cb4c153',
+  expiresIn: 90000,
 };
 
 export const mockInitialState = {


### PR DESCRIPTION
## Description

This adds the `postPaymentSession` client and changes the types of the `method` property of both `PaymentInstrument` and
`PostPaymentIntentInstrumentData` types to `string` to give more flexibility.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
