### PR TITLE
feat: add unitSalePrice to analytics events `v1`

### DIFF
--- a/packages/core/src/analytics/integrations/Omnitracking/definitions.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/definitions.js
@@ -13,6 +13,7 @@ import {
   getProductIdFromLineItems,
   getProductLineItems,
   getProductLineItemsQuantity,
+  getProductUnitSalePrice,
   getRecommendationsTrackingData,
   getValParameterForEvent,
 } from './omnitracking-helper';
@@ -811,6 +812,7 @@ export const pageEventsMapper = {
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
     productId: getProductIdFromLineItems(data),
+    unitSalePrice: getProductUnitSalePrice(data.properties),
     ...getRecommendationsTrackingData(data),
   }),
   [pageTypes.PRODUCT_LISTING]: data => ({

--- a/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
+++ b/packages/core/src/analytics/integrations/Omnitracking/omnitracking-helper.js
@@ -322,6 +322,28 @@ export const getValParameterForEvent = (valParameters = {}) => {
 };
 
 /**
+ * Get the product unit sale price from a specific product.
+ *
+ * @param {object} productData - Product data.
+ *
+ * @returns {number|undefined} The unit sale price value, or undefined if no pricing data was found in productData argument.
+ */
+export const getProductUnitSalePrice = productData => {
+  if (typeof productData.unitSalePrice === 'number') {
+    return productData.unitSalePrice;
+  }
+
+  if (
+    typeof productData.priceWithoutDiscount === 'number' &&
+    typeof productData.discountValue === 'number'
+  ) {
+    return productData.priceWithoutDiscount - productData.discountValue;
+  }
+
+  return undefined;
+};
+
+/**
  * Generates a payment attempt reference ID based on the correlationID (user local ID) and the timestamp of the event.
  *
  * @param {object} data - Event data passed by analytics.
@@ -491,6 +513,7 @@ export const getOmnitrackingProductMapper = productData => ({
   promoCode: productData.coupon,
   storeId: productData.locationId,
   listIndex: productData.position,
+  unitSalePrice: getProductUnitSalePrice(productData),
 });
 
 /**

--- a/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
+++ b/packages/core/src/analytics/integrations/__tests__/__snapshots__/Omnitracking.test.js.snap
@@ -44,7 +44,7 @@ Object {
   "checkoutStep": 1,
   "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\"}",
   "interactionType": "click",
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":0}]",
   "loginType": "guest",
   "orderCode": "ABC12",
   "orderId": 12345678,
@@ -78,7 +78,7 @@ Object {
   "checkoutStep": 2,
   "deliveryInformationDetails": "{\\"deliveryType\\":\\"Standard/Standard\\",\\"courierType\\":\\"Next Day\\",\\"packagingType\\":\\"foo\\"}",
   "interactionType": "click",
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":0}]",
   "orderCode": "ABC12",
   "orderId": 12345678,
   "promoCode": "PROMO_ABC",
@@ -169,7 +169,7 @@ Array [
 exports[`Omnitracking definitions \`Product Added to Cart\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "PDP",
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":0}]",
   "listIndex": 3,
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
@@ -183,7 +183,7 @@ exports[`Omnitracking definitions \`Product Added to Wishlist\` return should ma
 Object {
   "actionArea": "PDP",
   "isMainWishlist": true,
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":0}]",
   "listIndex": 3,
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
@@ -197,7 +197,7 @@ Object {
 exports[`Omnitracking definitions \`Product Clicked\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "PDP",
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":0}]",
   "listIndex": 3,
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
@@ -209,7 +209,7 @@ Object {
 exports[`Omnitracking definitions \`Product List Viewed\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "PLP",
-  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":25,\\"sizeId\\":1,\\"listIndex\\":2},{\\"productId\\":\\"507f1f77bcf86cd799439012\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25,\\"listIndex\\":3}]",
+  "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":25,\\"sizeId\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":19},{\\"productId\\":\\"507f1f77bcf86cd799439012\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25,\\"listIndex\\":3,\\"unitSalePrice\\":19}]",
   "moduleId": "[\\"12345\\"]",
   "moduleTitle": "[\\"Woman shopping\\"]",
   "tid": 2832,
@@ -220,7 +220,7 @@ exports[`Omnitracking definitions \`Product Removed From Wishlist\` return shoul
 Object {
   "actionArea": "PDP",
   "isMainWishlist": true,
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":0}]",
   "listIndex": 3,
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
@@ -234,7 +234,7 @@ Object {
 exports[`Omnitracking definitions \`Product Removed from Cart\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "PDP",
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":0}]",
   "listIndex": 3,
   "moduleId": "[\\"1234\\"]",
   "moduleTitle": "[\\"You may like\\"]",
@@ -360,7 +360,7 @@ exports[`Omnitracking definitions \`bag\` return should match the snapshot 1`] =
 Object {
   "basketQuantity": 8,
   "basketValue": 100,
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":5},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":3}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":5,\\"unitSalePrice\\":0},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":3,\\"unitSalePrice\\":0}]",
   "viewSubType": "Bag",
   "viewType": "Shopping Bag",
 }
@@ -1110,11 +1110,12 @@ Object {
 
 exports[`Omnitracking definitions \`product-details\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"unitSalePrice\\":0},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"unitSalePrice\\":0}]",
   "listIndex": 3,
   "moduleId": "[\\"5c1e447a-b14b-43a5-b010-2190f3366fad\\"]",
   "moduleTitle": "[\\"Recommendations\\"]",
   "productId": "12345678",
+  "unitSalePrice": undefined,
   "viewSubType": "Product",
   "viewType": "Product",
 }
@@ -1122,7 +1123,7 @@ Object {
 
 exports[`Omnitracking definitions \`product-listing\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"unitSalePrice\\":0},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"unitSalePrice\\":0}]",
   "viewSubType": "Listing",
   "viewType": "Listing",
 }
@@ -1303,7 +1304,7 @@ Array [
 
 exports[`Omnitracking definitions \`wishlist\` return should match the snapshot 1`] = `
 Object {
-  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":2},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":3}]",
+  "lineItems": "[{\\"productId\\":\\"12345678\\",\\"itemPromotion\\":1,\\"designerName\\":\\"designer name\\",\\"category\\":\\"shoes\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":2,\\"unitSalePrice\\":0},{\\"productId\\":\\"98765\\",\\"itemPromotion\\":1,\\"designerName\\":\\"shirt designer name\\",\\"category\\":\\"shirt\\",\\"itemFullPrice\\":1,\\"sizeId\\":1,\\"itemQuantity\\":3,\\"unitSalePrice\\":0}]",
   "viewSubType": "Wishlist",
   "viewType": "Wishlist",
   "wishlistQuantity": 5,


### PR DESCRIPTION
## Description

- Add unitSalePrice to lineItems and product_details event.
- Add a helper to calculate unitSalePrice (price - discount).
- Updated snapshots

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
