### PR TITLE
feat(redux): add shared wishlist middleware for updating snapshop

### DIFF
--- a/packages/redux/src/sharedWishlists/index.ts
+++ b/packages/redux/src/sharedWishlists/index.ts
@@ -1,4 +1,5 @@
-export * as wishlistsActionTypes from './actionTypes.js';
+export * as sharedWishlistsActionTypes from './actionTypes.js';
+export * as sharedWishlistsMiddlewares from './middlewares/index.js';
 
 export * from './actions/index.js';
 export * from './actions/factories/index.js';

--- a/packages/redux/src/sharedWishlists/middlewares/__tests__/updateSharedWishlistUponItemsChanges.test.ts
+++ b/packages/redux/src/sharedWishlists/middlewares/__tests__/updateSharedWishlistUponItemsChanges.test.ts
@@ -1,0 +1,70 @@
+import * as actionTypes from '../../../wishlists/actionTypes.js';
+import { INITIAL_STATE } from '../../reducer.js';
+import {
+  mockSharedWishlistId,
+  mockSharedWishlistState,
+} from 'tests/__fixtures__/sharedWishlists/sharedWishlists.fixtures.mjs';
+import { mockStore } from '../../../../tests/index.js';
+import { updateSharedWishlist } from '../../actions/index.js';
+import thunk from 'redux-thunk';
+import updateSharedWishlistUponItemsChanges from '../updateSharedWishlistUponItemsChanges.js';
+import type { UserEntity } from '../../../index.js';
+
+jest.mock('../../actions', () => ({
+  ...jest.requireActual('../../actions'),
+  updateSharedWishlist: jest.fn(() => () => ({ type: 'foo' })),
+}));
+
+describe('updateSharedWishlistUponItemsChanges', () => {
+  it('should do nothing if the action is not adding, deleting or updating a wishlist item', () => {
+    const store = mockStore({ sharedWishlist: INITIAL_STATE }, {}, [
+      updateSharedWishlistUponItemsChanges,
+    ]);
+
+    store.dispatch({ type: 'foo' });
+
+    expect(updateSharedWishlist).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    actionTypes.ADD_WISHLIST_ITEM_SUCCESS,
+    actionTypes.REMOVE_WISHLIST_ITEM_SUCCESS,
+    actionTypes.UPDATE_WISHLIST_ITEM_SUCCESS,
+  ])('should intercept %s, and do nothing for a guest user', actionType => {
+    const store = mockStore(
+      { sharedWishlist: INITIAL_STATE },
+      { entities: { user: { isGuest: true } as UserEntity } },
+      [updateSharedWishlistUponItemsChanges],
+    );
+
+    store.dispatch({ type: actionType });
+
+    expect(updateSharedWishlist).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    actionTypes.ADD_WISHLIST_ITEM_SUCCESS,
+    actionTypes.REMOVE_WISHLIST_ITEM_SUCCESS,
+    actionTypes.UPDATE_WISHLIST_ITEM_SUCCESS,
+  ])(
+    'should intercept %s, and update the shared wishlist for a non-guest user',
+    actionType => {
+      const store = mockStore(
+        mockSharedWishlistState,
+        {
+          entities: {
+            ...mockSharedWishlistState.entities,
+            user: { isGuest: false } as UserEntity,
+          },
+        },
+        [thunk, updateSharedWishlistUponItemsChanges],
+      );
+
+      store.dispatch({
+        type: actionType,
+      });
+
+      expect(updateSharedWishlist).toHaveBeenCalledWith(mockSharedWishlistId);
+    },
+  );
+});

--- a/packages/redux/src/sharedWishlists/middlewares/index.ts
+++ b/packages/redux/src/sharedWishlists/middlewares/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Shared wishlists middlewares.
+ */
+export { default as updateSharedWishlistUponItemsChanges } from './updateSharedWishlistUponItemsChanges.js';

--- a/packages/redux/src/sharedWishlists/middlewares/updateSharedWishlistUponItemsChanges.ts
+++ b/packages/redux/src/sharedWishlists/middlewares/updateSharedWishlistUponItemsChanges.ts
@@ -1,0 +1,46 @@
+import * as actionTypes from '../../wishlists/actionTypes.js';
+import {
+  getSharedWishlistId,
+  type UpdateSharedWishlistAction,
+} from '../index.js';
+import { getUser, getUserIsGuest } from '../../users/selectors.js';
+import { updateSharedWishlist } from '../actions/index.js';
+import type { AnyAction, Middleware } from 'redux';
+import type { GetOptionsArgument, StoreState } from '../../index.js';
+import type { ThunkDispatch } from 'redux-thunk';
+
+type UpdateSharedWishlistUponItemsChangesParams = {
+  // Redux action dispatch.
+  dispatch: ThunkDispatch<
+    StoreState,
+    GetOptionsArgument,
+    UpdateSharedWishlistAction
+  >;
+  // Returns the current redux state.
+  getState: () => StoreState;
+};
+
+const updateSharedWishlistUponItemsChanges: Middleware =
+  ({ dispatch, getState }: UpdateSharedWishlistUponItemsChangesParams) =>
+  next =>
+  (action: AnyAction) => {
+    if (
+      action.type === actionTypes.UPDATE_WISHLIST_ITEM_SUCCESS ||
+      action.type === actionTypes.ADD_WISHLIST_ITEM_SUCCESS ||
+      action.type === actionTypes.REMOVE_WISHLIST_ITEM_SUCCESS
+    ) {
+      const state = getState();
+      const user = getUser(state);
+      const isGuestUser = getUserIsGuest(user);
+
+      if (!isGuestUser) {
+        const sharedWishlistId = getSharedWishlistId(state);
+
+        dispatch(updateSharedWishlist(sharedWishlistId as string));
+      }
+    }
+
+    return next(action);
+  };
+
+export default updateSharedWishlistUponItemsChanges;


### PR DESCRIPTION
## Description

- This adds the shared wishlist middleware that handles the update of the snapshot when a wishlist item is updated, added or deleted.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
