### PR TITLE
feat(core): add middleware for getting the wishlist sets upon shared wishlist id changes

### DIFF
--- a/packages/core/src/sharedWishlists/redux/__tests__/reducer.test.js
+++ b/packages/core/src/sharedWishlists/redux/__tests__/reducer.test.js
@@ -270,6 +270,14 @@ describe('shared wishlists reducer', () => {
       ).toBe(expectedResult);
     });
 
+    it('should handle REMOVE_SHARED_WISHLIST_SUCCESS action type', () => {
+      expect(
+        reducer(currentState, {
+          type: actionTypes.REMOVE_SHARED_WISHLIST_SUCCESS,
+        }).result,
+      ).toBe(initialState.result);
+    });
+
     it('should handle other actions by returning the previous state', () => {
       const state = { result: 'foo' };
 

--- a/packages/core/src/sharedWishlists/redux/middlewares/__tests__/getWishlistSetsUponSharedWishlistIdChanges.test.js
+++ b/packages/core/src/sharedWishlists/redux/middlewares/__tests__/getWishlistSetsUponSharedWishlistIdChanges.test.js
@@ -1,0 +1,66 @@
+import {
+  CREATE_SHARED_WISHLIST_SUCCESS,
+  REMOVE_SHARED_WISHLIST_SUCCESS,
+} from '../../actionTypes';
+import { mockSharedWishlistState } from 'tests/__fixtures__/sharedWishlists';
+import { mockStore } from '../../../../../tests';
+import getWishlistSetsUponSharedWishlistIdChanges from '../updateSharedWishlistUponItemsChanges';
+import INITIAL_STATE from '../../reducer';
+
+jest.mock('../../../../wishlists/redux/actions', () => ({
+  ...jest.requireActual('../../../../wishlists/redux/actions'),
+  doGetWishlistSets: jest.fn(() => () => ({ type: 'foo' })),
+}));
+const mockState = {
+  ...mockSharedWishlistState,
+  entities: {
+    ...mockSharedWishlistState.entities,
+    user: { isGuest: false },
+  },
+};
+
+describe('updateSharedWishlistUponItemsChanges', () => {
+  it('should do nothing if the action is not adding, deleting or updating a wishlist item', () => {
+    const store = mockStore({ sharedWishlist: INITIAL_STATE }, mockState, [
+      getWishlistSetsUponSharedWishlistIdChanges,
+    ]);
+
+    store.dispatch({ type: 'foo' });
+
+    const actions = store.getActions();
+
+    expect(actions).toEqual(expect.arrayContaining([{ type: 'foo' }]));
+  });
+
+  it.each([CREATE_SHARED_WISHLIST_SUCCESS, REMOVE_SHARED_WISHLIST_SUCCESS])(
+    'should intercept %s, and do nothing for a guest user',
+    actionType => {
+      const store = mockStore(
+        { sharedWishlist: INITIAL_STATE },
+        { entities: { user: { isGuest: true } } },
+        [getWishlistSetsUponSharedWishlistIdChanges],
+      );
+
+      store.dispatch({ type: actionType });
+
+      const actions = store.getActions();
+
+      expect(actions).toEqual(expect.arrayContaining([{ type: actionType }]));
+    },
+  );
+
+  it.each([CREATE_SHARED_WISHLIST_SUCCESS, REMOVE_SHARED_WISHLIST_SUCCESS])(
+    'should intercept %s, and get the wishlist sets for a non-guest user',
+    actionType => {
+      const store = mockStore({ sharedWishlist: INITIAL_STATE }, mockState, [
+        getWishlistSetsUponSharedWishlistIdChanges,
+      ]);
+
+      store.dispatch({ type: actionType });
+
+      const actions = store.getActions();
+
+      expect(actions).toEqual(expect.arrayContaining([{ type: actionType }]));
+    },
+  );
+});

--- a/packages/core/src/sharedWishlists/redux/middlewares/__tests__/updateSharedWishlistUponItemsChanges.test.js
+++ b/packages/core/src/sharedWishlists/redux/middlewares/__tests__/updateSharedWishlistUponItemsChanges.test.js
@@ -2,6 +2,7 @@ import {
   ADD_ITEM_TO_WISHLIST_SUCCESS,
   DELETE_WISHLIST_ITEM_SUCCESS,
   UPDATE_WISHLIST_ITEM_SUCCESS,
+  UPDATE_WISHLIST_SET_SUCCESS,
 } from '../../../../wishlists/redux/actionTypes';
 import { mockSharedWishlistState } from 'tests/__fixtures__/sharedWishlists';
 import { mockStore } from '../../../../../tests';
@@ -37,6 +38,7 @@ describe('updateSharedWishlistUponItemsChanges', () => {
     ADD_ITEM_TO_WISHLIST_SUCCESS,
     DELETE_WISHLIST_ITEM_SUCCESS,
     UPDATE_WISHLIST_ITEM_SUCCESS,
+    UPDATE_WISHLIST_SET_SUCCESS,
   ])('should intercept %s, and do nothing for a guest user', actionType => {
     const store = mockStore(
       { sharedWishlist: INITIAL_STATE },
@@ -55,6 +57,7 @@ describe('updateSharedWishlistUponItemsChanges', () => {
     UPDATE_WISHLIST_ITEM_SUCCESS,
     ADD_ITEM_TO_WISHLIST_SUCCESS,
     DELETE_WISHLIST_ITEM_SUCCESS,
+    UPDATE_WISHLIST_SET_SUCCESS,
   ])(
     'should intercept %s, and update the shared wishlist for a non-guest user',
     actionType => {

--- a/packages/core/src/sharedWishlists/redux/middlewares/getWishlistSetsUponSharedWishlistIdChanges.js
+++ b/packages/core/src/sharedWishlists/redux/middlewares/getWishlistSetsUponSharedWishlistIdChanges.js
@@ -1,0 +1,35 @@
+import {
+  CREATE_SHARED_WISHLIST_SUCCESS,
+  REMOVE_SHARED_WISHLIST_SUCCESS,
+} from '../actionTypes';
+import { doGetWishlistSets } from '../../../wishlists/redux/actions';
+import { getUser, getUserIsGuest } from '../../../entities/redux/selectors';
+import { getWishlistsSets as getWishlistsSetsClient } from '../../../wishlists/client';
+
+const getWishlistSets = doGetWishlistSets(getWishlistsSetsClient);
+
+/**
+ * Middleware to get the updated wishlist sets if a shared wishlist has been created or deleted.
+ *
+ * @function getWishlistSetsUponSharedWishlistIdChanges
+ * @memberof module:sharedWishlists/middlewares
+ *
+ * @param {object} store - Redux store at the moment.
+ *
+ * @returns {Function} Redux middleware.
+ */
+export default store => next => action => {
+  if (
+    action.type === REMOVE_SHARED_WISHLIST_SUCCESS ||
+    action.type === CREATE_SHARED_WISHLIST_SUCCESS
+  ) {
+    const state = store.getState();
+    const user = getUser(state);
+    const isGuestUser = getUserIsGuest(user);
+
+    if (!isGuestUser) {
+      store.dispatch(getWishlistSets());
+    }
+  }
+  return next(action);
+};

--- a/packages/core/src/sharedWishlists/redux/middlewares/index.js
+++ b/packages/core/src/sharedWishlists/redux/middlewares/index.js
@@ -6,3 +6,4 @@
  * @subcategory Middlewares
  */
 export { default as updateSharedWishlistUponItemsChanges } from './updateSharedWishlistUponItemsChanges';
+export { default as getWishlistSetsUponSharedWishlistIdChanges } from './getWishlistSetsUponSharedWishlistIdChanges';

--- a/packages/core/src/sharedWishlists/redux/middlewares/updateSharedWishlistUponItemsChanges.js
+++ b/packages/core/src/sharedWishlists/redux/middlewares/updateSharedWishlistUponItemsChanges.js
@@ -2,6 +2,7 @@ import {
   ADD_ITEM_TO_WISHLIST_SUCCESS,
   DELETE_WISHLIST_ITEM_SUCCESS,
   UPDATE_WISHLIST_ITEM_SUCCESS,
+  UPDATE_WISHLIST_SET_SUCCESS,
 } from '../../../wishlists/redux/actionTypes';
 import { doUpdateSharedWishlist } from '../actions';
 import { getSharedWishlistId } from '../selectors';
@@ -24,7 +25,8 @@ export default store => next => action => {
   if (
     action.type === UPDATE_WISHLIST_ITEM_SUCCESS ||
     action.type === ADD_ITEM_TO_WISHLIST_SUCCESS ||
-    action.type === DELETE_WISHLIST_ITEM_SUCCESS
+    action.type === DELETE_WISHLIST_ITEM_SUCCESS ||
+    action.type === UPDATE_WISHLIST_SET_SUCCESS
   ) {
     const user = getUser(store.getState());
     const isGuestUser = getUserIsGuest(user);

--- a/packages/core/src/sharedWishlists/redux/reducer.js
+++ b/packages/core/src/sharedWishlists/redux/reducer.js
@@ -13,6 +13,8 @@ const result = (state = INITIAL_STATE.result, action = {}) => {
     case actionTypes.FETCH_SHARED_WISHLIST_SUCCESS:
     case actionTypes.UPDATE_SHARED_WISHLIST_SUCCESS:
       return action.payload.result;
+    case actionTypes.REMOVE_SHARED_WISHLIST_SUCCESS:
+      return INITIAL_STATE.result;
     default:
       return state;
   }


### PR DESCRIPTION
## Description

This adds a middleware for getting the wishlist sets when the `sharedWishlistId` has changed. It ensures we are always accessing the updated data from the wishlist sets after creating or deleting a shared wishlist.

Also, the action `UPDATE_WISHLIST_SET_SUCCESS` was added to the `updateSharedWishlistUponItemsChanges` middleware and the shared wishlist reducer (result) was adjusted.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [ ] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
