### PR TITLE
feat: omnitracking minor changes for `v1`

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/__tests__/omnitracking-helper.test.js
@@ -5,6 +5,7 @@ import {
   getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
   getGenderValueFromProperties,
+  getLoginSignupRecommendedParameters,
   getPageEventFromLocation,
   getPlatformSpecificParameters,
   getRecommendationsTrackingData,
@@ -17,268 +18,300 @@ import trackTypes from '../../../types/trackTypes';
 utils.logger.warn = jest.fn();
 const mockLoggerWarn = utils.logger.warn;
 
-describe('getPageEventFromLocation', () => {
-  it('should return null when location is not provided', () => {
-    expect(getPageEventFromLocation()).toBe(null);
+describe('omnitracking-helper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('should return null location.href is not set', () => {
-    expect(getPageEventFromLocation({})).toBe(null);
-  });
-});
+  describe('getPageEventFromLocation', () => {
+    it('should return null when location is not provided', () => {
+      expect(getPageEventFromLocation()).toBe(null);
+    });
 
-describe('getValParameterForEvent', () => {
-  it('should return a stringified object', () => {
-    expect(getValParameterForEvent()).toBe('{}');
-    expect(getValParameterForEvent({ foo: 'bar' })).toBe('{"foo":"bar"}');
-  });
-});
-
-describe('generatePaymentAttemptReferenceId', () => {
-  it('Should return a string with the generated payment attempt reference ID', () => {
-    const mockPaymentAttemptReferenceId = '12345_123456789';
-
-    expect(
-      generatePaymentAttemptReferenceId({
-        user: {
-          localId: '12345',
-        },
-        timestamp: 123456789,
-      }),
-    ).toEqual(mockPaymentAttemptReferenceId);
-  });
-});
-
-describe('getPlatformSpecificParameters', () => {
-  it('should not add parameters if the platform is mobile and track type is not screen', () => {
-    const eventData = {
-      platform: platformTypes.Mobile,
-      type: trackTypes.TRACK,
-    };
-
-    expect(getPlatformSpecificParameters(eventData)).toStrictEqual({});
-  });
-});
-
-describe('getCheckoutEventGenericProperties', () => {
-  it('should display some warn', () => {
-    const eventData = {
-      properties: {
-        orderId: '123',
-      },
-    };
-
-    getCheckoutEventGenericProperties(eventData);
-    expect(mockLoggerWarn).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'property orderId should be an alphanumeric value',
-      ),
-    );
-  });
-
-  it('should get orderCode without warn and without property orderId', () => {
-    const eventData = {
-      properties: {
-        orderId: '5H5QYB',
-        checkoutOrderId: '123',
-      },
-    };
-
-    expect(getCheckoutEventGenericProperties(eventData)).toEqual({
-      orderCode: '5H5QYB',
+    it('should return null location.href is not set', () => {
+      expect(getPageEventFromLocation({})).toBe(null);
     });
   });
 
-  it('should get orderCode without warn and with property orderId', () => {
-    const eventData = {
-      properties: {
-        orderId: '5H5QYB',
-        checkoutOrderId: 123,
-      },
+  describe('getValParameterForEvent', () => {
+    it('should return a stringified object', () => {
+      expect(getValParameterForEvent()).toBe('{}');
+      expect(getValParameterForEvent({ foo: 'bar' })).toBe('{"foo":"bar"}');
+    });
+  });
+
+  describe('generatePaymentAttemptReferenceId', () => {
+    it('Should return a string with the generated payment attempt reference ID', () => {
+      const mockPaymentAttemptReferenceId = '12345_123456789';
+
+      expect(
+        generatePaymentAttemptReferenceId({
+          user: {
+            localId: '12345',
+          },
+          timestamp: 123456789,
+        }),
+      ).toEqual(mockPaymentAttemptReferenceId);
+    });
+  });
+
+  describe('getPlatformSpecificParameters', () => {
+    it('should not add parameters if the platform is mobile and track type is not screen', () => {
+      const eventData = {
+        platform: platformTypes.Mobile,
+        type: trackTypes.TRACK,
+      };
+
+      expect(getPlatformSpecificParameters(eventData)).toStrictEqual({});
+    });
+  });
+
+  describe('getCheckoutEventGenericProperties', () => {
+    it('should display some warn', () => {
+      const eventData = {
+        properties: {
+          orderId: '123',
+        },
+      };
+
+      getCheckoutEventGenericProperties(eventData);
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'property orderId should be an alphanumeric value',
+        ),
+      );
+    });
+
+    it('should get orderCode without warn and without property orderId', () => {
+      const eventData = {
+        properties: {
+          orderId: '5H5QYB',
+          checkoutOrderId: '123',
+        },
+      };
+
+      expect(getCheckoutEventGenericProperties(eventData)).toEqual({
+        orderCode: '5H5QYB',
+      });
+    });
+
+    it('should get orderCode without warn and with property orderId', () => {
+      const eventData = {
+        properties: {
+          orderId: '5H5QYB',
+          checkoutOrderId: 123,
+        },
+      };
+
+      expect(getCheckoutEventGenericProperties(eventData, true)).toEqual({
+        orderCode: '5H5QYB',
+        orderId: 123,
+      });
+    });
+  });
+
+  describe('getGenderValueFromProperties', () => {
+    it(`should test all ways to return ${SignupNewsletterGenderMappings[0]} value`, () => {
+      expect(
+        getGenderValueFromProperties({
+          properties: {
+            gender: 0,
+          },
+        }),
+      ).toEqual(SignupNewsletterGenderMappings[0]);
+
+      expect(
+        getGenderValueFromProperties({
+          properties: {
+            gender: '0',
+          },
+        }),
+      ).toEqual(SignupNewsletterGenderMappings[0]);
+
+      expect(
+        getGenderValueFromProperties({
+          properties: {
+            gender: { id: '0' },
+          },
+        }),
+      ).toEqual(SignupNewsletterGenderMappings[0]);
+    });
+
+    it(`should test all ways to return ${SignupNewsletterGenderMappings[0]} and ${SignupNewsletterGenderMappings[1]} value`, () => {
+      const expected = `${SignupNewsletterGenderMappings[0]},${SignupNewsletterGenderMappings[1]}`;
+
+      expect(
+        getGenderValueFromProperties({
+          properties: {
+            gender: [0, 1],
+          },
+        }),
+      ).toEqual(expected);
+
+      expect(
+        getGenderValueFromProperties({
+          properties: {
+            gender: ['0', '1'],
+          },
+        }),
+      ).toEqual(expected);
+
+      expect(
+        getGenderValueFromProperties({
+          properties: {
+            gender: [{ id: '0' }, { id: '1' }],
+          },
+        }),
+      ).toEqual(expected);
+    });
+
+    it('should return custom value', () => {
+      expect(
+        getGenderValueFromProperties({
+          properties: {
+            gender: { name: 'W' },
+          },
+        }),
+      ).toEqual('W');
+
+      expect(
+        getGenderValueFromProperties({
+          properties: {
+            gender: [{ name: 'W' }, { name: 'M' }],
+          },
+        }),
+      ).toEqual('W,M');
+    });
+  });
+
+  describe('getDeliveryInformationDetails', () => {
+    it('should deal with empty information', () => {
+      expect(getDeliveryInformationDetails({})).toEqual(undefined);
+    });
+    it('should deal with delivery type', () => {
+      expect(
+        getDeliveryInformationDetails({
+          properties: {
+            deliveryType: 'sample',
+          },
+        }),
+      ).toEqual('{"deliveryType":"sample"}');
+    });
+
+    it('should deal with shipping tier', () => {
+      expect(
+        getDeliveryInformationDetails({
+          properties: {
+            shippingTier: 'sample',
+          },
+        }),
+      ).toEqual('{"courierType":"sample"}');
+    });
+  });
+
+  describe('getCommonCheckoutStepTrackingData', () => {
+    it('should obtain common checkout parameters', () => {
+      expect(
+        getCommonCheckoutStepTrackingData({
+          properties: {
+            step: 2,
+            deliveryType: 'sample_delivery',
+            shippingTier: 'sample_shipping',
+            interactionType: 'click',
+          },
+        }),
+      ).toEqual({
+        checkoutStep: 2,
+        deliveryInformationDetails:
+          '{"deliveryType":"sample_delivery","courierType":"sample_shipping"}',
+        interactionType: 'click',
+      });
+    });
+  });
+
+  describe('getRecommendationsTrackingData', () => {
+    const mockedRecommendationsValues = {
+      list: 'list123',
+      listId: '09a35590-bb62-4027-a630-5da04ec64fb5',
     };
 
-    expect(getCheckoutEventGenericProperties(eventData, true)).toEqual({
-      orderCode: '5H5QYB',
-      orderId: 123,
+    const mockedReturnedRecommendationsValues = {
+      moduleTitle: JSON.stringify([mockedRecommendationsValues.list]),
+      moduleId: JSON.stringify([mockedRecommendationsValues.listId]),
+    };
+
+    it('should return undefined in case its non recommendations product-details event', () => {
+      expect(
+        getRecommendationsTrackingData({
+          event: pageTypes.PRODUCT_DETAILS,
+          properties: {
+            from: 'abc',
+          },
+        }),
+      ).toBeUndefined();
     });
-  });
-});
 
-describe('getGenderValueFromProperties', () => {
-  it(`should test all ways to return ${SignupNewsletterGenderMappings[0]} value`, () => {
-    expect(
-      getGenderValueFromProperties({
-        properties: {
-          gender: 0,
-        },
-      }),
-    ).toEqual(SignupNewsletterGenderMappings[0]);
-
-    expect(
-      getGenderValueFromProperties({
-        properties: {
-          gender: '0',
-        },
-      }),
-    ).toEqual(SignupNewsletterGenderMappings[0]);
-
-    expect(
-      getGenderValueFromProperties({
-        properties: {
-          gender: { id: '0' },
-        },
-      }),
-    ).toEqual(SignupNewsletterGenderMappings[0]);
-  });
-
-  it(`should test all ways to return ${SignupNewsletterGenderMappings[0]} and ${SignupNewsletterGenderMappings[1]} value`, () => {
-    const expected = `${SignupNewsletterGenderMappings[0]},${SignupNewsletterGenderMappings[1]}`;
-
-    expect(
-      getGenderValueFromProperties({
-        properties: {
-          gender: [0, 1],
-        },
-      }),
-    ).toEqual(expected);
-
-    expect(
-      getGenderValueFromProperties({
-        properties: {
-          gender: ['0', '1'],
-        },
-      }),
-    ).toEqual(expected);
-
-    expect(
-      getGenderValueFromProperties({
-        properties: {
-          gender: [{ id: '0' }, { id: '1' }],
-        },
-      }),
-    ).toEqual(expected);
-  });
-
-  it('should return custom value', () => {
-    expect(
-      getGenderValueFromProperties({
-        properties: {
-          gender: { name: 'W' },
-        },
-      }),
-    ).toEqual('W');
-
-    expect(
-      getGenderValueFromProperties({
-        properties: {
-          gender: [{ name: 'W' }, { name: 'M' }],
-        },
-      }),
-    ).toEqual('W,M');
-  });
-});
-
-describe('getDeliveryInformationDetails', () => {
-  it('should deal with empty information', () => {
-    expect(getDeliveryInformationDetails({})).toEqual(undefined);
-  });
-  it('should deal with delivery type', () => {
-    expect(
-      getDeliveryInformationDetails({
-        properties: {
-          deliveryType: 'sample',
-        },
-      }),
-    ).toEqual('{"deliveryType":"sample"}');
-  });
-
-  it('should deal with shipping tier', () => {
-    expect(
-      getDeliveryInformationDetails({
-        properties: {
-          shippingTier: 'sample',
-        },
-      }),
-    ).toEqual('{"courierType":"sample"}');
-  });
-});
-
-describe('getCommonCheckoutStepTrackingData', () => {
-  it('should obtain common checkout parameters', () => {
-    expect(
-      getCommonCheckoutStepTrackingData({
-        properties: {
-          step: 2,
-          deliveryType: 'sample_delivery',
-          shippingTier: 'sample_shipping',
-          interactionType: 'click',
-        },
-      }),
-    ).toEqual({
-      checkoutStep: 2,
-      deliveryInformationDetails:
-        '{"deliveryType":"sample_delivery","courierType":"sample_shipping"}',
-      interactionType: 'click',
+    it('should return empty object if the event is sent without the recommendations parameters filled', () => {
+      expect(
+        getRecommendationsTrackingData({
+          event: 'abc',
+          properties: {
+            from: fromParameterTypes.RECOMMENDATIONS,
+          },
+        }),
+      ).toEqual({});
     });
-  });
-});
 
-describe('getRecommendationsTrackingData', () => {
-  const mockedRecommendationsValues = {
-    list: 'list123',
-    listId: '09a35590-bb62-4027-a630-5da04ec64fb5',
-  };
+    it('should return the json stringified values correctly', () => {
+      expect(
+        getRecommendationsTrackingData({
+          event: 'abc',
+          properties: {
+            from: fromParameterTypes.RECOMMENDATIONS,
+            ...mockedRecommendationsValues,
+          },
+        }),
+      ).toEqual(mockedReturnedRecommendationsValues);
+    });
 
-  const mockedReturnedRecommendationsValues = {
-    moduleTitle: JSON.stringify([mockedRecommendationsValues.list]),
-    moduleId: JSON.stringify([mockedRecommendationsValues.listId]),
-  };
+    it('should return just one stringified parameter in case its sent only one parameter', () => {
+      expect(
+        getRecommendationsTrackingData({
+          event: 'abc',
+          properties: {
+            from: 'abc',
+            list: mockedRecommendationsValues.list,
+          },
+        }),
+      ).toEqual({
+        moduleTitle: mockedReturnedRecommendationsValues.moduleTitle,
+      });
+    });
 
-  it('should return undefined in case its non recommendations product-details event', () => {
-    expect(
-      getRecommendationsTrackingData({
-        event: pageTypes.PRODUCT_DETAILS,
-        properties: {
-          from: 'abc',
-        },
-      }),
-    ).toBeUndefined();
-  });
+    describe('getLoginSignupRecommendedParameters', () => {
+      it('should log a warning when recommended properties are missing and should not return any properties.', () => {
+        expect(
+          getLoginSignupRecommendedParameters({
+            event: 'abc',
+            properties: {},
+          }),
+        ).toEqual({});
 
-  it('should return empty object if the event is sent without the recommendations parameters filled', () => {
-    expect(
-      getRecommendationsTrackingData({
-        event: 'abc',
-        properties: {
-          from: fromParameterTypes.RECOMMENDATIONS,
-        },
-      }),
-    ).toEqual({});
-  });
+        expect(mockLoggerWarn).toHaveBeenCalled();
+      });
 
-  it('should return the json stringified values correctly', () => {
-    expect(
-      getRecommendationsTrackingData({
-        event: 'abc',
-        properties: {
-          from: fromParameterTypes.RECOMMENDATIONS,
-          ...mockedRecommendationsValues,
-        },
-      }),
-    ).toEqual(mockedReturnedRecommendationsValues);
-  });
+      it('should not log a warning when all recommended properties are filled and correctly mapped to Omnitracking fields.', () => {
+        expect(
+          getLoginSignupRecommendedParameters({
+            event: 'abc',
+            properties: {
+              method: 'test',
+            },
+          }),
+        ).toEqual({ loginType: 'test' });
 
-  it('should return just one stringified parameter in case its sent only one parameter', () => {
-    expect(
-      getRecommendationsTrackingData({
-        event: 'abc',
-        properties: {
-          from: 'abc',
-          list: mockedRecommendationsValues.list,
-        },
-      }),
-    ).toEqual({
-      moduleTitle: mockedReturnedRecommendationsValues.moduleTitle,
+        expect(mockLoggerWarn).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -9,6 +9,7 @@ import {
   getCommonCheckoutStepTrackingData,
   getDeliveryInformationDetails,
   getGenderValueFromProperties,
+  getLoginSignupRecommendedParameters,
   getProductLineItems,
   getProductLineItemsQuantity,
   getRecommendationsTrackingData,
@@ -34,7 +35,7 @@ const commonPageParams = [
   'basketQuantity',
   'categoryIdList',
   'checkboxFilter',
-  'clientAdvertisingID',
+  'clientAdvertisingId',
   'clientCulture',
   'clientGender',
   'clientInstallId',
@@ -50,7 +51,7 @@ const commonPageParams = [
   'domainUrl',
   'elementsSeen',
   'exitInteraction',
-  'fittingRoomID',
+  'fittingRoomId',
   'fittingRoomList',
   'geoLocationCity',
   'geoLocationState',
@@ -107,7 +108,7 @@ const commonPageParams = [
   'viewGender',
   'viewSubType',
   'viewType',
-  'weChatOpenID',
+  'weChatOpenId',
   'weChatUnionId',
   'wishlistQuantity',
 ];
@@ -323,7 +324,7 @@ export const pageActionParameters = [
   'loadItemCoordinate',
   'moduleBenefit',
   'moduleContentDepartment',
-  'moduleContentID',
+  'moduleContentId',
   'moduleContentName',
   'moduleContentPublicationDate',
   'moduleContentVersion',
@@ -636,11 +637,11 @@ export const trackEventsMapper = {
   }),
   [eventTypes.LOGIN]: data => ({
     tid: 2924,
-    loginType: data.properties?.method,
+    ...getLoginSignupRecommendedParameters(data),
   }),
   [eventTypes.SIGNUP_FORM_COMPLETED]: data => ({
     tid: 2927,
-    loginType: data.properties?.method,
+    ...getLoginSignupRecommendedParameters(data),
   }),
   [eventTypes.INTERACT_CONTENT]: data => {
     const properties = data.properties;
@@ -700,7 +701,7 @@ export const trackEventsMapper = {
       productId: getProductId(properties),
       actionArea: properties?.from,
       listIndex: properties?.position,
-      storeID: properties?.locationId,
+      storeId: properties?.locationId,
     };
 
     if (properties.colour && properties.oldColour !== properties.colour) {
@@ -758,6 +759,7 @@ export const trackEventsMapper = {
         ...genericEventProperties,
         ...additionalParameters,
         tid: 2920,
+        itemSize: properties?.size,
       });
     }
 

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -486,10 +486,10 @@ export const getOmnitrackingProductMapper = productData => ({
   designerName: productData.brand,
   category: (productData.category || '').split('/')[0],
   itemFullPrice: productData.priceWithoutDiscount,
-  sizeID: productData.sizeId,
+  sizeId: productData.sizeId,
   itemQuantity: productData.quantity,
   promoCode: productData.coupon,
-  storeID: productData.locationId,
+  storeId: productData.locationId,
   listIndex: productData.position,
 });
 
@@ -646,4 +646,26 @@ export const getRecommendationsTrackingData = data => {
   // In case it's a non recommendations Product Details event,
   // we do not need to send these recommendations parameters.
   return;
+};
+
+/**
+ * Get Login/Signup Recommended Parameters, logging a warnings if the recommended properties are missing.
+ *
+ * @param {object} data - The event's data.
+ *
+ * @returns {object} - This function return common data from login or signup events.
+ */
+export const getLoginSignupRecommendedParameters = data => {
+  const mappedData = {};
+  if (data.properties?.method) {
+    mappedData['loginType'] = data.properties?.method;
+  } else {
+    logger.warn(
+      `[Omnitracking] - Event ${data.event}: The "method" property must be included in the payload
+                    when triggering an ${data.event} event. To track this event, please ensure that includes
+                    this property.`,
+    );
+  }
+
+  return mappedData;
 };

--- a/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
+++ b/packages/core/src/analytics/integrations/__tests__/Omnitracking.test.js
@@ -381,6 +381,55 @@ describe('Omnitracking', () => {
             expect(postTrackingsSpy).toHaveBeenCalledTimes(0);
           });
         });
+        describe('Login', () => {
+          const missingMethodWarn = expect.stringContaining(
+            'The "method" property must be included in the payload',
+          );
+
+          it('should log a warning message when "Login" event has missing properties on payload', async () => {
+            const data = generateTrackMockData({
+              event: eventTypes.LOGIN,
+              properties: {
+                method: 'Tenant',
+              },
+            });
+
+            await omnitracking.track(data);
+
+            expect(mockLoggerWarn).not.toHaveBeenCalledWith(missingMethodWarn);
+
+            data.properties.method = undefined;
+
+            await omnitracking.track(data);
+
+            expect(mockLoggerWarn).toHaveBeenCalledWith(missingMethodWarn);
+          });
+        });
+
+        describe('Sign-up', () => {
+          const missingMethodWarn = expect.stringContaining(
+            'The "method" property must be included in the payload',
+          );
+
+          it('should log a warning message when "Sign-up" event has missing properties on payload', async () => {
+            const data = generateTrackMockData({
+              event: eventTypes.SIGNUP_FORM_COMPLETED,
+              properties: {
+                method: 'Tenant',
+              },
+            });
+
+            await omnitracking.track(data);
+
+            expect(mockLoggerWarn).not.toHaveBeenCalledWith(missingMethodWarn);
+
+            data.properties.method = undefined;
+
+            await omnitracking.track(data);
+
+            expect(mockLoggerWarn).toHaveBeenCalledWith(missingMethodWarn);
+          });
+        });
         describe('Interact Content', () => {
           it('should not track an interact content event if the required parameters are missing', async () => {
             const data = generateTrackMockData({

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -44,7 +44,7 @@ Object {
   "checkoutStep": 1,
   "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\"}",
   "interactionType": "click",
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
   "loginType": "guest",
   "orderCode": "ABC12",
   "orderId": 12345678,
@@ -78,7 +78,7 @@ Object {
   "checkoutStep": 2,
   "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\",\\"packagingType\\":\\"foo\\"}",
   "interactionType": "click",
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
   "orderCode": "ABC12",
   "orderId": 12345678,
   "promoCode": "PROMO_ABC",
@@ -169,7 +169,7 @@ Array [
 exports[`Omnitracking definitions \`Product Added to Cart\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "PDP",
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
   "listIndex": 3,
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
@@ -182,7 +182,7 @@ exports[`Omnitracking definitions \`Product Added to Wishlist\` return should ma
 Object {
   "actionArea": "PDP",
   "isMainWishlist": true,
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
   "listIndex": 3,
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
@@ -195,7 +195,7 @@ Object {
 exports[`Omnitracking definitions \`Product Clicked\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "PDP",
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
   "listIndex": 3,
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
@@ -207,7 +207,7 @@ Object {
 exports[`Omnitracking definitions \`Product List Viewed\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "PLP",
-  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":25,\\"sizeID\\":1,\\"listIndex\\":2},{\\"productId\\":\\"507f1f77bcf86cd799439012\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25,\\"listIndex\\":3}]",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":25,\\"sizeId\\":1,\\"listIndex\\":2},{\\"productId\\":\\"507f1f77bcf86cd799439012\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25,\\"listIndex\\":3}]",
   "moduleId": "[\\"12345\\"]",
   "moduleTitle": "[\\"Woman shopping\\"]",
   "tid": 2832,
@@ -218,7 +218,7 @@ exports[`Omnitracking definitions \`Product Removed From Wishlist\` return shoul
 Object {
   "actionArea": "PDP",
   "isMainWishlist": true,
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
   "listIndex": 3,
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
@@ -231,7 +231,7 @@ Object {
 exports[`Omnitracking definitions \`Product Removed from Cart\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "PDP",
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
   "listIndex": 3,
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
@@ -247,16 +247,17 @@ Array [
     "colourList": "2, 1",
     "listIndex": 2,
     "productId": "12345",
-    "storeID": "123",
+    "storeId": "123",
     "tid": 2098,
   },
   Object {
     "actionArea": "PDP",
+    "itemSize": "S",
     "listIndex": 2,
     "productId": "12345",
     "scaleList": "10, 12",
     "sizeList": "11, 10",
-    "storeID": "123",
+    "storeId": "123",
     "tid": 2920,
   },
   Object {
@@ -264,7 +265,7 @@ Array [
     "itemQuantity": 2,
     "listIndex": 2,
     "productId": "12345",
-    "storeID": "123",
+    "storeId": "123",
     "tid": 2919,
   },
 ]
@@ -355,7 +356,7 @@ exports[`Omnitracking definitions \`bag\` return should match the snapshot 1`] =
 Object {
   "basketQuantity": 8,
   "basketValue": 100,
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"itemQuantity\\":5},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"itemQuantity\\":3}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":5},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":3}]",
   "viewSubType": "Bag",
   "viewType": "Shopping Bag",
 }
@@ -382,7 +383,7 @@ Object {
     "basketQuantity",
     "categoryIdList",
     "checkboxFilter",
-    "clientAdvertisingID",
+    "clientAdvertisingId",
     "clientCulture",
     "clientGender",
     "clientInstallId",
@@ -398,7 +399,7 @@ Object {
     "domainUrl",
     "elementsSeen",
     "exitInteraction",
-    "fittingRoomID",
+    "fittingRoomId",
     "fittingRoomList",
     "geoLocationCity",
     "geoLocationState",
@@ -455,7 +456,7 @@ Object {
     "viewGender",
     "viewSubType",
     "viewType",
-    "weChatOpenID",
+    "weChatOpenId",
     "weChatUnionId",
     "wishlistQuantity",
     "accessTier",
@@ -554,7 +555,7 @@ Object {
     "basketQuantity",
     "categoryIdList",
     "checkboxFilter",
-    "clientAdvertisingID",
+    "clientAdvertisingId",
     "clientCulture",
     "clientGender",
     "clientInstallId",
@@ -570,7 +571,7 @@ Object {
     "domainUrl",
     "elementsSeen",
     "exitInteraction",
-    "fittingRoomID",
+    "fittingRoomId",
     "fittingRoomList",
     "geoLocationCity",
     "geoLocationState",
@@ -627,7 +628,7 @@ Object {
     "viewGender",
     "viewSubType",
     "viewType",
-    "weChatOpenID",
+    "weChatOpenId",
     "weChatUnionId",
     "wishlistQuantity",
     "accessTier",
@@ -735,7 +736,7 @@ Object {
     "basketQuantity",
     "categoryIdList",
     "checkboxFilter",
-    "clientAdvertisingID",
+    "clientAdvertisingId",
     "clientCulture",
     "clientGender",
     "clientInstallId",
@@ -751,7 +752,7 @@ Object {
     "domainUrl",
     "elementsSeen",
     "exitInteraction",
-    "fittingRoomID",
+    "fittingRoomId",
     "fittingRoomList",
     "geoLocationCity",
     "geoLocationState",
@@ -808,7 +809,7 @@ Object {
     "viewGender",
     "viewSubType",
     "viewType",
-    "weChatOpenID",
+    "weChatOpenId",
     "weChatUnionId",
     "wishlistQuantity",
     "accessTier",
@@ -904,7 +905,7 @@ Object {
     "basketQuantity",
     "categoryIdList",
     "checkboxFilter",
-    "clientAdvertisingID",
+    "clientAdvertisingId",
     "clientCulture",
     "clientGender",
     "clientInstallId",
@@ -920,7 +921,7 @@ Object {
     "domainUrl",
     "elementsSeen",
     "exitInteraction",
-    "fittingRoomID",
+    "fittingRoomId",
     "fittingRoomList",
     "geoLocationCity",
     "geoLocationState",
@@ -977,7 +978,7 @@ Object {
     "viewGender",
     "viewSubType",
     "viewType",
-    "weChatOpenID",
+    "weChatOpenId",
     "weChatUnionId",
     "wishlistQuantity",
     "accessTier",
@@ -1105,7 +1106,7 @@ Object {
 
 exports[`Omnitracking definitions \`product-details\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1}]",
   "listIndex": 3,
   "moduleId": "[\\"5c1e447a-b14b-43a5-b010-2190f3366fad\\"]",
   "moduleTitle": "[\\"Recommendations\\"]",
@@ -1116,7 +1117,7 @@ Object {
 
 exports[`Omnitracking definitions \`product-listing\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeID\\":1}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1}]",
   "viewSubType": "Listing",
   "viewType": "Listing",
 }
@@ -1151,7 +1152,7 @@ Array [
   "loadItemCoordinate",
   "moduleBenefit",
   "moduleContentDepartment",
-  "moduleContentID",
+  "moduleContentId",
   "moduleContentName",
   "moduleContentPublicationDate",
   "moduleContentVersion",
@@ -1297,7 +1298,7 @@ Array [
 
 exports[`Omnitracking definitions \`wishlist\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"itemQuantity\\":2},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeID\\":1,\\"itemQuantity\\":3}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":2},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":3}]",
   "viewSubType": "Wishlist",
   "viewType": "Wishlist",
   "wishlistQuantity": 5,


### PR DESCRIPTION
## Description

- Add sizeItem to product_updated (size) event;
- Fix camelCase fields on omnitracking whitelisted parameters;
- Add warn when login or signup have method property missing;
- Add and fix omnitracking tests and snapshots.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.
<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
