### PR TITLE
feat: add parameters to payment info added event

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -130,9 +130,11 @@ Object {
 
 exports[`Omnitracking track events definitions \`Payment Info Added\` return should match the snapshot 1`] = `
 Object {
+  "checkoutOrderId": 15338048,
   "checkoutStep": undefined,
   "deliveryInformationDetails": undefined,
   "interactionType": undefined,
+  "orderCode": "50314b8e9bcf000000000000",
   "selectedPaymentMethod": "credit card",
   "tid": 2912,
 }

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -513,6 +513,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     checkoutStep: data.properties?.step,
   }),
   [EventType.PaymentInfoAdded]: data => ({
+    ...getCheckoutEventGenericProperties(data),
     ...getCommonCheckoutStepTrackingData(data),
     tid: 2912,
   }),

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -595,6 +595,7 @@ Array [
       "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
       "path_clean": "/en-pt/",
       "payment_type": "credit card",
+      "transaction_id": "50314b8e9bcf000000000000",
       "value": 24.64,
     },
   ],

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.ts
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.ts
@@ -328,6 +328,7 @@ const getCheckoutParametersFromEvent = (eventProperties: EventProperties) => {
     coupon: eventProperties.coupon,
     items,
     value: eventProperties.total,
+    transaction_id: eventProperties.orderId,
   };
 };
 
@@ -345,7 +346,6 @@ const getCheckoutStartedParametersFromEvent = (
     ...getCheckoutParametersFromEvent(eventProperties),
     checkout_step: eventProperties.step,
     delivery_type: eventProperties.deliveryType,
-    transaction_id: eventProperties.orderId,
     payment_type: eventProperties.paymentType,
     packaging_type: eventProperties.packagingType,
     shipping: eventProperties.shipping,
@@ -411,7 +411,6 @@ const getDeliveryMethodAddedParametersFromEvent = (
 ) => {
   return {
     ...getCheckoutParametersFromEvent(eventProperties),
-    transaction_id: eventProperties.orderId,
     shipping_tier: eventProperties.shippingTier,
     delivery_type: eventProperties.deliveryType,
     packaging_type: eventProperties.packagingType,
@@ -478,7 +477,6 @@ const getShippingInfoAddedParametersFromEvent = (
     delivery_type: eventProperties.deliveryType,
     packaging_type: eventProperties.packagingType,
     checkout_step: eventProperties.step,
-    transaction_id: eventProperties.orderId,
   };
 };
 
@@ -578,7 +576,6 @@ const getOrderPurchaseOrRefundGenericParametersFromEvent = (
 ) => {
   return {
     ...getCheckoutParametersFromEvent(eventProperties),
-    transaction_id: eventProperties.orderId,
     affiliation: eventProperties.affiliation,
     shipping: eventProperties.shipping,
     tax: eventProperties.tax,

--- a/tests/__fixtures__/analytics/track/paymentInfoAddedTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/paymentInfoAddedTrackData.fixtures.mts
@@ -5,6 +5,7 @@ const fixtures = {
   ...baseTrackData,
   event: EventType.PaymentInfoAdded,
   properties: {
+    checkoutOrderId: 15338048,
     orderId: '50314b8e9bcf000000000000',
     total: 24.64,
     shipping: 3.6,


### PR DESCRIPTION
## Description

- Add checkout_order_id (omni) and transaction_id (ga4) to payment_info_added event
- Updated unit tests as well.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
