### PR TITLE
feat(redux): add share wishlist middleware for refetching wishlist sets

### DIFF
--- a/packages/redux/src/sharedWishlists/middlewares/__tests__/getWishlistSetsUponSharedWishlistIdChanges.test.ts
+++ b/packages/redux/src/sharedWishlists/middlewares/__tests__/getWishlistSetsUponSharedWishlistIdChanges.test.ts
@@ -1,0 +1,73 @@
+import * as actionTypes from '../../actionTypes.js';
+import { fetchWishlistSets } from '../../../wishlists/actions/index.js';
+import { INITIAL_STATE } from '../../reducer.js';
+import { mockStore } from '../../../../tests/index.js';
+import {
+  mockWishlistId,
+  mockWishlistState,
+} from 'tests/__fixtures__/wishlists/wishlists.fixtures.mjs';
+import getWishlistSetsUponSharedWishlistIdChanges from '../getWishlistSetsUponSharedWishlistIdChanges.js';
+import thunk from 'redux-thunk';
+import type { UserEntity } from '../../../index.js';
+
+jest.mock('../../../wishlists/actions', () => ({
+  ...jest.requireActual('../../actions'),
+  fetchWishlistSets: jest.fn(() => () => ({ type: 'foo' })),
+}));
+
+describe('getWishlistSetsUponSharedWishlistIdChanges', () => {
+  it('should do nothing if the action is not creating or deleting a shared wishlist', () => {
+    const store = mockStore({ sharedWishlist: INITIAL_STATE }, {}, [
+      getWishlistSetsUponSharedWishlistIdChanges,
+    ]);
+
+    store.dispatch({ type: 'foo' });
+
+    expect(fetchWishlistSets).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    actionTypes.CREATE_SHARED_WISHLIST_SUCCESS,
+    actionTypes.REMOVE_SHARED_WISHLIST_SUCCESS,
+  ])('should intercept %s, and do nothing for a guest user', actionType => {
+    const store = mockStore(
+      mockWishlistState,
+      {
+        entities: {
+          ...mockWishlistState.entities,
+          user: { isGuest: true } as UserEntity,
+        },
+      },
+      [getWishlistSetsUponSharedWishlistIdChanges],
+    );
+
+    store.dispatch({ type: actionType });
+
+    expect(fetchWishlistSets).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    actionTypes.CREATE_SHARED_WISHLIST_SUCCESS,
+    actionTypes.REMOVE_SHARED_WISHLIST_SUCCESS,
+  ])(
+    'should intercept %s, and fetch the wishlist sets for a non-guest user',
+    actionType => {
+      const store = mockStore(
+        mockWishlistState,
+        {
+          entities: {
+            ...mockWishlistState.entities,
+            user: { isGuest: false } as UserEntity,
+          },
+        },
+        [thunk, getWishlistSetsUponSharedWishlistIdChanges],
+      );
+
+      store.dispatch({
+        type: actionType,
+      });
+
+      expect(fetchWishlistSets).toHaveBeenCalledWith(mockWishlistId);
+    },
+  );
+});

--- a/packages/redux/src/sharedWishlists/middlewares/__tests__/updateSharedWishlistUponItemsChanges.test.ts
+++ b/packages/redux/src/sharedWishlists/middlewares/__tests__/updateSharedWishlistUponItemsChanges.test.ts
@@ -30,6 +30,7 @@ describe('updateSharedWishlistUponItemsChanges', () => {
     actionTypes.ADD_WISHLIST_ITEM_SUCCESS,
     actionTypes.REMOVE_WISHLIST_ITEM_SUCCESS,
     actionTypes.UPDATE_WISHLIST_ITEM_SUCCESS,
+    actionTypes.UPDATE_WISHLIST_SET_SUCCESS,
   ])('should intercept %s, and do nothing for a guest user', actionType => {
     const store = mockStore(
       { sharedWishlist: INITIAL_STATE },
@@ -46,6 +47,7 @@ describe('updateSharedWishlistUponItemsChanges', () => {
     actionTypes.ADD_WISHLIST_ITEM_SUCCESS,
     actionTypes.REMOVE_WISHLIST_ITEM_SUCCESS,
     actionTypes.UPDATE_WISHLIST_ITEM_SUCCESS,
+    actionTypes.UPDATE_WISHLIST_SET_SUCCESS,
   ])(
     'should intercept %s, and update the shared wishlist for a non-guest user',
     actionType => {

--- a/packages/redux/src/sharedWishlists/middlewares/getWishlistSetsUponSharedWishlistIdChanges.ts
+++ b/packages/redux/src/sharedWishlists/middlewares/getWishlistSetsUponSharedWishlistIdChanges.ts
@@ -1,0 +1,45 @@
+import * as actionTypes from '../../sharedWishlists/actionTypes.js';
+import { fetchWishlistSets } from '../../wishlists/actions/index.js';
+import { type FetchWishlistSetsAction } from '../../wishlists/types/actions.types.js';
+import {
+  type GetOptionsArgument,
+  getWishlistId,
+  type StoreState,
+} from '../../index.js';
+import { getUser, getUserIsGuest } from '../../users/selectors.js';
+import type { AnyAction, Middleware } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
+
+type GetWishlistSetsUponSharedWishlistIdChangesParams = {
+  // Redux action dispatch.
+  dispatch: ThunkDispatch<
+    StoreState,
+    GetOptionsArgument,
+    FetchWishlistSetsAction
+  >;
+  // Returns the current redux state.
+  getState: () => StoreState;
+};
+
+const getWishlistSetsUponSharedWishlistIdChanges: Middleware =
+  ({ dispatch, getState }: GetWishlistSetsUponSharedWishlistIdChangesParams) =>
+  next =>
+  (action: AnyAction) => {
+    if (
+      action.type === actionTypes.REMOVE_SHARED_WISHLIST_SUCCESS ||
+      action.type === actionTypes.CREATE_SHARED_WISHLIST_SUCCESS
+    ) {
+      const state = getState();
+      const user = getUser(state);
+      const isGuestUser = getUserIsGuest(user);
+      const wishlistId = getWishlistId(state);
+
+      if (!isGuestUser) {
+        dispatch(fetchWishlistSets(wishlistId as string));
+      }
+    }
+
+    return next(action);
+  };
+
+export default getWishlistSetsUponSharedWishlistIdChanges;

--- a/packages/redux/src/sharedWishlists/middlewares/index.ts
+++ b/packages/redux/src/sharedWishlists/middlewares/index.ts
@@ -1,4 +1,5 @@
 /**
  * Shared wishlists middlewares.
  */
+export { default as getWishlistSetsUponSharedWishlistIdChanges } from './getWishlistSetsUponSharedWishlistIdChanges.js';
 export { default as updateSharedWishlistUponItemsChanges } from './updateSharedWishlistUponItemsChanges.js';

--- a/packages/redux/src/sharedWishlists/middlewares/updateSharedWishlistUponItemsChanges.ts
+++ b/packages/redux/src/sharedWishlists/middlewares/updateSharedWishlistUponItemsChanges.ts
@@ -27,7 +27,8 @@ const updateSharedWishlistUponItemsChanges: Middleware =
     if (
       action.type === actionTypes.UPDATE_WISHLIST_ITEM_SUCCESS ||
       action.type === actionTypes.ADD_WISHLIST_ITEM_SUCCESS ||
-      action.type === actionTypes.REMOVE_WISHLIST_ITEM_SUCCESS
+      action.type === actionTypes.REMOVE_WISHLIST_ITEM_SUCCESS ||
+      action.type === actionTypes.UPDATE_WISHLIST_SET_SUCCESS
     ) {
       const state = getState();
       const user = getUser(state);


### PR DESCRIPTION
## Description

This adds a middleware for getting the wishlist sets when the `sharedWishlistId` has changed. It ensures we are always accessing the updated data from the wishlist sets after creating or deleting a shared wishlist.

Also, the action `UPDATE_WISHLIST_SET_SUCCESS` was added to the `updateSharedWishlistUponItemsChanges` middleware.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
