### PR TITLE
feat: add checkout step to analytics events `main`

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -131,7 +131,7 @@ Object {
 exports[`Omnitracking track events definitions \`Payment Info Added\` return should match the snapshot 1`] = `
 Object {
   "checkoutOrderId": 15338048,
-  "checkoutStep": undefined,
+  "checkoutStep": 1,
   "deliveryInformationDetails": undefined,
   "interactionType": undefined,
   "orderCode": "50314b8e9bcf000000000000",
@@ -143,6 +143,7 @@ Object {
 exports[`Omnitracking track events definitions \`Place Order Started\` return should match the snapshot 1`] = `
 Object {
   "checkoutOrderId": 15338048,
+  "checkoutStep": 1,
   "orderCode": "50314b8e9bcf000000000000",
   "promocode": "ACME2019",
   "shippingTotalValue": 3.6,

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -483,6 +483,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
       ...getCheckoutEventGenericProperties(data),
       promocode: data.properties?.coupon,
       shippingTotalValue: data.properties?.shipping,
+      checkoutStep: data.properties?.step,
     };
   },
   [EventType.CheckoutStarted]: data => ({

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -570,6 +570,7 @@ Array [
     Object {
       "analytics_package_version": "0.1.0",
       "blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
+      "checkout_step": 1,
       "coupon": "ACME2019",
       "currency": "USD",
       "items": Array [
@@ -613,6 +614,7 @@ Array [
       "affiliation": undefined,
       "analytics_package_version": "0.1.0",
       "blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
+      "checkout_step": 1,
       "coupon": "ACME2019",
       "currency": "USD",
       "page_path": "/en-pt/?utm_term=utm_term&utm_source=utm_source&utm_medium=utm_medium&utm_content=utm_content&utm_campaign=utm_campaign",

--- a/packages/react/src/analytics/integrations/GA4/eventMapping.ts
+++ b/packages/react/src/analytics/integrations/GA4/eventMapping.ts
@@ -372,6 +372,7 @@ const getCheckoutPaymentStepParametersFromEvent = (
   return {
     ...getCheckoutParametersFromEvent(eventProperties),
     payment_type: eventProperties.paymentType,
+    checkout_step: eventProperties.step,
   };
 };
 
@@ -631,6 +632,7 @@ const getPlaceOrderStartedParametersFromEvent = (
     affiliation: eventProperties.affiliation,
     shipping: eventProperties.shipping,
     tax: eventProperties.tax,
+    checkout_step: eventProperties.step,
   };
 };
 

--- a/tests/__fixtures__/analytics/track/paymentInfoAddedTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/paymentInfoAddedTrackData.fixtures.mts
@@ -13,6 +13,7 @@ const fixtures = {
     coupon: 'ACME2019',
     paymentType: 'credit card',
     currency: 'USD',
+    step: 1,
     products: [
       {
         id: '507f1f77bcf86cd799439011',

--- a/tests/__fixtures__/analytics/track/placeOrderStartedTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/placeOrderStartedTrackData.fixtures.mts
@@ -12,6 +12,7 @@ const fixtures = {
     tax: 2.04,
     coupon: 'ACME2019',
     currency: 'USD',
+    step: 1,
   },
 };
 


### PR DESCRIPTION
## Description

- Added checkout step parameter to two analytics events (place_order_started and payment_info_added).
- Updated unit tests for both events.

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
