### PR TITLE
feat(analytics): add analytics versions to omnitracking for `main`

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
+++ b/packages/analytics/src/integrations/Omnitracking/Omnitracking.ts
@@ -181,7 +181,7 @@ class Omnitracking extends Integration<OmnitrackingOptions> {
     const precalculatedParameters: OmnitrackingPreCalculatedEventParameters =
       {};
 
-    const { culture, currencyCode } = data.context;
+    const { culture, currencyCode, library } = data.context;
 
     // First we check if we need to change the values
     // of the uniqueViewId and previousUniqueViewId
@@ -256,6 +256,7 @@ class Omnitracking extends Integration<OmnitrackingOptions> {
 
     precalculatedParameters.uniqueViewId = this.currentUniqueViewId;
     precalculatedParameters.viewCurrency = currencyCode;
+    precalculatedParameters.analyticsPackageVersion = library?.version;
 
     return precalculatedParameters;
   }

--- a/packages/analytics/src/integrations/Omnitracking/__fixtures__/expectedTrackPayload.fixtures.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__fixtures__/expectedTrackPayload.fixtures.ts
@@ -15,6 +15,7 @@ const fixtures = {
     clientTimestamp: new Date(trackMockData.timestamp).toJSON(),
     uuid: mockedUuid,
     uniqueViewId: mocked_view_uid,
+    analyticsPackageVersion: '0.1.0',
   },
 };
 

--- a/packages/analytics/src/integrations/Omnitracking/types/Omnitracking.types.ts
+++ b/packages/analytics/src/integrations/Omnitracking/types/Omnitracking.types.ts
@@ -40,8 +40,14 @@ export type OmnitrackingCommonEventParameters = {
   [K in (typeof commonTrackAndPageParams)[number]]?: unknown;
 };
 
+type OmnitrackingNonListedParameters = {
+  analyticsPackageVersion?: string;
+};
+
 export type OmnitrackingPreCalculatedEventParameters =
-  OmnitrackingTrackEventParameters & OmnitrackingPageEventParameters;
+  OmnitrackingTrackEventParameters &
+    OmnitrackingPageEventParameters &
+    OmnitrackingNonListedParameters;
 
 export interface OmnitrackingRequestPayload<
   T extends PageViewEvents | PageActionEvents,


### PR DESCRIPTION
## Description

- Add analytics versions field to omnitracking output payload.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
