### PR TITLE
fix(redux): adjust shared wishlists reducer

### DIFF
--- a/packages/redux/src/sharedWishlists/__tests__/reducer.test.ts
+++ b/packages/redux/src/sharedWishlists/__tests__/reducer.test.ts
@@ -66,6 +66,20 @@ describe('shared wishlists reducer', () => {
       ).toBe(expectedResult);
     });
 
+    it('should handle REMOVE_SHARED_WISHLIST_SUCCESS action type', () => {
+      const currentState = {
+        error: null,
+        isLoading: false,
+        result: '08a4b1d9-8d50-4b39-8719-3837f58c96c5',
+      };
+
+      expect(
+        reducer(currentState, {
+          type: actionTypes.REMOVE_SHARED_WISHLIST_SUCCESS,
+        }).result,
+      ).toBe(initialState.result);
+    });
+
     it('should handle other actions by returning the previous state', () => {
       const state = {
         ...INITIAL_STATE,

--- a/packages/redux/src/sharedWishlists/reducer.ts
+++ b/packages/redux/src/sharedWishlists/reducer.ts
@@ -16,6 +16,8 @@ const result = (state = INITIAL_STATE.result, action: AnyAction) => {
     case actionTypes.FETCH_SHARED_WISHLIST_SUCCESS:
     case actionTypes.UPDATE_SHARED_WISHLIST_SUCCESS:
       return action.payload.result;
+    case actionTypes.REMOVE_SHARED_WISHLIST_SUCCESS:
+      return INITIAL_STATE.result;
     default:
       return state;
   }


### PR DESCRIPTION
## Description

- This adjusts the result slice in the shared wishlist reducer for handling the `REMOVE_SHARED_WISHLIST_SUCCESS` action.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [ ] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
