### PR TITLE
fix: fix fetchCheckoutOrderOperation action not being exported

### DIFF
--- a/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
@@ -639,6 +639,7 @@ Object {
   "fetchCheckoutOrderDetails": [Function],
   "fetchCheckoutOrderDetailsFactory": [Function],
   "fetchCheckoutOrderFactory": [Function],
+  "fetchCheckoutOrderOperation": [Function],
   "fetchCheckoutOrderOperationFactory": [Function],
   "fetchCheckoutOrderOperations": [Function],
   "fetchCheckoutOrderOperationsFactory": [Function],

--- a/packages/redux/src/checkout/actions/index.ts
+++ b/packages/redux/src/checkout/actions/index.ts
@@ -10,6 +10,7 @@ export { default as fetchCheckoutOrderContext } from './fetchCheckoutOrderContex
 export { default as fetchCheckoutOrderContexts } from './fetchCheckoutOrderContexts.js';
 export { default as fetchCheckoutOrderDetails } from './fetchCheckoutOrderDetails.js';
 export { default as fetchCheckoutOrderCharge } from './fetchCheckoutOrderCharge.js';
+export { default as fetchCheckoutOrderOperation } from './fetchCheckoutOrderOperation.js';
 export { default as fetchCheckoutOrderOperations } from './fetchCheckoutOrderOperations.js';
 export { default as fetchCollectPoints } from './fetchCollectPoints.js';
 export { default as fetchCheckoutOrderDeliveryBundleUpgrades } from './fetchCheckoutOrderDeliveryBundleUpgrades.js';


### PR DESCRIPTION
## Description

Added the export for `fetchCheckoutOrderOperation` action as it was not being exported and causes the applications that use it to fail.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
