### PR TITLE
feat: add checkout step to analytics events `v1`

### DIFF
--- a/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
+++ b/packages/core/src/analytics/__fixtures__/trackData.fixtures.js
@@ -90,6 +90,7 @@ export const customTrackMockData = {
   [eventTypes.PLACE_ORDER_STARTED]: {
     orderId: 'ABC12',
     coupon: 'promo',
+    step: 1,
   },
   [eventTypes.ORDER_COMPLETED]: {
     orderId: 'ABC12',

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -473,6 +473,7 @@ export const trackEventsMapper = {
         ...getCheckoutEventGenericProperties(data),
         promocode: data.properties.coupon,
         shippingTotalValue: data.properties?.shipping,
+        checkoutStep: data.properties?.step,
       },
     ];
   },

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -156,6 +156,7 @@ Array [
     "val": "{\\"type\\":\\"TRANSACTION\\",\\"paymentAttemptReferenceId\\":\\"d9864a1c112d-47ff-8ee4-968c-5acecae23_1567010265879\\"}",
   },
   Object {
+    "checkoutStep": 1,
     "orderCode": "ABC12",
     "promocode": "promo",
     "shippingTotalValue": 10,

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.js
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.js
@@ -340,6 +340,7 @@ const getCheckoutPaymentStepParametersFromEvent = eventProperties => {
   return {
     ...getCheckoutParametersFromEvent(eventProperties),
     payment_type: eventProperties.paymentType,
+    checkout_step: eventProperties.step,
   };
 };
 
@@ -571,6 +572,7 @@ const getPlaceOrderStartedParametersFromEvent = eventProperties => {
     affiliation: eventProperties.affiliation,
     shipping: eventProperties.shipping,
     tax: eventProperties.tax,
+    checkout_step: eventProperties.step,
   };
 };
 

--- a/packages/react/src/analytics/integrations/__fixtures__/gaData.fixtures.js
+++ b/packages/react/src/analytics/integrations/__fixtures__/gaData.fixtures.js
@@ -309,6 +309,7 @@ const validTrackEvents = {
       coupon: 'HARRODS2019',
       paymentType: 'credit card',
       currency: 'USD',
+      step: 1,
       products: [
         {
           id: '507f1f77bcf86cd799439011',
@@ -488,6 +489,7 @@ const validTrackEvents = {
       tax: 2.04,
       coupon: 'HARRODS2019',
       currency: 'USD',
+      step: 1,
     },
   },
 

--- a/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
+++ b/packages/react/src/analytics/integrations/__tests__/__snapshots__/GA4.test.js.snap
@@ -471,6 +471,7 @@ Array [
     Object {
       "analytics_package_version": "0.1.0",
       "blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "checkout_step": 1,
       "coupon": "HARRODS2019",
       "currency": "USD",
       "items": Array [
@@ -514,6 +515,7 @@ Array [
       "affiliation": undefined,
       "analytics_package_version": "0.1.0",
       "blackoutAnalyticsEventId": "111945ad-b9d4-4c21-b3b0-2764b31bd1111",
+      "checkout_step": 1,
       "coupon": "HARRODS2019",
       "currency": "USD",
       "page_path": "/pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",


### PR DESCRIPTION
## Description

- Added checkout step parameter to two analytics events (place_order_started and payment_info_added).
- Updated unit tests for both events.

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
