### PR TITLE
fix: fix social login actions

### DIFF
--- a/packages/react/src/authentication/hooks/__tests__/useSocialLogin.test.tsx
+++ b/packages/react/src/authentication/hooks/__tests__/useSocialLogin.test.tsx
@@ -1,5 +1,8 @@
 import { cleanup, renderHook } from '@testing-library/react';
-import { mockInitialState } from 'tests/__fixtures__/authentication/index.mjs';
+import {
+  mockInitialState,
+  mockResponse,
+} from 'tests/__fixtures__/authentication/index.mjs';
 import { mockStore } from '../../../../tests/helpers/index.js';
 import { postAccountLink, postSocialLogin } from '@farfetch/blackout-client';
 import { Provider } from 'react-redux';
@@ -24,15 +27,15 @@ jest.mock('@farfetch/blackout-client', () => {
 
   return {
     ...original,
-    postSocialLogin: jest.fn(() => Promise.resolve()),
-    postAccountLink: jest.fn(() => Promise.resolve()),
+    postSocialLogin: jest.fn(() => Promise.resolve(mockResponse)),
+    postAccountLink: jest.fn(() => Promise.resolve(mockResponse)),
   };
 });
 
 const genericMock = {
   actions: {
     createAccountLink: expect.any(Function),
-    login: expect.any(Function),
+    socialLogin: expect.any(Function),
   },
 };
 
@@ -61,19 +64,19 @@ describe('useSocialLogin', () => {
   });
 
   describe('actions', () => {
-    describe('login', () => {
-      it('should call `useSocialLogin` login action with config', async () => {
+    describe('socialLogin', () => {
+      it('should call `useSocialLogin` socialLogin action with config', async () => {
         const current = getRenderedHook(mockInitialState);
 
-        await current.actions.login(mockLoginData, mockConfig);
+        await current.actions.socialLogin(mockLoginData, mockConfig);
 
         expect(postSocialLogin).toHaveBeenCalledWith(mockLoginData, mockConfig);
       });
 
-      it('should call `useSocialLogin` login action without config', async () => {
+      it('should call `useSocialLogin` socialLogin action without config', async () => {
         const current = getRenderedHook(mockInitialState);
 
-        await current.actions.login(mockLoginData);
+        await current.actions.socialLogin(mockLoginData);
 
         expect(postSocialLogin).toHaveBeenCalledWith(mockLoginData, undefined);
       });

--- a/packages/react/src/authentication/hooks/useSocialLogin.ts
+++ b/packages/react/src/authentication/hooks/useSocialLogin.ts
@@ -5,23 +5,23 @@ import {
 } from '@farfetch/blackout-client';
 import {
   createAccountLink as createAccountLinkAction,
-  socialLogin as socialLoginAction,
+  socialLogin as socialLoginReduxAction,
 } from '@farfetch/blackout-redux';
 import { useCallback } from 'react';
 import useAction from '../../helpers/useAction.js';
 
 function useSocialLogin() {
-  const socialLogin = useAction(socialLoginAction);
+  const socialLoginAction = useAction(socialLoginReduxAction);
   const accountLink = useAction(createAccountLinkAction);
-  const login = useCallback(
+  const socialLogin = useCallback(
     async (data: PostSocialLoginData, config?: Config) => {
       if (!data) {
         return Promise.reject(new Error('No data was specified.'));
       }
 
-      return await socialLogin(data, config);
+      return await socialLoginAction(data, config);
     },
-    [socialLogin],
+    [socialLoginAction],
   );
 
   const createAccountLink = useCallback(
@@ -37,7 +37,7 @@ function useSocialLogin() {
 
   return {
     actions: {
-      login,
+      socialLogin,
       createAccountLink,
     },
   };

--- a/packages/redux/src/users/authentication/actions/__tests__/__snapshots__/createAccountLink.test.ts.snap
+++ b/packages/redux/src/users/authentication/actions/__tests__/__snapshots__/createAccountLink.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     "entities": Object {
       "user": Object {},
     },
+    "result": undefined,
   },
   "type": "@farfetch/blackout-redux/CREATE_ACCOUNT_LINK_SUCCESS",
 }

--- a/packages/redux/src/users/authentication/actions/__tests__/__snapshots__/socialLogin.test.ts.snap
+++ b/packages/redux/src/users/authentication/actions/__tests__/__snapshots__/socialLogin.test.ts.snap
@@ -29,6 +29,7 @@ Object {
         "wishlistId": "1e5232f8-7af0-4fba-b6b1-b87e2cb3a88f",
       },
     },
+    "result": 29556478,
   },
   "type": "@farfetch/blackout-redux/SOCIAL_LOGIN_SUCCESS",
 }

--- a/packages/redux/src/users/authentication/actions/__tests__/socialLogin.test.ts
+++ b/packages/redux/src/users/authentication/actions/__tests__/socialLogin.test.ts
@@ -1,6 +1,6 @@
 import * as actionTypes from '../../actionTypes.js';
 import {
-  expectedNormalizedSocialLoginPayload,
+  expectedNormalizedPayload,
   mockResponse,
 } from 'tests/__fixtures__/authentication/index.mjs';
 import { find } from 'lodash-es';
@@ -71,7 +71,7 @@ describe('socialLogin() action creator', () => {
       { type: actionTypes.SOCIAL_LOGIN_REQUEST },
       {
         type: actionTypes.SOCIAL_LOGIN_SUCCESS,
-        payload: expectedNormalizedSocialLoginPayload,
+        payload: expectedNormalizedPayload,
       },
     ]);
     expect(

--- a/packages/redux/src/users/authentication/actions/factories/createAccountLinkFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/createAccountLinkFactory.ts
@@ -27,6 +27,7 @@ const createAccountLinkFactory =
       const user = result;
       const userEntity = {
         entities: { user },
+        result: result.id,
       };
 
       dispatch({

--- a/packages/redux/src/users/authentication/actions/factories/socialLoginFactory.ts
+++ b/packages/redux/src/users/authentication/actions/factories/socialLoginFactory.ts
@@ -30,6 +30,7 @@ const socialLoginFactory =
 
       const userEntity = {
         entities: { user },
+        result: result.id,
       };
 
       await dispatch({


### PR DESCRIPTION
## Description
This fixes socialLogin and createAccountLink actions that were missing user id. Also, it renames useSocialLogin action from login to socialLogin, in order to prevent issues with the usual login action.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
