### PR TITLE
feat: add productId to analytics events `main`

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -172,6 +172,7 @@ Object {
   "moduleId": "[\\"/en-pt/shopping/woman\\"]",
   "moduleTitle": "[\\"Woman shopping\\"]",
   "priceCurrency": "USD",
+  "productId": "507f1f77bcf86cd799439011",
   "tid": 2916,
   "wishlistId": "d3618128-5aa9-4caa-a452-1dd1377a6190",
 }

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -3,6 +3,7 @@ import {
   getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
   getGenderValueFromProperties,
+  getProductIdFromLineItems,
   getProductLineItems,
   getProductLineItemsQuantity,
   getRecommendationsTrackingData,
@@ -551,6 +552,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
     isMainWishlist: data.properties?.isMainWishlist,
+    productId: getProductIdFromLineItems(data),
     ...getRecommendationsTrackingData(data),
   }),
   [EventType.ProductRemovedFromWishlist]: (

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -522,6 +522,27 @@ export const getProductLineItems = (data: EventData<TrackTypesValues>) => {
 };
 
 /**
+ * Get the first product id from line items omnitracking parameter.
+ *
+ * @param data - The event tracking data.
+ *
+ * @returns The first product id from line items parameter.
+ */
+export const getProductIdFromLineItems = (
+  data: EventData<TrackTypesValues>,
+) => {
+  const lineItems = getProductLineItems(data);
+
+  if (lineItems) {
+    const products = JSON.parse(lineItems);
+
+    return products[0]['productId'];
+  }
+
+  return undefined;
+};
+
+/**
  * Obtain checkout generic omnitracking's properties.
  *
  * @param data - The event's data.


### PR DESCRIPTION
## Description

- Add productId parameter (that maps the first productId of lineItems parameter) to product_added_to_wishlist event.
- Add a helper to support this logic of mapping the first productId of lineItems.
- Updated snapshots

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
