### PR TITLE
feat: add productId to analytics events `v1`

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -10,6 +10,7 @@ import {
   getDeliveryInformationDetails,
   getGenderValueFromProperties,
   getLoginSignupRecommendedParameters,
+  getProductIdFromLineItems,
   getProductLineItems,
   getProductLineItemsQuantity,
   getRecommendationsTrackingData,
@@ -583,6 +584,7 @@ export const trackEventsMapper = {
     priceCurrency: data.properties?.currency,
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
+    productId: getProductIdFromLineItems(data),
     ...getRecommendationsTrackingData(data),
   }),
   [eventTypes.PRODUCT_REMOVED_FROM_CART]: data => ({
@@ -591,6 +593,7 @@ export const trackEventsMapper = {
     priceCurrency: data.properties?.currency,
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
+    productId: getProductIdFromLineItems(data),
     ...getRecommendationsTrackingData(data),
   }),
   [eventTypes.PRODUCT_ADDED_TO_WISHLIST]: data => ({
@@ -601,6 +604,7 @@ export const trackEventsMapper = {
     isMainWishlist: data.properties?.isMainWishlist,
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
+    productId: getProductIdFromLineItems(data),
     ...getRecommendationsTrackingData(data),
   }),
   [eventTypes.PRODUCT_REMOVED_FROM_WISHLIST]: data => ({
@@ -611,12 +615,13 @@ export const trackEventsMapper = {
     isMainWishlist: data.properties?.isMainWishlist,
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
+    productId: getProductIdFromLineItems(data),
     ...getRecommendationsTrackingData(data),
   }),
   [eventTypes.PRODUCT_CLICKED]: data => ({
     tid: 2926,
     actionArea: data.properties?.from,
-    productId: getProductId(data.properties),
+    productId: getProductIdFromLineItems(data),
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
     ...getRecommendationsTrackingData(data),
@@ -805,6 +810,7 @@ export const pageEventsMapper = {
     viewSubType: 'Product',
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
+    productId: getProductIdFromLineItems(data),
     ...getRecommendationsTrackingData(data),
   }),
   [pageTypes.PRODUCT_LISTING]: data => ({

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -519,6 +519,27 @@ export const getProductLineItems = data => {
 };
 
 /**
+ * Get the first product id from line items omnitracking parameter.
+ *
+ * @param {object} data - The event tracking data.
+ *
+ * @returns {string} - The first product id from line items parameter.
+ */
+export const getProductIdFromLineItems = data => {
+  const lineItems = getProductLineItems(data);
+
+  if (lineItems) {
+    const products = JSON.parse(lineItems);
+
+    if (Array.isArray(products) && products.length) {
+      return products[0]['productId'];
+    }
+  }
+
+  return undefined;
+};
+
+/**
  * Obtain sum all quantities from product line item list.
  *
  * @param {object} productList - The item list with quantity inside each element.

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -174,6 +174,7 @@ Object {
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
   "priceCurrency": "EUR",
+  "productId": "12345678",
   "tid": 2915,
 }
 `;
@@ -187,6 +188,7 @@ Object {
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
   "priceCurrency": "EUR",
+  "productId": "12345678",
   "tid": 2916,
   "wishlistId": "4c040892-cc27-4294-99e3-524b14eddf33",
 }
@@ -199,7 +201,7 @@ Object {
   "listIndex": 3,
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
-  "productId": "123",
+  "productId": "12345678",
   "tid": 2926,
 }
 `;
@@ -223,6 +225,7 @@ Object {
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
   "priceCurrency": "EUR",
+  "productId": "12345678",
   "tid": 2925,
   "wishlistId": "4c040892-cc27-4294-99e3-524b14eddf33",
 }
@@ -236,6 +239,7 @@ Object {
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
   "priceCurrency": "EUR",
+  "productId": "12345678",
   "tid": 131,
 }
 `;
@@ -1110,6 +1114,7 @@ Object {
   "listIndex": 3,
   "moduleId": "[\\"5c1e447a-b14b-43a5-b010-2190f3366fad\\"]",
   "moduleTitle": "[\\"Recommendations\\"]",
+  "productId": "12345678",
   "viewSubType": "Product",
   "viewType": "Product",
 }


### PR DESCRIPTION
## Description

- Add productId parameter (that maps the first productId of lineItems parameter) to product_added_to_wishlist event.
- Add a helper to support this logic of mapping the first productId of lineItems.
- Updated snapshots

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
