### PR TITLE
feat: add parameters to payment info added event

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -124,6 +124,8 @@ export const customTrackMockData = {
     deliveryType: 'Standard/Standard',
     interactionType: 'click',
     paymentType: 'credit',
+    checkoutOrderId: 12345678,
+    orderId: 'ABC12',
   },
   [eventTypes.SHIPPING_METHOD_ADDED]: {
     step: '2',

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -559,6 +559,7 @@ export const trackEventsMapper = {
     promocode: data.properties.coupon,
   }),
   [eventTypes.PAYMENT_INFO_ADDED]: data => ({
+    ...getCheckoutEventGenericProperties(data, true),
     ...getCommonCheckoutStepTrackingData(data),
     tid: 2912,
     selectedPaymentMethod: data.properties?.paymentType,

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -142,6 +142,8 @@ Object {
   "checkoutStep": "1",
   "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\"}",
   "interactionType": "click",
+  "orderCode": "ABC12",
+  "orderId": 12345678,
   "selectedPaymentMethod": "credit",
   "tid": 2912,
 }

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.js
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.js
@@ -299,6 +299,7 @@ const getCheckoutParametersFromEvent = eventProperties => {
     currency: eventProperties.currency,
     coupon: eventProperties.coupon,
     items,
+    transaction_id: eventProperties.orderId,
     value: eventProperties.total,
   };
 };
@@ -315,7 +316,6 @@ const getCheckoutStartedParametersFromEvent = eventProperties => {
     ...getCheckoutParametersFromEvent(eventProperties),
     checkout_step: eventProperties.step,
     delivery_type: eventProperties.deliveryType,
-    transaction_id: eventProperties.orderId,
     payment_type: eventProperties.paymentType,
     packaging_type: eventProperties.packagingType,
     shipping_tier: eventProperties.shippingTier,
@@ -367,7 +367,6 @@ const getCheckoutShippingStepParametersFromEvent = eventProperties => {
 const getDeliveryMethodAddedParametersFromEvent = eventProperties => {
   return {
     ...getCheckoutParametersFromEvent(eventProperties),
-    transaction_id: eventProperties.orderId,
     shipping_tier: eventProperties.shippingTier,
     delivery_type: eventProperties.deliveryType,
     packaging_type: eventProperties.packagingType,
@@ -427,7 +426,6 @@ const getShippingInfoAddedParametersFromEvent = eventProperties => {
     delivery_type: eventProperties.deliveryType,
     packaging_type: eventProperties.packagingType,
     checkout_step: eventProperties.step,
-    transaction_id: eventProperties.orderId,
   };
 };
 
@@ -523,7 +521,6 @@ const getLoginAndSignupParametersFromEvent = eventProperties => {
 const getOrderPurchaseOrRefundGenericParametersFromEvent = eventProperties => {
   return {
     ...getCheckoutParametersFromEvent(eventProperties),
-    transaction_id: eventProperties.orderId,
     affiliation: eventProperties.affiliation,
     shipping: eventProperties.shipping,
     tax: eventProperties.tax,

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
@@ -498,6 +498,7 @@ Array [
       "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
       "path_clean": "/pt/",
       "payment_type": "credit card",
+      "transaction_id": "50314b8e9bcf000000000000",
       "value": 24.64,
     },
   ],


### PR DESCRIPTION
## Description

- Add checkout_order_id (omni) and transaction_id (ga4) to payment_info_added event
- Updated unit tests as well.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
