### PR TITLE
feat: add site performance measuring event to analytics to `v1`

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -243,6 +243,13 @@ export const customTrackMockData = {
     id: '123',
     productId: '12345',
   },
+  [eventTypes.SITE_PERFORMANCE]: {
+    performanceStats: {
+      ttfb: 766.2,
+      dcl: 2716.1,
+      fp: 1545.1,
+    },
+  },
   [eventTypes.PRODUCT_LIST_VIEWED]: {
     category: 'Clothing',
     list: 'Woman shopping',

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -771,6 +771,20 @@ export const trackEventsMapper = {
 
     return eventList;
   },
+  [eventTypes.SITE_PERFORMANCE]: data => {
+    const performanceStats = data?.properties?.performanceStats;
+    if (performanceStats && typeof performanceStats === 'object') {
+      return {
+        tid: 1217,
+        performanceTimings: JSON.stringify(performanceStats),
+      };
+    }
+
+    logger.error(
+      `[Omnitracking] - Event "${data.event}": To track this event, a valid "performanceStats" property should be added to the payload.`,
+    );
+    return;
+  },
 };
 
 /**

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -346,6 +346,41 @@ describe('Omnitracking', () => {
       });
 
       describe('Event Tracking', () => {
+        describe('Site Performance', () => {
+          it('should not track "Site Performance" event if the required parameters are missing', async () => {
+            const data = generateTrackMockData({
+              event: eventTypes.SITE_PERFORMANCE,
+              properties: {
+                performanceStats: undefined,
+              },
+            });
+            await omnitracking.track(data);
+
+            expect(mockLoggerError).toHaveBeenCalledWith(
+              expect.stringContaining(
+                'To track this event, a valid "performanceStats" property should be added to the payload.',
+              ),
+            );
+            expect(postTrackingsSpy).toHaveBeenCalledTimes(0);
+          });
+
+          it('should not track "Site Performance"event if the required parameters have the wrong type', async () => {
+            const data = generateTrackMockData({
+              event: eventTypes.SITE_PERFORMANCE,
+              properties: {
+                performanceStats: 'wrong value',
+              },
+            });
+            await omnitracking.track(data);
+
+            expect(mockLoggerError).toHaveBeenCalledWith(
+              expect.stringContaining(
+                'To track this event, a valid "performanceStats" property should be added to the payload.',
+              ),
+            );
+            expect(postTrackingsSpy).toHaveBeenCalledTimes(0);
+          });
+        });
         describe('Interact Content', () => {
           it('should not track an interact content event if the required parameters are missing', async () => {
             const data = generateTrackMockData({

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -339,6 +339,13 @@ Object {
 }
 `;
 
+exports[`Omnitracking definitions \`Site Performance\` return should match the snapshot 1`] = `
+Object {
+  "performanceTimings": "{\\"ttfb\\":766.2,\\"dcl\\":2716.1,\\"fp\\":1545.1}",
+  "tid": 1217,
+}
+`;
+
 exports[`Omnitracking definitions \`bag\` return should match the snapshot 1`] = `
 Object {
   "basketQuantity": 8,

--- a/packages/core/src/analytics/types/__tests__/__snapshots__/eventTypes.test.js.snap
+++ b/packages/core/src/analytics/types/__tests__/__snapshots__/eventTypes.test.js.snap
@@ -37,5 +37,6 @@ Object {
   "SIGNUP_FORM_COMPLETED": "Sign-up Form Completed",
   "SIGNUP_FORM_VIEWED": "Sign-up Form Viewed",
   "SIGNUP_NEWSLETTER": "Sign-up Newsletter",
+  "SITE_PERFORMANCE": "Site Performance",
 }
 `;

--- a/packages/core/src/analytics/types/eventTypes.js
+++ b/packages/core/src/analytics/types/eventTypes.js
@@ -79,4 +79,6 @@ export default {
   SIGNUP_FORM_VIEWED: 'Sign-up Form Viewed',
   /** Signup Newsletter should be tracked when the user signs-up the newsletter. */
   SIGNUP_NEWSLETTER: 'Sign-up Newsletter',
+  /** Track the performance of the site. */
+  SITE_PERFORMANCE: 'Site Performance',
 };


### PR DESCRIPTION
## Description

Add new event to analytics: Site Performance.
- Add compatibility to omnitracking;

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
