### PR TITLE
Feat add analytics versions to omnitracking for `v1`

### DIFF
--- a/packages/core/src/analytics/__fixtures__/commonData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/commonData.fixtures.js
@@ -12,4 +12,5 @@ export const expectedCommonParameters = {
   clientTimestamp: new Date(mockCommonData.timestamp).toJSON(),
   uuid: mockAnalyticsUniqueEventId,
   uniqueViewId: null,
+  analyticsPackageVersion: '0.1.0',
 };

--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -233,6 +233,7 @@ export const expectedTrackPayload = {
   event: 'PageAction',
   parameters: {
     ...expectedCommonParameters,
+    analyticsPackageVersion: '0.1.0',
   },
 };
 

--- a/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/Omnitracking.js
@@ -151,7 +151,7 @@ class Omnitracking extends Integration {
     const isPageOrScreenEvent =
       type === analyticsTrackTypes.PAGE || type === analyticsTrackTypes.SCREEN;
     const precalculatedParameters = {};
-    const { culture, currencyCode } = data.context;
+    const { culture, currencyCode, library } = data.context;
 
     // First we check if we need to change the values
     // of the uniqueViewId and previousUniqueViewId
@@ -216,6 +216,8 @@ class Omnitracking extends Integration {
 
     precalculatedParameters.uniqueViewId = this.currentUniqueViewId;
     precalculatedParameters.viewCurrency = currencyCode;
+
+    precalculatedParameters.analyticsPackageVersion = library?.version;
 
     return precalculatedParameters;
   }


### PR DESCRIPTION
## Description

- Add analytics versions field to omnitracking output payload.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

Note.

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
