### PR TITLE
fix(client): checkout session types

### DIFF
--- a/packages/client/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/client/src/__tests__/__snapshots__/index.test.ts.snap
@@ -134,6 +134,18 @@ Object {
     "OrderCreated": 3,
     "Paid": 2,
   },
+  "CheckoutSessionOrderStatus": Object {
+    "0": "NoError",
+    "1": "AddressesError",
+    "2": "ShippingOptionsError",
+    "3": "DeliveryBundleError",
+    "4": "Recovered",
+    "AddressesError": 1,
+    "DeliveryBundleError": 3,
+    "NoError": 0,
+    "Recovered": 4,
+    "ShippingOptionsError": 2,
+  },
   "CheckoutSessionType": Object {
     "0": "Checkout",
     "1": "Payment",

--- a/packages/client/src/checkout/types/checkoutSession.types.ts
+++ b/packages/client/src/checkout/types/checkoutSession.types.ts
@@ -1,8 +1,22 @@
+import type {
+  CheckoutAddress,
+  CheckoutShippingAddress,
+  ClickAndCollect,
+  Controls,
+} from '../../index.js';
 import type { CheckoutSessionItem } from './checkoutSessionItem.types.js';
 
 export enum CheckoutSessionType {
   Checkout,
   Payment,
+}
+
+export enum CheckoutSessionOrderStatus {
+  NoError,
+  AddressesError,
+  ShippingOptionsError,
+  DeliveryBundleError,
+  Recovered,
 }
 
 export type CheckoutSessionMetadata = Record<string, string>;
@@ -20,7 +34,9 @@ export type CheckoutSession = {
   clientId: number;
   isGuest: boolean;
   userId: number;
-  orderId: number;
+  checkoutOrderId: number;
+  orderId?: string;
+  orderStatus: CheckoutSessionOrderStatus;
   grandTotal: number;
   subTotalAmount: number;
   subTotalAmountExclTaxes: number;
@@ -31,4 +47,7 @@ export type CheckoutSession = {
   taxType: string;
   metadata?: CheckoutSessionMetadata;
   items: CheckoutSessionItem[];
-};
+  shippingAddress?: CheckoutShippingAddress;
+  billingAddress?: CheckoutAddress;
+  clickAndCollect?: ClickAndCollect;
+} & Controls;

--- a/tests/__fixtures__/checkout/checkoutSessions.fixtures.mts
+++ b/tests/__fixtures__/checkout/checkoutSessions.fixtures.mts
@@ -1,9 +1,44 @@
 import {
   type CheckoutSession,
+  CheckoutSessionOrderStatus,
   CheckoutSessionType,
+  type CheckoutShippingAddress,
 } from '@farfetch/blackout-client';
 
 export const mockCheckoutSessionId = '6c3a577c-01b7-497a-91ab-b4a3388e36d3';
+
+const mockShippingAddress: CheckoutShippingAddress = {
+  addressLine1: 'Rua da Lionesa 446, G12',
+  addressLine2: ' Teste',
+  addressLine3: '',
+  city: {
+    countryId: 0,
+    id: 0,
+    name: 'Leça do Balio',
+  },
+  country: {
+    alpha2Code: 'PT',
+    alpha3Code: 'PRT',
+    culture: 'pt-PT',
+    id: 165,
+    name: 'Portugal',
+    nativeName: 'Portugal',
+    region: 'Europe',
+    subfolder: '/pt-PT',
+    regionId: 0,
+    continentId: 3,
+  },
+  firstName: 'tester',
+  id: '00000000-0000-0000-0000-000000000000',
+  lastName: 'teste',
+  phone: '121525125',
+  state: {
+    countryId: 0,
+    id: 0,
+    name: '',
+  },
+  zipCode: '4465-761',
+};
 
 export const mockCheckoutSession: CheckoutSession = {
   id: mockCheckoutSessionId,
@@ -17,7 +52,9 @@ export const mockCheckoutSession: CheckoutSession = {
   clientId: 2,
   isGuest: false,
   userId: 1,
-  orderId: 1,
+  orderId: '1',
+  checkoutOrderId: 1,
+  orderStatus: CheckoutSessionOrderStatus.NoError,
   grandTotal: 115.0,
   subTotalAmount: 100.0,
   subTotalAmountExclTaxes: 100.0,
@@ -853,4 +890,15 @@ export const mockCheckoutSession: CheckoutSession = {
       sizeDescription: '38.5',
     },
   ],
+  shippingAddress: mockShippingAddress,
+  billingAddress: mockShippingAddress,
+  clickAndCollect: {
+    collectPointId: 0,
+    merchantLocationId: 0,
+  },
+  '@controls': {
+    operation: {
+      href: '/v1/orders/1/operations/123',
+    },
+  },
 };


### PR DESCRIPTION
## Description

This adds the types for `checkoutOrderId`, `orderStatus`, `shippingAddress`, `billingAddress` and `clickAndCollect` to the `checkoutSession` type. It also changes the type for `orderId`.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
