### PR TITLE
feat: add site performance measuring event to analytics for `main`

### DIFF
--- a/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/analytics/src/__tests__/__snapshots__/index.test.ts.snap
@@ -38,6 +38,7 @@ Object {
     "SignupFormCompleted": "Sign-up Form Completed",
     "SignupFormViewed": "Sign-up Form Viewed",
     "SignupNewsletter": "Sign-up Newsletter",
+    "SitePerformance": "Site Performance",
   },
   "FromParameterType": Object {
     "Bag": "Bag",

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/Omnitracking.test.ts
@@ -527,6 +527,44 @@ describe('Omnitracking', () => {
       );
     });
 
+    describe('Site Performance', () => {
+      it('should not track "Site Performance" event if the required parameters are missing', async () => {
+        const data = generateTrackMockData({
+          event: EventType.SitePerformance,
+          properties: {
+            performanceStats: undefined,
+          },
+        });
+
+        await omnitracking.track(data);
+
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'To track this event, a valid "performanceStats" property should be added to the payload.',
+          ),
+        );
+        expect(postTrackingSpy).not.toHaveBeenCalled();
+      });
+
+      it('should not track "Site Performance"event if the required parameters have the wrong type', async () => {
+        const data = generateTrackMockData({
+          event: EventType.SitePerformance,
+          properties: {
+            performanceStats: 'wrong value',
+          },
+        });
+
+        await omnitracking.track(data);
+
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'To track this event, a valid "performanceStats" property should be added to the payload.',
+          ),
+        );
+        expect(postTrackingSpy).not.toHaveBeenCalled();
+      });
+    });
+
     describe('select content', () => {
       const expectedErrorMessage =
         'properties "contentType" and "id" should be sent';

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -317,6 +317,13 @@ Object {
 }
 `;
 
+exports[`Omnitracking track events definitions \`Site Performance\` return should match the snapshot 1`] = `
+Object {
+  "performanceTimings": "{\\"ttfb\\":766.2,\\"dcl\\":2716.1,\\"fp\\":1545.1,\\"fcp\\":1545.2,\\"lcp\\":1838.8,\\"plt\\":3166.2,\\"fid\\":2,\\"cls\\":0.008834942534125895,\\"tlt\\":13244,\\"tbt\\":6594,\\"fltst\\":1591.4,\\"fltd\\":124,\\"loltst\\":1907.9,\\"loltd\\":812,\\"lltst\\":250539.2,\\"lltd\\":126,\\"nlt\\":133,\\"top\\":252654}",
+  "tid": 1217,
+}
+`;
+
 exports[`Omnitracking track events definitions \`bag\` return should match the snapshot 1`] = `
 Object {
   "basketQuantity": 1,

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -764,6 +764,22 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
 
     return eventList;
   },
+  [EventType.SitePerformance]: (data: EventData<TrackTypesValues>) => {
+    const performanceStats = data?.properties?.performanceStats;
+
+    if (performanceStats && typeof performanceStats === 'object') {
+      return {
+        tid: 1217,
+        performanceTimings: JSON.stringify(data.properties.performanceStats),
+      };
+    }
+
+    logger.error(
+      `[Omnitracking] - Event "${data.event}": To track this event, a valid "performanceStats" property should be added to the payload.`,
+    );
+
+    return;
+  },
 } as const;
 
 /**

--- a/packages/analytics/src/types/EventType.ts
+++ b/packages/analytics/src/types/EventType.ts
@@ -158,6 +158,10 @@ enum EventType {
    * Signup Newsletter should be tracked when the user signs-up the newsletter.
    */
   SignupNewsletter = 'Sign-up Newsletter',
+  /**
+   * Track the performance of the site.
+   */
+  SitePerformance = 'Site Performance',
 }
 
 export default EventType;

--- a/packages/analytics/src/types/__tests__/__snapshots__/EventType.test.ts.snap
+++ b/packages/analytics/src/types/__tests__/__snapshots__/EventType.test.ts.snap
@@ -37,5 +37,6 @@ Object {
   "SignupFormCompleted": "Sign-up Form Completed",
   "SignupFormViewed": "Sign-up Form Viewed",
   "SignupNewsletter": "Sign-up Newsletter",
+  "SitePerformance": "Site Performance",
 }
 `;

--- a/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/index.test.ts.snap
@@ -58,6 +58,7 @@ Object {
     "SignupFormCompleted": "Sign-up Form Completed",
     "SignupFormViewed": "Sign-up Form Viewed",
     "SignupNewsletter": "Sign-up Newsletter",
+    "SitePerformance": "Site Performance",
   },
   "FromParameterType": Object {
     "Bag": "Bag",

--- a/tests/__fixtures__/analytics/track/index.mts
+++ b/tests/__fixtures__/analytics/track/index.mts
@@ -38,6 +38,7 @@ import shippingMethodAddedTrackData from './shippingMethodAddedTrackData.fixture
 import signupFormCompletedTrackData from './signupFormCompletedTrackData.fixtures.mjs';
 import signupFormViewedTrackData from './signupFormViewedTrackData.fixtures.mjs';
 import signupNewsletterTrackData from './signupNewsletterTrackData.fixtures.mjs';
+import sitePerformanceTrackData from './sitePerformanceTrackData.fixtures.mjs';
 
 export type TrackFixtures = {
   [eventType in EventType]: EventData<TrackType> & {
@@ -81,6 +82,7 @@ const allFixtures: TrackFixtures = {
   [EventType.SignupFormCompleted]: signupFormCompletedTrackData,
   [EventType.SignupFormViewed]: signupFormViewedTrackData,
   [EventType.SignupNewsletter]: signupNewsletterTrackData,
+  [EventType.SitePerformance]: sitePerformanceTrackData,
 };
 
 export default allFixtures;

--- a/tests/__fixtures__/analytics/track/sitePerformanceTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/sitePerformanceTrackData.fixtures.mts
@@ -1,0 +1,31 @@
+import { EventType } from '@farfetch/blackout-analytics';
+import baseTrackData from './baseTrackData.fixtures.mjs';
+
+const fixtures = {
+  ...baseTrackData,
+  event: EventType.SitePerformance,
+  properties: {
+    performanceStats: {
+      ttfb: 766.2,
+      dcl: 2716.1,
+      fp: 1545.1,
+      fcp: 1545.2,
+      lcp: 1838.8,
+      plt: 3166.2,
+      fid: 2,
+      cls: 0.008834942534125895,
+      tlt: 13244,
+      tbt: 6594,
+      fltst: 1591.4,
+      fltd: 124,
+      loltst: 1907.9,
+      loltd: 812,
+      lltst: 250539.2,
+      lltd: 126,
+      nlt: 133,
+      top: 252654,
+    },
+  },
+};
+
+export default fixtures;


### PR DESCRIPTION
## Description

Add new event to analytics: Site Performance.
- Add compatibility to omnitracking;

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
