### PR TITLE
fix: fix user addresses put requests

### DIFF
--- a/packages/client/src/users/addresses/__tests__/putUserDefaultBillingAddress.test.ts
+++ b/packages/client/src/users/addresses/__tests__/putUserDefaultBillingAddress.test.ts
@@ -20,6 +20,7 @@ describe('putUserDefaultBillingAddress', () => {
 
     expect(spy).toHaveBeenCalledWith(
       `/account/v1/users/${userId}/addresses/billing/${id}`,
+      undefined,
       expectedConfig,
     );
   });
@@ -32,6 +33,7 @@ describe('putUserDefaultBillingAddress', () => {
     ).rejects.toMatchSnapshot();
     expect(spy).toHaveBeenCalledWith(
       `/account/v1/users/${userId}/addresses/billing/${id}`,
+      undefined,
       expectedConfig,
     );
   });

--- a/packages/client/src/users/addresses/__tests__/putUserDefaultContactAddress.test.ts
+++ b/packages/client/src/users/addresses/__tests__/putUserDefaultContactAddress.test.ts
@@ -18,7 +18,7 @@ describe('putUserDefaultContactAddress', () => {
     mswServer.use(fixtures.success());
 
     await expect(putUserDefaultContactAddress(userId, id)).resolves.toBe(204);
-    expect(spy).toHaveBeenCalledWith(expectedUrl, expectedConfig);
+    expect(spy).toHaveBeenCalledWith(expectedUrl, undefined, expectedConfig);
   });
 
   it('should receive a client request error', async () => {
@@ -27,6 +27,6 @@ describe('putUserDefaultContactAddress', () => {
     await expect(
       putUserDefaultContactAddress(userId, id),
     ).rejects.toMatchSnapshot();
-    expect(spy).toHaveBeenCalledWith(expectedUrl, expectedConfig);
+    expect(spy).toHaveBeenCalledWith(expectedUrl, undefined, expectedConfig);
   });
 });

--- a/packages/client/src/users/addresses/__tests__/putUserDefaultShippingAddress.test.ts
+++ b/packages/client/src/users/addresses/__tests__/putUserDefaultShippingAddress.test.ts
@@ -23,6 +23,7 @@ describe('putUserDefaultShippingAddress', () => {
 
       expect(spy).toHaveBeenCalledWith(
         `/account/v1/users/${userId}/addresses/shipping/${id}`,
+        undefined,
         expectedConfig,
       );
     });
@@ -35,6 +36,7 @@ describe('putUserDefaultShippingAddress', () => {
       ).rejects.toMatchSnapshot();
       expect(spy).toHaveBeenCalledWith(
         `/account/v1/users/${userId}/addresses/shipping/${id}`,
+        undefined,
         expectedConfig,
       );
     });

--- a/packages/client/src/users/addresses/putUserDefaultBillingAddress.ts
+++ b/packages/client/src/users/addresses/putUserDefaultBillingAddress.ts
@@ -20,6 +20,7 @@ const putUserDefaultBillingAddress: PutUserDefaultBillingAddress = (
   client
     .put(
       join('/account/v1/users', userId, 'addresses/billing', addressId),
+      undefined,
       config,
     )
     .then(response => response.status)

--- a/packages/client/src/users/addresses/putUserDefaultContactAddress.ts
+++ b/packages/client/src/users/addresses/putUserDefaultContactAddress.ts
@@ -20,6 +20,7 @@ const putUserDefaultContactAddress: PutUserDefaultContactAddress = (
   client
     .put(
       join('/account/v1/users', userId, 'addresses/preferred', addressId),
+      undefined,
       config,
     )
     .then(response => response.status)

--- a/packages/client/src/users/addresses/putUserDefaultShippingAddress.ts
+++ b/packages/client/src/users/addresses/putUserDefaultShippingAddress.ts
@@ -20,6 +20,7 @@ const putUserDefaultShippingAddress: PutUserDefaultShippingAddress = (
   client
     .put(
       join('/account/v1/users', userId, 'addresses/shipping', addressId),
+      undefined,
       config,
     )
     .then(response => response.status)


### PR DESCRIPTION
## Description

This fixes the user addresses put requests that were specifying the incorrect arguments to the `axios.put` call.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

Closes #846 

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
