### PR TITLE
fix: content metadata type

### DIFF
--- a/packages/client/src/contents/types/contents.types.ts
+++ b/packages/client/src/contents/types/contents.types.ts
@@ -46,14 +46,7 @@ export type ComponentType = {
 };
 
 export type ContentMetadata = {
-  custom?: {
-    id: string;
-    gender: string;
-    brand: string;
-    priceType: string;
-    category: string;
-    eventDate?: string;
-  };
+  custom?: Record<string, string>;
 };
 
 export type ContentEntry<T = ComponentType[]> = {

--- a/packages/redux/src/entities/types/contents.types.ts
+++ b/packages/redux/src/entities/types/contents.types.ts
@@ -4,9 +4,9 @@ import type {
   ContentMetadata,
 } from '@farfetch/blackout-client';
 
-export type CustomMetadataNormalized = Omit<
-  NonNullable<ContentMetadata['custom']>,
-  'eventDate'
+export type CustomMetadataNormalized = Record<
+  string,
+  string | number | null
 > & {
   eventDate: number | null;
 };


### PR DESCRIPTION
## Description

This fixes `ContentMetadata` type to be more flexible.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
