### PR TITLE
feat: add isMainWishlist parameter to `main`

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -165,6 +165,7 @@ Object {
 exports[`Omnitracking track events definitions \`Product Added to Wishlist\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "Plp",
+  "isMainWishlist": true,
   "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":2}]",
   "listIndex": 2,
   "moduleId": "[\\"/en-pt/shopping/woman\\"]",
@@ -200,6 +201,7 @@ Object {
 exports[`Omnitracking track events definitions \`Product Removed From Wishlist\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "Plp",
+  "isMainWishlist": true,
   "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":2}]",
   "listIndex": 2,
   "moduleId": "[\\"/en-pt/shopping/woman\\"]",

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -549,6 +549,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     wishlistId: data.properties?.wishlistId,
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
+    isMainWishlist: data.properties?.isMainWishlist,
     ...getRecommendationsTrackingData(data),
   }),
   [EventType.ProductRemovedFromWishlist]: (
@@ -558,6 +559,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     actionArea: data.properties?.from,
     priceCurrency: data.properties?.currency,
     wishlistId: data.properties?.wishlistId,
+    isMainWishlist: data.properties?.isMainWishlist,
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
     ...getRecommendationsTrackingData(data),

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -82,6 +82,7 @@ Array [
       "currency": "USD",
       "from": "Bag",
       "index": undefined,
+      "is_main_wishlist": undefined,
       "item_list_id": "e0030b3c-b970-4496-bc72-f9a38d6270b1",
       "item_list_name": "Bag",
       "items": Array [
@@ -637,6 +638,7 @@ Array [
       "currency": "USD",
       "from": "Wishlist",
       "index": 2,
+      "is_main_wishlist": undefined,
       "item_list_id": "d3618128-5aa9-4caa-a452-1dd1377a6190",
       "item_list_name": "my_wishlist",
       "items": Array [
@@ -680,6 +682,7 @@ Array [
       "currency": "USD",
       "from": "Plp",
       "index": 2,
+      "is_main_wishlist": true,
       "item_list_id": "/en-pt/shopping/woman",
       "item_list_name": "Woman shopping",
       "items": Array [
@@ -820,6 +823,7 @@ Array [
       "discount": 6,
       "from": "Plp",
       "index": 2,
+      "is_main_wishlist": true,
       "item_brand": "Just A T-Shirt",
       "item_category": "Clothing",
       "item_category2": "Tops",
@@ -854,6 +858,7 @@ Array [
       "currency": "USD",
       "from": "Bag",
       "index": 1,
+      "is_main_wishlist": undefined,
       "item_list_id": "e0030b3c-b970-4496-bc72-f9a38d6270b1",
       "item_list_name": "Bag",
       "items": Array [

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.ts
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.ts
@@ -267,6 +267,7 @@ const getPrePurchaseParametersFromEvent = (
     item_list_name: eventProperties.list,
     wishlist_name: eventProperties.wishlist,
     wishlist_id: eventProperties.wishlistId,
+    is_main_wishlist: eventProperties.isMainWishlist,
     items,
     value: getEventTotalValue(eventProperties, items),
     index: eventProperties.position,
@@ -308,6 +309,7 @@ const getProductRemovedFromWishlist = (eventProperties: EventProperties) => {
     wishlist_name: eventProperties.wishlist,
     wishlist_id: eventProperties.wishlistId,
     index: eventProperties.position,
+    is_main_wishlist: eventProperties.isMainWishlist,
     value: getEventTotalValue(eventProperties, new Array(productParameters)),
     ...productParameters,
   };

--- a/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.ts
+++ b/packages/react/src/analytics/integrations/GA4/validation/eventSchemas.ts
@@ -132,6 +132,10 @@ const sortOptionSchema = yup.object({
   sortOption: yup.string().notRequired(),
 });
 
+const isMainWishlistSchema = yup.object({
+  isMainWishlist: yup.boolean().notRequired(),
+});
+
 const viewItemSchema = fullProductSchema.concat(imageCountSchema);
 
 const viewItemListSchema = productsSchema
@@ -168,8 +172,9 @@ const manageProductInCartSchema = fromSchema
   .concat(currencyRequiredSchema)
   .concat(productUpdatesInCartWishlistSchema);
 
-const manageProductInWishlistSchema =
-  manageProductInCartSchema.concat(wishlistIdSchema);
+const manageProductInWishlistSchema = manageProductInCartSchema
+  .concat(wishlistIdSchema)
+  .concat(isMainWishlistSchema);
 
 const productUpdatedSchema = fromSchema.concat(productRequiredSchema).concat(
   yup.object({

--- a/packages/redux/src/analytics/middlewares/__tests__/wishlist.test.ts
+++ b/packages/redux/src/analytics/middlewares/__tests__/wishlist.test.ts
@@ -84,6 +84,7 @@ const currencyCode = 'USD';
 const listId = 'related_products';
 const list = 'Related products';
 const wishlistName = 'my_wishlist';
+const isMainWishlist = true;
 const getMockState = (data: Record<string, unknown> = {}): StoreState =>
   merge({}, wishlistMockData.state, data);
 
@@ -288,6 +289,7 @@ describe('analyticsWishlistMiddleware', () => {
               wishlistMockData.wishListItemId
             ]?.size.scale,
           value,
+          isMainWishlist,
         },
       });
 
@@ -314,6 +316,7 @@ describe('analyticsWishlistMiddleware', () => {
         variant: colorName,
         wishlistId: wishlistMockData.wishlistId,
         locationId: expect.any(String),
+        isMainWishlist,
       });
     });
   });
@@ -342,6 +345,7 @@ describe('analyticsWishlistMiddleware', () => {
           position,
           productId: wishlistMockData.productId,
           wishlistItemId: wishlistMockData.wishListItemId,
+          isMainWishlist,
         },
       });
 
@@ -370,6 +374,7 @@ describe('analyticsWishlistMiddleware', () => {
           variant: colorName,
           wishlistId: wishlistMockData.wishlistId,
           locationId: expect.any(String),
+          isMainWishlist,
         },
       );
     });
@@ -400,6 +405,7 @@ describe('analyticsWishlistMiddleware', () => {
             listId,
             position,
             wishlistSetId,
+            isMainWishlist,
           },
         });
 
@@ -428,6 +434,7 @@ describe('analyticsWishlistMiddleware', () => {
             variant: colorName,
             wishlistId: wishlistSetId,
             locationId: expect.any(String),
+            isMainWishlist,
           },
         );
       });
@@ -447,6 +454,7 @@ describe('analyticsWishlistMiddleware', () => {
             position,
             wishlistSetId,
             wishlistItemId: wishlistMockData.wishListItemId,
+            isMainWishlist,
           },
         });
 
@@ -475,6 +483,7 @@ describe('analyticsWishlistMiddleware', () => {
             variant: colorName,
             wishlistId: wishlistSetId,
             locationId: expect.any(String),
+            isMainWishlist,
           },
         );
       });
@@ -569,6 +578,7 @@ describe('analyticsWishlistMiddleware', () => {
             listId,
             position,
             wishlistSetId,
+            isMainWishlist,
           },
         });
 
@@ -597,6 +607,7 @@ describe('analyticsWishlistMiddleware', () => {
             variant: colorName,
             wishlistId: wishlistSetId,
             locationId: expect.any(String),
+            isMainWishlist,
           },
         );
       });
@@ -616,6 +627,7 @@ describe('analyticsWishlistMiddleware', () => {
             position,
             wishlistSetId,
             wishlistItemId: wishlistMockData.wishListItemId,
+            isMainWishlist,
           },
         });
 
@@ -644,6 +656,7 @@ describe('analyticsWishlistMiddleware', () => {
             variant: colorName,
             wishlistId: wishlistSetId,
             locationId: expect.any(String),
+            isMainWishlist,
           },
         );
       });

--- a/packages/redux/src/analytics/middlewares/wishlist.ts
+++ b/packages/redux/src/analytics/middlewares/wishlist.ts
@@ -121,6 +121,7 @@ const getWishlistData = (
     list: get(action, 'meta.list'),
     listId: get(action, 'meta.listId'),
     position: get(action, 'meta.position'),
+    isMainWishlist: get(action, 'meta.isMainWishlist'),
     value:
       get(action, 'meta.value') || get(wishlistItem, 'price.includingTaxes'),
   };

--- a/packages/redux/src/wishlists/types/actions.types.ts
+++ b/packages/redux/src/wishlists/types/actions.types.ts
@@ -33,6 +33,7 @@ export type WishlistItemActionMetadata = {
   coupon?: string;
   position?: number;
   value?: number;
+  isMainWishlist?: boolean;
 } & Record<string, unknown>;
 
 export type WishlistSetsNormalizedPayload = NormalizedSchema<

--- a/tests/__fixtures__/analytics/track/productAddedToWishlistTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/productAddedToWishlistTrackData.fixtures.mts
@@ -19,6 +19,7 @@ const fixtures = {
     position: 2,
     listId: '/en-pt/shopping/woman',
     wishlistId: 'd3618128-5aa9-4caa-a452-1dd1377a6190',
+    isMainWishlist: true,
   },
 };
 

--- a/tests/__fixtures__/analytics/track/productRemovedFromWishlistTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/productRemovedFromWishlistTrackData.fixtures.mts
@@ -19,6 +19,7 @@ const fixtures = {
     priceWithoutDiscount: 25,
     currency: 'USD',
     wishlistId: 'd3618128-5aa9-4caa-a452-1dd1377a6190',
+    isMainWishlist: true,
   },
 };
 

--- a/tests/__fixtures__/analytics/track/productUpdatedWishlistTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/productUpdatedWishlistTrackData.fixtures.mts
@@ -17,6 +17,7 @@ const fixtures = {
     currency: 'USD',
     list: 'my_wishlist',
     listId: 'd3618128-5aa9-4caa-a452-1dd1377a6190',
+    isMainWishlist: true,
   },
 };
 


### PR DESCRIPTION
## Description

- Add isMainWishlist parameter to wishlist related events
- Updated unit tests as well

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
