### PR TITLE
fix(analytics): remove analytics API consent dependency

### DIFF
--- a/packages/react/src/analytics/integrations/AnalyticsApi/AnalyticsApi.ts
+++ b/packages/react/src/analytics/integrations/AnalyticsApi/AnalyticsApi.ts
@@ -16,10 +16,17 @@ import {
 import { isArray, omit } from 'lodash-es';
 
 export default class AnalyticsAPI extends integrations.Integration<AnalyticsApiIntegrationOptions> {
-  static override [utils.CONSENT_CATEGORIES_PROPERTY] =
-    utils.DefaultConsentKeys.Marketing;
   private debugMode: boolean | undefined;
   private whitelisted: Array<string> | undefined;
+
+  /**
+   * Method to check if the integration is ready to be loaded.
+   *
+   * @returns If the integration is ready to be loaded.
+   */
+  static override shouldLoad() {
+    return true;
+  }
 
   /**
    * Creates an instance of Analytics Api integration.

--- a/packages/react/src/analytics/integrations/AnalyticsApi/__tests__/AnalyticsApi.test.ts
+++ b/packages/react/src/analytics/integrations/AnalyticsApi/__tests__/AnalyticsApi.test.ts
@@ -69,13 +69,14 @@ describe('AnalyticsApi Integration', () => {
     expect(AnalyticsApi.prototype).toBeInstanceOf(integrations.Integration);
   });
 
-  it('`shouldLoad` should return false if there is no user consent', () => {
-    expect(AnalyticsApi.shouldLoad({ marketing: false }, {})).toBe(false);
-    expect(AnalyticsApi.shouldLoad({}, {})).toBe(false);
-  });
-
-  it('`shouldLoad` should return true if there is user consent', () => {
+  it('`shouldLoad` should return always true', () => {
+    expect(AnalyticsApi.shouldLoad()).toBe(true);
+    // @ts-expect-error
+    expect(AnalyticsApi.shouldLoad({}, {})).toBe(true);
+    // @ts-expect-error
     expect(AnalyticsApi.shouldLoad({ marketing: true }, {})).toBe(true);
+    // @ts-expect-error
+    expect(AnalyticsApi.shouldLoad({ marketing: false }, {})).toBe(true);
   });
 
   describe('AnalyticsApi Instance', () => {


### PR DESCRIPTION
## Description
This PR removes the dependency of a marketing consent on the client-side Analytics API integration. 

The consent must be managed on the server side, as it is already passed to its endpoint along with all event data. We must only control the consent there and load the server-side integrations accordingly. 
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
