### PR TITLE
feat: add parameters to interact content event for `v1`

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -647,6 +647,7 @@ export const trackEventsMapper = {
         return {
           tid: 668,
           scrollDepth: properties.percentageScrolled,
+          pageNumber: data.properties?.pageNumber,
         };
 
       return;

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -383,6 +383,29 @@ describe('Omnitracking', () => {
               }),
             );
           });
+
+          it('should track scroll event and deal with endless scroll feature', async () => {
+            const data = generateTrackMockData({
+              event: eventTypes.INTERACT_CONTENT,
+              properties: {
+                interactionType: interactionTypes.SCROLL,
+                target: document.body,
+                percentageScrolled: 100,
+                pageNumber: 2,
+              },
+            });
+            await omnitracking.track(data);
+
+            expect(postTrackingsSpy).toHaveBeenCalledWith(
+              expect.objectContaining({
+                parameters: expect.objectContaining({
+                  tid: 668,
+                  scrollDepth: 100,
+                  pageNumber: 2,
+                }),
+              }),
+            );
+          });
         });
 
         it('should not track an event when interactionType is scroll but target is not document.body', async () => {

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.js
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.js
@@ -748,6 +748,7 @@ const getSignupNewsletterParametersFromEvent = eventProperties => {
 const getScrollParametersFromEvent = eventProperties => {
   return {
     percent_scrolled: eventProperties.percentageScrolled,
+    page_number: eventProperties.pageNumber,
   };
 };
 

--- a/packages/react/src/analytics/integrations/__tests__/GA4.test.js
+++ b/packages/react/src/analytics/integrations/__tests__/GA4.test.js
@@ -1452,7 +1452,8 @@ describe('GA4 Integration', () => {
 
           clonedEvent.properties.interactionType = interactionTypes.SCROLL;
           clonedEvent.properties.target = document.body;
-          clonedEvent.properties.percentageScrolled = 25;
+          clonedEvent.properties.percentageScrolled = 100;
+          clonedEvent.properties.pageNumber = 2;
 
           await ga4Instance.track(clonedEvent);
 

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
@@ -1096,9 +1096,10 @@ Array [
     Object {
       "analytics_package_version": "0.1.0",
       "blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "page_number": 2,
       "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",
       "path_clean": "/pt/",
-      "percent_scrolled": 25,
+      "percent_scrolled": 100,
     },
   ],
 ]


### PR DESCRIPTION


## Description

- add new parameter `page number` for cases of endlessScrolling in interact content events (scrolling)

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
