### PR TITLE
WIP: feat: add productId to add-to-wishlist event `v1`

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -9,6 +9,7 @@ import {
   getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
   getGenderValueFromProperties,
+  getProductIdFromLineItems,
   getProductLineItems,
   getProductLineItemsQuantity,
   getRecommendationsTrackingData,
@@ -598,6 +599,7 @@ export const trackEventsMapper = {
     wishlistId: data.properties?.wishlistId,
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
+    productId: getProductIdFromLineItems(data),
     ...getRecommendationsTrackingData(data),
   }),
   [eventTypes.PRODUCT_REMOVED_FROM_WISHLIST]: data => ({

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -519,6 +519,25 @@ export const getProductLineItems = data => {
 };
 
 /**
+ * Get the first product id from line items omnitracking parameter.
+ *
+ * @param {object} data - The event tracking data.
+ *
+ * @returns {string} - The first product id from line items parameter.
+ */
+export const getProductIdFromLineItems = data => {
+  const lineItems = getProductLineItems(data);
+
+  if (lineItems) {
+    const products = JSON.parse(lineItems);
+
+    return products[0]['productId'];
+  }
+
+  return undefined;
+};
+
+/**
  * Obtain sum all quantities from product line item list.
  *
  * @param {object} productList - The item list with quantity inside each element.

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -185,6 +185,7 @@ Object {
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
   "priceCurrency": "EUR",
+  "productId": "12345678",
   "tid": 2916,
   "wishlistId": "4c040892-cc27-4294-99e3-524b14eddf33",
 }


### PR DESCRIPTION
## Description

- Add productId parameter (that maps the first productId of lineItems parameter) to product_added_to_wishlist event.
- Add a helper to support this logic of mapping the first productId of lineItems.
- Updated snapshots

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
