### PR TITLE
feat(react) useUserContact and useUserContacts hooks

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
@@ -349,6 +349,7 @@ Object {
   "useUser": [Function],
   "useUserAddress": [Function],
   "useUserAddresses": [Function],
+  "useUserContacts": [Function],
   "useUserOrders": [Function],
   "useUserProfile": [Function],
   "useUserReturns": [Function],

--- a/packages/react/src/users/hooks/__tests__/useUserContact.test.ts
+++ b/packages/react/src/users/hooks/__tests__/useUserContact.test.ts
@@ -1,0 +1,558 @@
+import { cleanup, renderHook } from '@testing-library/react';
+import {
+  createUserContact,
+  fetchUserContact,
+  removeUserContact,
+  updateUserContact,
+} from '@farfetch/blackout-redux';
+import {
+  expectedGetContactsNormalized,
+  mockAuthenticatedUserEntities,
+  mockGetContactResponse,
+  mockUserInitialState,
+} from 'tests/__fixtures__/users/index.mjs';
+import { merge } from 'lodash-es';
+import {
+  type PatchUserContactOperation,
+  toBlackoutError,
+} from '@farfetch/blackout-client';
+import { withStore } from '../../../../tests/helpers/index.js';
+import useUserContact from '../useUserContact.js';
+
+jest.mock('@farfetch/blackout-redux', () => {
+  const original = jest.requireActual('@farfetch/blackout-redux');
+
+  return {
+    ...original,
+    fetchUserContact: jest.fn(() => () => Promise.resolve()),
+    createUserContact: jest.fn(() => () => Promise.resolve()),
+    removeUserContact: jest.fn(() => () => Promise.resolve()),
+    updateUserContact: jest.fn(() => () => Promise.resolve()),
+  };
+});
+
+const mockInitialState = {
+  entities: { ...mockAuthenticatedUserEntities },
+  users: { ...mockUserInitialState, id: mockAuthenticatedUserEntities.user.id },
+};
+
+const mockWithDataState = {
+  entities: {
+    ...mockInitialState.entities,
+    ...expectedGetContactsNormalized.entities,
+  },
+  users: {
+    ...mockInitialState.users,
+    contacts: {
+      ...mockInitialState.users.contacts,
+      result: expectedGetContactsNormalized.result,
+      isLoading: false,
+      error: null,
+    },
+  },
+};
+
+const mockErrorState = {
+  ...mockInitialState,
+  users: {
+    ...mockInitialState.users,
+    contacts: {
+      ...mockInitialState.users.contacts,
+      result: null,
+      isLoading: false,
+      error: toBlackoutError(new Error('dummy error')),
+    },
+  },
+};
+
+const mockLoadingState = {
+  ...mockInitialState,
+  users: {
+    ...mockInitialState.users,
+    contacts: {
+      ...mockInitialState.users.contacts,
+      result: null,
+      isLoading: true,
+      error: null,
+    },
+  },
+};
+
+const defaultReturn = {
+  data: undefined,
+  isLoading: false,
+  isFetched: false,
+  error: null,
+  actions: {
+    fetch: expect.any(Function),
+    create: expect.any(Function),
+    update: expect.any(Function),
+    remove: expect.any(Function),
+  },
+};
+
+describe('useUserContact', () => {
+  beforeEach(jest.clearAllMocks);
+
+  afterEach(cleanup);
+
+  it('should return correctly with initial state', () => {
+    const {
+      result: { current },
+    } = renderHook(() => useUserContact(mockGetContactResponse?.id), {
+      wrapper: withStore(mockInitialState),
+    });
+
+    expect(current).toStrictEqual(defaultReturn);
+  });
+
+  it('should return correctly when the contact is fetched', () => {
+    const {
+      result: { current },
+    } = renderHook(() => useUserContact(mockGetContactResponse?.id), {
+      wrapper: withStore(mockWithDataState),
+    });
+
+    expect(current).toStrictEqual({
+      ...defaultReturn,
+      data: expectedGetContactsNormalized.entities.contacts[
+        mockGetContactResponse?.id
+      ],
+      isFetched: true,
+    });
+  });
+
+  it('should return correctly when there is an error', () => {
+    const {
+      result: { current },
+    } = renderHook(() => useUserContact(mockGetContactResponse?.id), {
+      wrapper: withStore(mockErrorState),
+    });
+
+    expect(current).toStrictEqual({
+      ...defaultReturn,
+      isFetched: true,
+      error: mockErrorState.users.contacts.error,
+    });
+  });
+
+  it('should return correctly when it is loading', () => {
+    const {
+      result: { current },
+    } = renderHook(() => useUserContact(mockGetContactResponse?.id), {
+      wrapper: withStore(mockLoadingState),
+    });
+
+    expect(current).toStrictEqual({
+      ...defaultReturn,
+      isLoading: true,
+    });
+  });
+
+  describe('options', () => {
+    describe('enableAutoFetch', () => {
+      it('should call fetch data if it is true', () => {
+        renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: true,
+            }),
+          {
+            wrapper: withStore(mockInitialState),
+          },
+        );
+
+        expect(fetchUserContact).toHaveBeenCalled();
+      });
+
+      it('should not fetch data if it is false', () => {
+        renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockInitialState),
+          },
+        );
+
+        expect(fetchUserContact).not.toHaveBeenCalled();
+      });
+
+      it('by default it should be set to true and should fetch data', () => {
+        renderHook(() => useUserContact(mockGetContactResponse?.id), {
+          wrapper: withStore(mockInitialState),
+        });
+
+        expect(fetchUserContact).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('actions', () => {
+    describe('fetch', () => {
+      it('should call `fetchUserContact` action if the user is authenticated', async () => {
+        const {
+          result: {
+            current: {
+              actions: { fetch },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockInitialState),
+          },
+        );
+
+        await fetch();
+
+        expect(fetchUserContact).toHaveBeenCalled();
+      });
+
+      it('should _NOT_ call `fetchUserContact` action if the user is not set', async () => {
+        const mockWithoutUserState = merge({}, mockInitialState);
+
+        // @ts-expect-error Cannot set user to null/undefined if it exists
+        mockWithoutUserState.entities.user = null;
+        // @ts-expect-error Cannot set user's id to null/undefined if it exists
+        mockWithoutUserState.users.id = null;
+
+        const {
+          result: {
+            current: {
+              actions: { fetch },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockWithoutUserState),
+          },
+        );
+
+        await expect(fetch()).rejects.toThrow('User is not authenticated');
+
+        expect(fetchUserContact).not.toHaveBeenCalled();
+      });
+
+      it('should _NOT_ call `fetchUserContact` action if the user is guest', async () => {
+        const mockWithGuestUserState = merge({}, mockInitialState);
+
+        mockWithGuestUserState.entities.user.isGuest = true;
+
+        const {
+          result: {
+            current: {
+              actions: { fetch },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockWithGuestUserState),
+          },
+        );
+
+        await expect(fetch()).rejects.toThrow('User is not authenticated');
+
+        expect(fetchUserContact).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('create', () => {
+      it('should call `createUserContact` action if the user is authenticated', async () => {
+        const {
+          result: {
+            current: {
+              actions: { create },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockInitialState),
+          },
+        );
+
+        await create(mockGetContactResponse);
+
+        expect(createUserContact).toHaveBeenCalledWith(
+          mockInitialState.entities.user.id,
+          mockGetContactResponse,
+          undefined,
+        );
+      });
+
+      it('should _NOT_ call `createUserContact` action if the user is not set', async () => {
+        const mockWithoutUserState = merge({}, mockInitialState);
+
+        // @ts-expect-error Cannot set user to null/undefined if it exists
+        mockWithoutUserState.entities.user = null;
+        // @ts-expect-error Cannot set user's id to null/undefined if it exists
+        mockWithoutUserState.users.id = null;
+
+        const {
+          result: {
+            current: {
+              actions: { create },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockWithoutUserState),
+          },
+        );
+
+        await expect(create(mockGetContactResponse)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(createUserContact).not.toHaveBeenCalled();
+      });
+
+      it('should _NOT_ call `createUserContact` action if the user is guest', async () => {
+        const mockWithGuestUserState = merge({}, mockInitialState);
+
+        mockWithGuestUserState.entities.user.isGuest = true;
+
+        const {
+          result: {
+            current: {
+              actions: { create },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockWithGuestUserState),
+          },
+        );
+
+        await expect(create(mockGetContactResponse)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(createUserContact).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('update', () => {
+      it('should call `updateUserContact` action if the user is authenticated', async () => {
+        const {
+          result: {
+            current: {
+              actions: { update },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockInitialState),
+          },
+        );
+
+        const data = [
+          {
+            op: 'replace',
+            path: '/description',
+            value: 'dead',
+          },
+        ] as PatchUserContactOperation[];
+
+        await update(mockGetContactResponse?.id, data);
+
+        expect(updateUserContact).toHaveBeenCalledWith(
+          mockInitialState.entities.user.id,
+          mockGetContactResponse?.id,
+          data,
+          undefined,
+        );
+      });
+
+      it('should _NOT_ call `updateUserContact` action if the user is not set', async () => {
+        const mockWithoutUserState = merge({}, mockInitialState);
+
+        // @ts-expect-error Cannot set user to null/undefined if it exists
+        mockWithoutUserState.entities.user = null;
+        // @ts-expect-error Cannot set user's id to null/undefined if it exists
+        mockWithoutUserState.users.id = null;
+
+        const {
+          result: {
+            current: {
+              actions: { update },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockWithoutUserState),
+          },
+        );
+
+        const data = [
+          {
+            op: 'replace',
+            path: '/description',
+            value: 'dead',
+          },
+        ] as PatchUserContactOperation[];
+
+        await expect(update(mockGetContactResponse?.id, data)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(updateUserContact).not.toHaveBeenCalled();
+      });
+
+      it('should _NOT_ call `updateUserContact` action if the user is guest', async () => {
+        const mockWithGuestUserState = merge({}, mockInitialState);
+
+        mockWithGuestUserState.entities.user.isGuest = true;
+
+        const {
+          result: {
+            current: {
+              actions: { update },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockWithGuestUserState),
+          },
+        );
+
+        const data = [
+          {
+            op: 'replace',
+            path: '/description',
+            value: 'dead',
+          },
+        ] as PatchUserContactOperation[];
+
+        await expect(update(mockGetContactResponse?.id, data)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(updateUserContact).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('remove', () => {
+      it('should call `removeUserContact` action if the user is authenticated', async () => {
+        const {
+          result: {
+            current: {
+              actions: { remove },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockInitialState),
+          },
+        );
+
+        await remove(mockGetContactResponse?.id);
+
+        expect(removeUserContact).toHaveBeenCalledWith(
+          mockInitialState.entities.user.id,
+          mockGetContactResponse?.id,
+          undefined,
+        );
+      });
+
+      it('should _NOT_ call `removeUserContact` action if the user is not set', async () => {
+        const mockWithoutUserState = merge({}, mockInitialState);
+
+        // @ts-expect-error Cannot set user to null/undefined if it exists
+        mockWithoutUserState.entities.user = null;
+        // @ts-expect-error Cannot set user's id to null/undefined if it exists
+        mockWithoutUserState.users.id = null;
+
+        const {
+          result: {
+            current: {
+              actions: { remove },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockWithoutUserState),
+          },
+        );
+
+        await expect(remove(mockGetContactResponse?.id)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(removeUserContact).not.toHaveBeenCalled();
+      });
+
+      it('should _NOT_ call `removeUserContact` action if the user is guest', async () => {
+        const mockWithGuestUserState = merge({}, mockInitialState);
+
+        mockWithGuestUserState.entities.user.isGuest = true;
+
+        const {
+          result: {
+            current: {
+              actions: { remove },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContact(mockGetContactResponse?.id, {
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockWithGuestUserState),
+          },
+        );
+
+        await expect(remove(mockGetContactResponse?.id)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(removeUserContact).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/react/src/users/hooks/__tests__/useUserContacts.test.ts
+++ b/packages/react/src/users/hooks/__tests__/useUserContacts.test.ts
@@ -1,0 +1,490 @@
+import { cleanup, renderHook } from '@testing-library/react';
+import {
+  createUserContact,
+  fetchUserContacts,
+  removeUserContact,
+  updateUserContact,
+} from '@farfetch/blackout-redux';
+import {
+  expectedGetContactsNormalized,
+  mockAuthenticatedUserEntities,
+  mockGetContactResponse,
+  mockUserInitialState,
+} from 'tests/__fixtures__/users/index.mjs';
+import { merge } from 'lodash-es';
+import {
+  type PatchUserContactOperation,
+  toBlackoutError,
+} from '@farfetch/blackout-client';
+import { withStore } from '../../../../tests/helpers/index.js';
+import useUserContacts from '../useUserContacts.js';
+
+jest.mock('@farfetch/blackout-redux', () => {
+  const original = jest.requireActual('@farfetch/blackout-redux');
+
+  return {
+    ...original,
+    fetchUserContacts: jest.fn(() => () => Promise.resolve()),
+    createUserContact: jest.fn(() => () => Promise.resolve()),
+    removeUserContact: jest.fn(() => () => Promise.resolve()),
+    updateUserContact: jest.fn(() => () => Promise.resolve()),
+  };
+});
+
+const mockInitialState = {
+  entities: { ...mockAuthenticatedUserEntities },
+  users: { ...mockUserInitialState, id: mockAuthenticatedUserEntities.user.id },
+};
+
+const mockWithDataState = {
+  entities: {
+    ...mockInitialState.entities,
+    ...expectedGetContactsNormalized.entities,
+  },
+  users: {
+    ...mockInitialState.users,
+    contacts: {
+      ...mockInitialState.users.contacts,
+      result: expectedGetContactsNormalized.result,
+      isLoading: false,
+      error: null,
+    },
+  },
+};
+
+const mockErrorState = {
+  ...mockInitialState,
+  users: {
+    ...mockInitialState.users,
+    contacts: {
+      ...mockInitialState.users.contacts,
+      result: null,
+      isLoading: false,
+      error: toBlackoutError(new Error('dummy error')),
+    },
+  },
+};
+
+const mockLoadingState = {
+  ...mockInitialState,
+  users: {
+    ...mockInitialState.users,
+    contacts: {
+      ...mockInitialState.users.contacts,
+      result: null,
+      isLoading: true,
+      error: null,
+    },
+  },
+};
+
+const defaultReturn = {
+  data: undefined,
+  isLoading: false,
+  isFetched: false,
+  error: null,
+  actions: {
+    fetch: expect.any(Function),
+    create: expect.any(Function),
+    update: expect.any(Function),
+    remove: expect.any(Function),
+  },
+};
+
+describe('useUserContacts', () => {
+  beforeEach(jest.clearAllMocks);
+
+  afterEach(cleanup);
+
+  it('should return correctly with initial state', () => {
+    const {
+      result: { current },
+    } = renderHook(() => useUserContacts(), {
+      wrapper: withStore(mockInitialState),
+    });
+
+    expect(current).toStrictEqual(defaultReturn);
+  });
+
+  it('should return correctly when the contacts are fetched', () => {
+    const {
+      result: { current },
+    } = renderHook(() => useUserContacts(), {
+      wrapper: withStore(mockWithDataState),
+    });
+
+    expect(current).toStrictEqual({
+      ...defaultReturn,
+      data: expectedGetContactsNormalized.entities.contacts,
+      isFetched: true,
+    });
+  });
+
+  it('should return correctly when there is an error', () => {
+    const {
+      result: { current },
+    } = renderHook(() => useUserContacts(), {
+      wrapper: withStore(mockErrorState),
+    });
+
+    expect(current).toStrictEqual({
+      ...defaultReturn,
+      isFetched: true,
+      error: mockErrorState.users.contacts.error,
+    });
+  });
+
+  it('should return correctly when it is loading', () => {
+    const {
+      result: { current },
+    } = renderHook(() => useUserContacts(), {
+      wrapper: withStore(mockLoadingState),
+    });
+
+    expect(current).toStrictEqual({
+      ...defaultReturn,
+      isLoading: true,
+    });
+  });
+
+  describe('options', () => {
+    describe('enableAutoFetch', () => {
+      it('should call fetch data if it is true', () => {
+        renderHook(() => useUserContacts({ enableAutoFetch: true }), {
+          wrapper: withStore(mockInitialState),
+        });
+
+        expect(fetchUserContacts).toHaveBeenCalled();
+      });
+
+      it('should not fetch data if it is false', () => {
+        renderHook(() => useUserContacts({ enableAutoFetch: false }), {
+          wrapper: withStore(mockInitialState),
+        });
+
+        expect(fetchUserContacts).not.toHaveBeenCalled();
+      });
+
+      it('by default it should be set to true and should fetch data', () => {
+        renderHook(() => useUserContacts(), {
+          wrapper: withStore(mockInitialState),
+        });
+
+        expect(fetchUserContacts).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('actions', () => {
+    describe('fetch', () => {
+      it('should call `fetchUserContacts` action if the user is authenticated', async () => {
+        const {
+          result: {
+            current: {
+              actions: { fetch },
+            },
+          },
+        } = renderHook(() => useUserContacts({ enableAutoFetch: false }), {
+          wrapper: withStore(mockInitialState),
+        });
+
+        await fetch();
+
+        expect(fetchUserContacts).toHaveBeenCalled();
+      });
+
+      it('should _NOT_ call `fetchUserContacts` action if the user is not set', async () => {
+        const mockWithoutUserState = merge({}, mockInitialState);
+
+        // @ts-expect-error Cannot set user to null/undefined if it exists
+        mockWithoutUserState.entities.user = null;
+        // @ts-expect-error Cannot set user's id to null/undefined if it exists
+        mockWithoutUserState.users.id = null;
+
+        const {
+          result: {
+            current: {
+              actions: { fetch },
+            },
+          },
+        } = renderHook(() => useUserContacts({ enableAutoFetch: false }), {
+          wrapper: withStore(mockWithoutUserState),
+        });
+
+        await expect(fetch()).rejects.toThrow('User is not authenticated');
+
+        expect(fetchUserContacts).not.toHaveBeenCalled();
+      });
+
+      it('should _NOT_ call `fetchUserContacts` action if the user is guest', async () => {
+        const mockWithGuestUserState = merge({}, mockInitialState);
+
+        mockWithGuestUserState.entities.user.isGuest = true;
+
+        const {
+          result: {
+            current: {
+              actions: { fetch },
+            },
+          },
+        } = renderHook(() => useUserContacts({ enableAutoFetch: false }), {
+          wrapper: withStore(mockWithGuestUserState),
+        });
+
+        await expect(fetch()).rejects.toThrow('User is not authenticated');
+
+        expect(fetchUserContacts).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('create', () => {
+      it('should call `createUserContact` action if the user is authenticated', async () => {
+        const {
+          result: {
+            current: {
+              actions: { create },
+            },
+          },
+        } = renderHook(() => useUserContacts({ enableAutoFetch: false }), {
+          wrapper: withStore(mockInitialState),
+        });
+
+        await create(mockGetContactResponse);
+
+        expect(createUserContact).toHaveBeenCalledWith(
+          mockInitialState.entities.user.id,
+          mockGetContactResponse,
+          undefined,
+        );
+      });
+
+      it('should _NOT_ call `createUserContact` action if the user is not set', async () => {
+        const mockWithoutUserState = merge({}, mockInitialState);
+
+        // @ts-expect-error Cannot set user to null/undefined if it exists
+        mockWithoutUserState.entities.user = null;
+        // @ts-expect-error Cannot set user's id to null/undefined if it exists
+        mockWithoutUserState.users.id = null;
+
+        const {
+          result: {
+            current: {
+              actions: { create },
+            },
+          },
+        } = renderHook(() => useUserContacts({ enableAutoFetch: false }), {
+          wrapper: withStore(mockWithoutUserState),
+        });
+
+        await expect(create(mockGetContactResponse)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(createUserContact).not.toHaveBeenCalled();
+      });
+
+      it('should _NOT_ call `createUserContact` action if the user is guest', async () => {
+        const mockWithGuestUserState = merge({}, mockInitialState);
+
+        mockWithGuestUserState.entities.user.isGuest = true;
+
+        const {
+          result: {
+            current: {
+              actions: { create },
+            },
+          },
+        } = renderHook(() => useUserContacts({ enableAutoFetch: false }), {
+          wrapper: withStore(mockWithGuestUserState),
+        });
+
+        await expect(create(mockGetContactResponse)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(createUserContact).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('update', () => {
+      it('should call `updateUserContact` action if the user is authenticated', async () => {
+        const {
+          result: {
+            current: {
+              actions: { update },
+            },
+          },
+        } = renderHook(() => useUserContacts({ enableAutoFetch: false }), {
+          wrapper: withStore(mockInitialState),
+        });
+
+        const data = [
+          {
+            op: 'replace',
+            path: '/description',
+            value: 'dead',
+          },
+        ] as PatchUserContactOperation[];
+
+        await update(mockGetContactResponse?.id, data);
+
+        expect(updateUserContact).toHaveBeenCalledWith(
+          mockInitialState.entities.user.id,
+          mockGetContactResponse?.id,
+          data,
+          undefined,
+        );
+      });
+
+      it('should _NOT_ call `updateUserContact` action if the user is not set', async () => {
+        const mockWithoutUserState = merge({}, mockInitialState);
+
+        // @ts-expect-error Cannot set user to null/undefined if it exists
+        mockWithoutUserState.entities.user = null;
+        // @ts-expect-error Cannot set user's id to null/undefined if it exists
+        mockWithoutUserState.users.id = null;
+
+        const {
+          result: {
+            current: {
+              actions: { update },
+            },
+          },
+        } = renderHook(() => useUserContacts({ enableAutoFetch: false }), {
+          wrapper: withStore(mockWithoutUserState),
+        });
+
+        const data = [
+          {
+            op: 'replace',
+            path: '/description',
+            value: 'dead',
+          },
+        ] as PatchUserContactOperation[];
+
+        await expect(update(mockGetContactResponse?.id, data)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(updateUserContact).not.toHaveBeenCalled();
+      });
+
+      it('should _NOT_ call `updateUserContact` action if the user is guest', async () => {
+        const mockWithGuestUserState = merge({}, mockInitialState);
+
+        mockWithGuestUserState.entities.user.isGuest = true;
+
+        const {
+          result: {
+            current: {
+              actions: { update },
+            },
+          },
+        } = renderHook(() => useUserContacts({ enableAutoFetch: false }), {
+          wrapper: withStore(mockWithGuestUserState),
+        });
+
+        const data = [
+          {
+            op: 'replace',
+            path: '/description',
+            value: 'dead',
+          },
+        ] as PatchUserContactOperation[];
+
+        await expect(update(mockGetContactResponse?.id, data)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(updateUserContact).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('remove', () => {
+      it('should call `removeUserContact` action if the user is authenticated', async () => {
+        const {
+          result: {
+            current: {
+              actions: { remove },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContacts({
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockInitialState),
+          },
+        );
+
+        await remove(mockGetContactResponse?.id);
+
+        expect(removeUserContact).toHaveBeenCalledWith(
+          mockInitialState.entities.user.id,
+          mockGetContactResponse?.id,
+          undefined,
+        );
+      });
+
+      it('should _NOT_ call `removeUserContact` action if the user is not set', async () => {
+        const mockWithoutUserState = merge({}, mockInitialState);
+
+        // @ts-expect-error Cannot set user to null/undefined if it exists
+        mockWithoutUserState.entities.user = null;
+        // @ts-expect-error Cannot set user's id to null/undefined if it exists
+        mockWithoutUserState.users.id = null;
+
+        const {
+          result: {
+            current: {
+              actions: { remove },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContacts({
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockWithoutUserState),
+          },
+        );
+
+        await expect(remove(mockGetContactResponse?.id)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(removeUserContact).not.toHaveBeenCalled();
+      });
+
+      it('should _NOT_ call `removeUserContact` action if the user is guest', async () => {
+        const mockWithGuestUserState = merge({}, mockInitialState);
+
+        mockWithGuestUserState.entities.user.isGuest = true;
+
+        const {
+          result: {
+            current: {
+              actions: { remove },
+            },
+          },
+        } = renderHook(
+          () =>
+            useUserContacts({
+              enableAutoFetch: false,
+            }),
+          {
+            wrapper: withStore(mockWithGuestUserState),
+          },
+        );
+
+        await expect(remove(mockGetContactResponse?.id)).rejects.toThrow(
+          'User is not authenticated',
+        );
+
+        expect(removeUserContact).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/react/src/users/hooks/index.ts
+++ b/packages/react/src/users/hooks/index.ts
@@ -2,7 +2,8 @@
  * User hooks.
  */
 export { default as useUser } from './useUser.js';
-export { default as useUserAddresses } from './useUserAddresses.js';
 export { default as useUserAddress } from './useUserAddress.js';
+export { default as useUserAddresses } from './useUserAddresses.js';
+export { default as useUserContacts } from './useUserContacts.js';
 
 export * from './types/index.js';

--- a/packages/react/src/users/hooks/types/index.ts
+++ b/packages/react/src/users/hooks/types/index.ts
@@ -1,3 +1,5 @@
 export * from './useUser.types.js';
 export * from './useUserAddress.types.js';
 export * from './useUserAddresses.types.js';
+export * from './useUserContact.types.js';
+export * from './useUserContacts.types.js';

--- a/packages/react/src/users/hooks/types/useUserContact.types.ts
+++ b/packages/react/src/users/hooks/types/useUserContact.types.ts
@@ -1,0 +1,6 @@
+import type { Config } from '@farfetch/blackout-client';
+
+export type UseUserContactOptions = {
+  enableAutoFetch?: boolean;
+  fetchConfig?: Config;
+};

--- a/packages/react/src/users/hooks/types/useUserContacts.types.ts
+++ b/packages/react/src/users/hooks/types/useUserContacts.types.ts
@@ -1,0 +1,6 @@
+import type { Config } from '@farfetch/blackout-client';
+
+export type UseUserContactsOptions = {
+  enableAutoFetch?: boolean;
+  fetchConfig?: Config;
+};

--- a/packages/react/src/users/hooks/useUserContact.ts
+++ b/packages/react/src/users/hooks/useUserContact.ts
@@ -1,0 +1,160 @@
+import {
+  areUserContactsFetched,
+  areUserContactsLoading,
+  createUserContact as createUserContactAction,
+  fetchUserContact as fetchUserContactAction,
+  getUserContacts,
+  getUserContactsError,
+  isAuthenticated as isAuthenticatedSelector,
+  removeUserContact as removeUserContactAction,
+  updateUserContact as updateUserContactAction,
+} from '@farfetch/blackout-redux';
+import { useCallback, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useUser } from '../../index.js';
+import useAction from '../../helpers/useAction.js';
+import type {
+  Config,
+  PatchUserContactOperation,
+  User,
+  UserContact,
+} from '@farfetch/blackout-client';
+import type { UseUserContactOptions } from './types/index.js';
+
+function useUserContact(
+  contactId: UserContact['id'],
+  options: UseUserContactOptions = {
+    enableAutoFetch: true,
+  },
+) {
+  const { enableAutoFetch = true, fetchConfig } = options;
+  const { data: user } = useUser();
+  const userId = user?.id;
+  const isAuthenticated = useSelector(isAuthenticatedSelector);
+  const isFetched = useSelector(areUserContactsFetched);
+  const isLoading = useSelector(areUserContactsLoading);
+  const userContact = useSelector(getUserContacts)?.[contactId];
+  const error = useSelector(getUserContactsError);
+  const fetchUserContactActionDispatcher = useAction(fetchUserContactAction);
+  const createUserContactActionDispatcher = useAction(createUserContactAction);
+  const updateUserContactActionDispatcher = useAction(updateUserContactAction);
+  const removeUserContactActionDispatcher = useAction(removeUserContactAction);
+
+  const fetchUserContact = useCallback(
+    (config: Config | undefined = fetchConfig) => {
+      if (!isAuthenticated) {
+        return Promise.reject(new Error('User is not authenticated'));
+      }
+
+      return fetchUserContactActionDispatcher(
+        userId as User['id'],
+        contactId,
+        config,
+      );
+    },
+    [
+      fetchUserContactActionDispatcher,
+      isAuthenticated,
+      userId,
+      contactId,
+      fetchConfig,
+    ],
+  );
+
+  const createUserContact = useCallback(
+    (data: UserContact, config: Config | undefined = fetchConfig) => {
+      if (!isAuthenticated) {
+        return Promise.reject(new Error('User is not authenticated'));
+      }
+
+      if (!data) {
+        return Promise.reject(new Error('No data provided'));
+      }
+
+      return createUserContactActionDispatcher(
+        userId as User['id'],
+        data,
+        config,
+      );
+    },
+    [createUserContactActionDispatcher, isAuthenticated, userId, fetchConfig],
+  );
+
+  const updateUserContact = useCallback(
+    (
+      contactId: UserContact['id'],
+      data: PatchUserContactOperation[],
+      config: Config | undefined = fetchConfig,
+    ) => {
+      if (!isAuthenticated) {
+        return Promise.reject(new Error('User is not authenticated'));
+      }
+
+      if (!contactId) {
+        return Promise.reject(new Error('No contactId provided'));
+      }
+
+      if (!data) {
+        return Promise.reject(new Error('No data provided'));
+      }
+
+      return updateUserContactActionDispatcher(
+        userId as User['id'],
+        contactId,
+        data,
+        config,
+      );
+    },
+    [isAuthenticated, updateUserContactActionDispatcher, userId, fetchConfig],
+  );
+
+  const removeUserContact = useCallback(
+    (
+      contactId: UserContact['id'],
+      config: Config | undefined = fetchConfig,
+    ) => {
+      if (!isAuthenticated) {
+        return Promise.reject(new Error('User is not authenticated'));
+      }
+
+      if (!contactId) {
+        return Promise.reject(new Error('No contactId provided'));
+      }
+
+      return removeUserContactActionDispatcher(
+        userId as User['id'],
+        contactId,
+        config,
+      );
+    },
+    [isAuthenticated, removeUserContactActionDispatcher, userId, fetchConfig],
+  );
+
+  useEffect(() => {
+    if (enableAutoFetch && !isFetched && !isLoading && isAuthenticated) {
+      fetchUserContact(fetchConfig);
+    }
+  }, [
+    enableAutoFetch,
+    fetchConfig,
+    fetchUserContact,
+    isAuthenticated,
+    isFetched,
+    isLoading,
+  ]);
+
+  return {
+    data: userContact,
+    isLoading,
+    isFetched,
+    error,
+    actions: {
+      fetch: fetchUserContact,
+      create: createUserContact,
+      update: updateUserContact,
+      remove: removeUserContact,
+    },
+  };
+}
+
+export default useUserContact;

--- a/packages/react/src/users/hooks/useUserContacts.ts
+++ b/packages/react/src/users/hooks/useUserContacts.ts
@@ -1,0 +1,149 @@
+import {
+  areUserContactsFetched,
+  areUserContactsLoading,
+  createUserContact as createUserContactAction,
+  fetchUserContacts as fetchUserContactsAction,
+  getUserContacts,
+  getUserContactsError,
+  isAuthenticated as isAuthenticatedSelector,
+  removeUserContact as removeUserContactAction,
+  updateUserContact as updateUserContactAction,
+} from '@farfetch/blackout-redux';
+import { useCallback, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useUser } from '../../index.js';
+import useAction from '../../helpers/useAction.js';
+import type {
+  Config,
+  PatchUserContactOperation,
+  User,
+  UserContact,
+} from '@farfetch/blackout-client';
+import type { UseUserContactsOptions } from './types/index.js';
+
+function useUserContacts(
+  options: UseUserContactsOptions = {
+    enableAutoFetch: true,
+  },
+) {
+  const { enableAutoFetch = true, fetchConfig } = options;
+  const { data: user } = useUser();
+  const userId = user?.id;
+  const isAuthenticated = useSelector(isAuthenticatedSelector);
+  const isFetched = useSelector(areUserContactsFetched);
+  const isLoading = useSelector(areUserContactsLoading);
+  const userContacts = useSelector(getUserContacts);
+  const error = useSelector(getUserContactsError);
+  const fetchUserContactsActionDispatcher = useAction(fetchUserContactsAction);
+  const createUserContactActionDispatcher = useAction(createUserContactAction);
+  const updateUserContactActionDispatcher = useAction(updateUserContactAction);
+  const removeUserContactActionDispatcher = useAction(removeUserContactAction);
+
+  const fetchUserContacts = useCallback(
+    (config: Config | undefined = fetchConfig) => {
+      if (!isAuthenticated) {
+        return Promise.reject(new Error('User is not authenticated'));
+      }
+
+      return fetchUserContactsActionDispatcher(userId as User['id'], config);
+    },
+    [fetchUserContactsActionDispatcher, isAuthenticated, userId, fetchConfig],
+  );
+
+  const createUserContact = useCallback(
+    (data: UserContact, config: Config | undefined = fetchConfig) => {
+      if (!isAuthenticated) {
+        return Promise.reject(new Error('User is not authenticated'));
+      }
+
+      if (!data) {
+        return Promise.reject(new Error('No data provided'));
+      }
+
+      return createUserContactActionDispatcher(
+        userId as User['id'],
+        data,
+        config,
+      );
+    },
+    [createUserContactActionDispatcher, isAuthenticated, userId, fetchConfig],
+  );
+
+  const updateUserContact = useCallback(
+    (
+      contactId: UserContact['id'],
+      data: PatchUserContactOperation[],
+      config: Config | undefined = fetchConfig,
+    ) => {
+      if (!isAuthenticated) {
+        return Promise.reject(new Error('User is not authenticated'));
+      }
+
+      if (!contactId) {
+        return Promise.reject(new Error('No contactId provided'));
+      }
+
+      if (!data) {
+        return Promise.reject(new Error('No data provided'));
+      }
+
+      return updateUserContactActionDispatcher(
+        userId as User['id'],
+        contactId,
+        data,
+        config,
+      );
+    },
+    [isAuthenticated, updateUserContactActionDispatcher, userId, fetchConfig],
+  );
+
+  const removeUserContact = useCallback(
+    (
+      contactId: UserContact['id'],
+      config: Config | undefined = fetchConfig,
+    ) => {
+      if (!isAuthenticated) {
+        return Promise.reject(new Error('User is not authenticated'));
+      }
+
+      if (!contactId) {
+        return Promise.reject(new Error('No contactId provided'));
+      }
+
+      return removeUserContactActionDispatcher(
+        userId as User['id'],
+        contactId,
+        config,
+      );
+    },
+    [isAuthenticated, removeUserContactActionDispatcher, userId, fetchConfig],
+  );
+
+  useEffect(() => {
+    if (enableAutoFetch && !isFetched && !isLoading && isAuthenticated) {
+      fetchUserContacts(fetchConfig);
+    }
+  }, [
+    enableAutoFetch,
+    fetchConfig,
+    fetchUserContacts,
+    isAuthenticated,
+    isFetched,
+    isLoading,
+  ]);
+
+  return {
+    data: userContacts,
+    isLoading,
+    isFetched,
+    error,
+    actions: {
+      fetch: fetchUserContacts,
+      create: createUserContact,
+      update: updateUserContact,
+      remove: removeUserContact,
+    },
+  };
+}
+
+export default useUserContacts;

--- a/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
@@ -129,6 +129,7 @@ Object {
   "areUserAddressesLoading": [Function],
   "areUserAttributesLoading": [Function],
   "areUserBenefitsLoading": [Function],
+  "areUserContactsFetched": [Function],
   "areUserContactsLoading": [Function],
   "areUserCreditMovementsLoading": [Function],
   "areUserCreditsLoading": [Function],

--- a/packages/redux/src/users/contacts/selectors.ts
+++ b/packages/redux/src/users/contacts/selectors.ts
@@ -32,3 +32,15 @@ export const getUserContactsError = (state: StoreState) =>
  */
 export const getUserContacts = (state: StoreState) =>
   getEntities(state, 'contacts');
+
+/**
+ * Returns the fetched status of the user contacts area.
+ *
+ * @param state - Application state.
+ *
+ * @returns Loader status.
+ */
+export const areUserContactsFetched = (state: StoreState) =>
+  (getUserContacts(state) !== undefined ||
+    getUserContactsError(state) !== null) &&
+  !areUserContactsLoading(state);


### PR DESCRIPTION
## Description

This adds both new hooks for user contacts management, one for using with a single address and the other with the user contacts list.
<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
