### PR TITLE
feat: add unitSalePrice to analytics events `main`

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -44,7 +44,7 @@ Object {
   "checkoutOrderId": 12345678,
   "checkoutStep": 1,
   "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/standard\\",\\"courierType\\":\\"Next Day\\"}",
-  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1}]",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"unitSalePrice\\":19}]",
   "loginType": "guest",
   "orderCode": "50314b8e9bcf000000000000",
   "orderVAT": 2.04,
@@ -71,7 +71,7 @@ Object {
   "checkoutStep": 2,
   "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\",\\"packagingType\\":\\"foo\\"}",
   "interactionType": "click",
-  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1}]",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"unitSalePrice\\":19}]",
   "orderCode": "50314b8e9bcf000000000000",
   "promoCode": "ACME2019",
   "selectedPaymentMethod": "credit",
@@ -154,7 +154,7 @@ Object {
 exports[`Omnitracking track events definitions \`Product Added to Cart\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "Wishlist",
-  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":19}]",
   "listIndex": 2,
   "moduleId": "[\\"d3618128-5aa9-4caa-a452-1dd1377a6190\\"]",
   "moduleTitle": "[\\"my_wishlist\\"]",
@@ -168,7 +168,7 @@ exports[`Omnitracking track events definitions \`Product Added to Wishlist\` ret
 Object {
   "actionArea": "Plp",
   "isMainWishlist": true,
-  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":19}]",
   "listIndex": 2,
   "moduleId": "[\\"/en-pt/shopping/woman\\"]",
   "moduleTitle": "[\\"Woman shopping\\"]",
@@ -182,7 +182,7 @@ Object {
 exports[`Omnitracking track events definitions \`Product Clicked\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "Plp",
-  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":3}]",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":3,\\"unitSalePrice\\":19}]",
   "listIndex": 3,
   "moduleId": "[\\"/en-pt/shopping/woman\\"]",
   "moduleTitle": "[\\"Woman shopping\\"]",
@@ -194,7 +194,7 @@ Object {
 exports[`Omnitracking track events definitions \`Product List Viewed\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "Plp",
-  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25,\\"listIndex\\":2},{\\"productId\\":\\"507f1f77bcf86cd799439012\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25,\\"listIndex\\":3}]",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25,\\"listIndex\\":2,\\"unitSalePrice\\":19},{\\"productId\\":\\"507f1f77bcf86cd799439012\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25,\\"listIndex\\":3,\\"unitSalePrice\\":19}]",
   "moduleId": "[\\"d3618128-5aa9-4caa-a452-1dd1377a6190\\"]",
   "moduleTitle": "[\\"Woman shopping\\"]",
   "tid": 2832,
@@ -205,7 +205,7 @@ exports[`Omnitracking track events definitions \`Product Removed From Wishlist\`
 Object {
   "actionArea": "Plp",
   "isMainWishlist": true,
-  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":19}]",
   "listIndex": 2,
   "moduleId": "[\\"/en-pt/shopping/woman\\"]",
   "moduleTitle": "[\\"Woman shopping\\"]",
@@ -219,7 +219,7 @@ Object {
 exports[`Omnitracking track events definitions \`Product Removed from Cart\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "Bag",
-  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":1}]",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":1,\\"unitSalePrice\\":19}]",
   "listIndex": 1,
   "moduleId": "[\\"e0030b3c-b970-4496-bc72-f9a38d6270b1\\"]",
   "moduleTitle": "[\\"Bag\\"]",
@@ -338,7 +338,7 @@ exports[`Omnitracking track events definitions \`bag\` return should match the s
 Object {
   "basketQuantity": 1,
   "basketValue": 13,
-  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1}]",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"unitSalePrice\\":19}]",
   "viewSubType": "Bag",
   "viewType": "Shopping Bag",
 }
@@ -1089,11 +1089,12 @@ Object {
 
 exports[`Omnitracking track events definitions \`product-details\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":\\"12122479\\",\\"itemPromotion\\":1,\\"designerName\\":\\"Saint Laurent\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":2,\\"sizeId\\":\\"20\\",\\"itemQuantity\\":13,\\"promoCode\\":\\"EASTER2022\\",\\"storeId\\":20000,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12122479\\",\\"itemPromotion\\":1,\\"designerName\\":\\"Saint Laurent\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":2,\\"sizeId\\":\\"20\\",\\"itemQuantity\\":13,\\"promoCode\\":\\"EASTER2022\\",\\"storeId\\":20000,\\"listIndex\\":2,\\"unitSalePrice\\":1}]",
   "listIndex": 2,
   "moduleId": "[\\"5c1e447a-b14b-43a5-b010-2190f3366fad\\"]",
   "moduleTitle": "[\\"Recommendations\\"]",
   "productId": "12122479",
+  "unitSalePrice": 1,
   "viewSubType": "Product",
   "viewType": "Product",
 }
@@ -1101,7 +1102,7 @@ Object {
 
 exports[`Omnitracking track events definitions \`product-listing\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"unitSalePrice\\":0}]",
   "viewSubType": "Listing",
   "viewType": "Listing",
 }
@@ -1282,7 +1283,7 @@ Array [
 
 exports[`Omnitracking track events definitions \`wishlist\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":\\"12122479\\",\\"itemPromotion\\":1,\\"designerName\\":\\"Saint Laurent\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":2,\\"sizeId\\":\\"20\\",\\"itemQuantity\\":13,\\"promoCode\\":\\"EASTER2022\\",\\"storeId\\":20000,\\"listIndex\\":1},{\\"productId\\":\\"12122479\\",\\"itemPromotion\\":1,\\"designerName\\":\\"Saint Laurent\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":2,\\"sizeId\\":\\"21\\",\\"itemQuantity\\":13,\\"promoCode\\":\\"EASTER2022\\",\\"storeId\\":20000,\\"listIndex\\":1}]",
+  "lineItems": "[{\\"productId\\":\\"12122479\\",\\"itemPromotion\\":1,\\"designerName\\":\\"Saint Laurent\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":2,\\"sizeId\\":\\"20\\",\\"itemQuantity\\":13,\\"promoCode\\":\\"EASTER2022\\",\\"storeId\\":20000,\\"listIndex\\":1,\\"unitSalePrice\\":1},{\\"productId\\":\\"12122479\\",\\"itemPromotion\\":1,\\"designerName\\":\\"Saint Laurent\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":2,\\"sizeId\\":\\"21\\",\\"itemQuantity\\":13,\\"promoCode\\":\\"EASTER2022\\",\\"storeId\\":20000,\\"listIndex\\":1,\\"unitSalePrice\\":1}]",
   "viewSubType": "Wishlist",
   "viewType": "Wishlist",
   "wishlistQuantity": 26,

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -7,6 +7,7 @@ import {
   getProductIdFromLineItems,
   getProductLineItems,
   getProductLineItemsQuantity,
+  getProductUnitSalePrice,
   getRecommendationsTrackingData,
 } from './omnitracking-helper.js';
 import { getProductId, logger } from '../../utils/index.js';
@@ -808,6 +809,7 @@ export const pageEventsMapper: Readonly<OmnitrackingPageEventsMapper> = {
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
     productId: getProductIdFromLineItems(data),
+    unitSalePrice: getProductUnitSalePrice(data.properties),
     ...getRecommendationsTrackingData(data),
   }),
   [PageType.ProductListing]: data => ({

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -324,6 +324,30 @@ export const getValParameterForEvent = (
 };
 
 /**
+ * Get the product unit sale price from a specific product.
+ *
+ * @param productData - Product data.
+ *
+ * @returns The unit sale price value, or undefined if no pricing data was found in productData argument.
+ */
+export const getProductUnitSalePrice = (
+  productData: AnalyticsProduct,
+): number | undefined => {
+  if (typeof productData.unitSalePrice === 'number') {
+    return productData.unitSalePrice;
+  }
+
+  if (
+    typeof productData.priceWithoutDiscount === 'number' &&
+    typeof productData.discountValue === 'number'
+  ) {
+    return productData.priceWithoutDiscount - productData.discountValue;
+  }
+
+  return undefined;
+};
+
+/**
  * Generates a payment attempt reference ID based on the correlationID (user local
  * ID) and the timestamp of the event.
  *
@@ -473,6 +497,7 @@ export const getOmnitrackingProductMapper = (
   promoCode: productData.coupon,
   storeId: productData.locationId,
   listIndex: productData.position,
+  unitSalePrice: getProductUnitSalePrice(productData),
 });
 
 /**

--- a/packages/analytics/src/types/analytics.types.ts
+++ b/packages/analytics/src/types/analytics.types.ts
@@ -135,4 +135,5 @@ export type AnalyticsProduct = {
   list?: string;
   listId?: string;
   size?: string;
+  unitSalePrice?: number;
 } & Record<string, unknown>;


### PR DESCRIPTION
## Description

- Add unitSalePrice to lineItems and product_details event.
- Add a helper to calculate unitSalePrice (price - discount).
- Updated snapshots

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
