### PR TITLE
fix: save exchange filters by id

### DIFF
--- a/packages/core/src/entities/redux/__tests__/__snapshots__/reducer.test.js.snap
+++ b/packages/core/src/entities/redux/__tests__/__snapshots__/reducer.test.js.snap
@@ -38,6 +38,10 @@ Object {
     "@farfetch/blackout-core/GET_MEASUREMENTS_SUCCESS": [Function],
     "@farfetch/blackout-core/RESET_DETAILS_ENTITIES": [Function],
   },
+  "exchangeFilters": Object {
+    "@farfetch/blackout-core/LOGOUT_SUCCESS": [Function],
+    "@farfetch/blackout-core/RESET_EXCHANGE_FILTERS_ENTITIES": [Function],
+  },
   "listing": Object {
     "@farfetch/blackout-core/RESET_LISTING_ENTITIES": [Function],
   },

--- a/packages/core/src/entities/redux/reducer/entitiesMapper.js
+++ b/packages/core/src/entities/redux/reducer/entitiesMapper.js
@@ -3,6 +3,7 @@ import { entitiesMapper as authenticationEntitiesMapper } from '../../../authent
 import { entitiesMapper as bagEntitiesMapper } from '../../../bags/redux';
 import { entitiesMapper as checkoutEntitiesMapper } from '../../../checkout/redux';
 import { entitiesMapper as detailsEntitiesMapper } from '../../../products/details/redux';
+import { entitiesMapper as exchangeFiltersEntitiesMapper } from '../../../exchanges/redux';
 import { entitiesMapper as listingEntitiesMapper } from '../../../products/listing/redux';
 import { entitiesMapper as merchantsLocationsEntitiesMapper } from '../../../merchantsLocations/redux';
 import { entitiesMapper as ordersEntitiesMapper } from '../../../orders/redux';
@@ -22,6 +23,7 @@ export const defaultMappers = {
   bag: bagEntitiesMapper,
   checkout: checkoutEntitiesMapper,
   details: detailsEntitiesMapper,
+  exchangeFilters: exchangeFiltersEntitiesMapper,
   listing: listingEntitiesMapper,
   merchantsLocations: merchantsLocationsEntitiesMapper,
   orders: ordersEntitiesMapper,
@@ -39,6 +41,7 @@ export default ({ ...extraMappers }) =>
     ...bagEntitiesMapper,
     ...checkoutEntitiesMapper,
     ...detailsEntitiesMapper,
+    ...exchangeFiltersEntitiesMapper,
     ...listingEntitiesMapper,
     ...merchantsLocationsEntitiesMapper,
     ...ordersEntitiesMapper,

--- a/packages/core/src/entities/schemas/exchangeFilter.js
+++ b/packages/core/src/entities/schemas/exchangeFilter.js
@@ -1,0 +1,11 @@
+import { schema } from 'normalizr';
+
+const exchangeFiltersSchema = new schema.Entity(
+  'exchangeFilters',
+  {},
+  {
+    idAttribute: value => value.exchangeFilterItems[0].orderItemUuid,
+  },
+);
+
+export default exchangeFiltersSchema;

--- a/packages/core/src/exchanges/redux/__fixtures__/exchanges.fixtures.js
+++ b/packages/core/src/exchanges/redux/__fixtures__/exchanges.fixtures.js
@@ -23,21 +23,18 @@ export const responses = {
           orderItemUuid: orderItemUuid,
         },
       ],
-      logicOperator: {
-        logicOperatorType: 'And',
-        operators: [
-          {
-            criteria: 'ProductId',
-            comparator: 'Equals',
-            value: 18061196,
-          },
-          {
-            criteria: 'Price',
-            comparator: 'LessThanEqual',
-            value: 1.0,
-          },
-        ],
-      },
+      filters: [
+        {
+          criteria: 'ProductId',
+          comparator: 'Equals',
+          values: '18061196',
+        },
+        {
+          criteria: 'Price',
+          comparator: 'LessThanOrEqual',
+          values: '1.0',
+        },
+      ],
     },
   },
   postExchange: {
@@ -130,6 +127,13 @@ export const requestData = {
       },
     ],
   },
+  postExchangeFilterWithoutOrderItemUuid: {
+    exchangeFilterItems: [
+      {
+        orderCode: orderId,
+      },
+    ],
+  },
   postExchange: {
     exchangeGroups: [
       {
@@ -152,4 +156,33 @@ export const requestData = {
       },
     ],
   },
+};
+
+export const expectedExchangeFiltersNormalizedPayload = {
+  entities: {
+    exchangeFilters: {
+      [orderItemUuid]: {
+        id: exchangeFilterId,
+        exchangeFilterItems: [
+          {
+            orderCode: orderId,
+            orderItemUuid: orderItemUuid,
+          },
+        ],
+        filters: [
+          {
+            criteria: 'ProductId',
+            comparator: 'Equals',
+            values: '18061196',
+          },
+          {
+            criteria: 'Price',
+            comparator: 'LessThanOrEqual',
+            values: '1.0',
+          },
+        ],
+      },
+    },
+  },
+  result: orderItemUuid,
 };

--- a/packages/core/src/exchanges/redux/__tests__/selectors.test.js
+++ b/packages/core/src/exchanges/redux/__tests__/selectors.test.js
@@ -1,5 +1,11 @@
+import * as fromEntities from '../../../entities/redux/selectors/entity';
 import * as fromExchanges from '../reducer';
 import * as selectors from '../selectors';
+import {
+  exchangeFilterId,
+  orderId,
+  orderItemUuid,
+} from '../__fixtures__/exchanges.fixtures';
 
 describe('exchanges redux selectors', () => {
   const mockState = {
@@ -7,10 +13,9 @@ describe('exchanges redux selectors', () => {
       error: 'error: not loaded',
       result: 'mock result',
       isLoading: false,
-      exchangeFilter: {
-        error: 'error: not loaded',
-        isLoading: false,
-        result: 'mock result',
+      exchangeFilters: {
+        error: { [orderItemUuid]: null, '': null },
+        isLoading: { [orderItemUuid]: false, '': false },
       },
       exchangeBookRequests: {
         error: 'error: not loaded',
@@ -18,6 +23,32 @@ describe('exchanges redux selectors', () => {
         result: 'mock result',
       },
     },
+    entities: {
+      exchangeFilters: {
+        [orderItemUuid]: {
+          id: exchangeFilterId,
+          exchangeFilterItems: [
+            {
+              orderCode: orderId,
+              orderItemUuid: orderItemUuid,
+            },
+          ],
+          filters: [
+            {
+              criteria: 'ProductId',
+              comparator: 'Equals',
+              values: '18061196',
+            },
+            {
+              criteria: 'Price',
+              comparator: 'LessThanOrEqual',
+              values: '1.0',
+            },
+          ],
+        },
+      },
+    },
+    result: orderItemUuid,
   };
 
   beforeEach(jest.clearAllMocks);
@@ -53,30 +84,64 @@ describe('exchanges redux selectors', () => {
     });
   });
 
-  describe('getExchangeFilter()', () => {
-    it('should get the exchange filter result property from state', () => {
-      const spy = jest.spyOn(fromExchanges, 'getExchangeFilter');
+  describe('getExchangeFilters()', () => {
+    it('should get the exchange filters from state', () => {
+      const expectedResult = mockState.entities.exchangeFilters;
+      const spy = jest.spyOn(fromEntities, 'getEntity');
 
-      expect(selectors.getExchangeFilter(mockState)).toEqual(
-        mockState.exchanges.exchangeFilter.result,
+      expect(selectors.getExchangeFilters(mockState)).toEqual(expectedResult);
+      expect(spy).toHaveBeenCalledWith(mockState, 'exchangeFilters');
+    });
+  });
+
+  describe('getExchangeFilterById()', () => {
+    it('should get the exchange filter by id from state', () => {
+      const spy = jest.spyOn(fromEntities, 'getEntity');
+
+      expect(selectors.getExchangeFilterById(mockState, orderItemUuid)).toEqual(
+        mockState.entities.exchangeFilters[orderItemUuid],
       );
+      expect(spy).toHaveBeenCalledWith(
+        mockState,
+        'exchangeFilters',
+        orderItemUuid,
+      );
+    });
+  });
+
+  describe('getExchangeFilter()', () => {
+    it('should get the exchange filter error property from state', () => {
+      const spy = jest.spyOn(fromExchanges, 'getExchangeFilters');
+
+      expect(
+        selectors.getExchangeFilterError(mockState, orderItemUuid),
+      ).toEqual(mockState.exchanges.exchangeFilters.error[orderItemUuid]);
       expect(spy).toHaveBeenCalledWith(mockState.exchanges);
     });
 
-    it('should get the exchange filter error property from state', () => {
-      const spy = jest.spyOn(fromExchanges, 'getExchangeFilter');
+    it('should get the exchange filter error property from state without an orderItemUuid', () => {
+      const spy = jest.spyOn(fromExchanges, 'getExchangeFilters');
 
       expect(selectors.getExchangeFilterError(mockState)).toEqual(
-        mockState.exchanges.exchangeFilter.error,
+        mockState.exchanges.exchangeFilters.error[''],
       );
       expect(spy).toHaveBeenCalledWith(mockState.exchanges);
     });
 
     it('should get the exchange filter isLoading property from state', () => {
-      const spy = jest.spyOn(fromExchanges, 'getExchangeFilter');
+      const spy = jest.spyOn(fromExchanges, 'getExchangeFilters');
+
+      expect(
+        selectors.isExchangeFilterLoading(mockState, orderItemUuid),
+      ).toEqual(mockState.exchanges.exchangeFilters.isLoading[orderItemUuid]);
+      expect(spy).toHaveBeenCalledWith(mockState.exchanges);
+    });
+
+    it('should get the exchange filter isLoading property from state without an orderItemUuid', () => {
+      const spy = jest.spyOn(fromExchanges, 'getExchangeFilters');
 
       expect(selectors.isExchangeFilterLoading(mockState)).toEqual(
-        mockState.exchanges.exchangeFilter.isLoading,
+        mockState.exchanges.exchangeFilters.isLoading[''],
       );
       expect(spy).toHaveBeenCalledWith(mockState.exchanges);
     });

--- a/packages/core/src/exchanges/redux/actionTypes.js
+++ b/packages/core/src/exchanges/redux/actionTypes.js
@@ -56,3 +56,11 @@ export const CREATE_EXCHANGE_SUCCESS =
 
 /** Action type dispatched when reseting the exchanges. */
 export const RESET_EXCHANGES = '@farfetch/blackout-core/RESET_EXCHANGES';
+
+/** Action type dispatched when reseting the exchange filters. */
+export const RESET_EXCHANGE_FILTERS_STATE =
+  '@farfetch/blackout-core/RESET_EXCHANGE_FILTERS_STATE';
+
+/** Action type dispatched when reseting the exchange filters entities. */
+export const RESET_EXCHANGE_FILTERS_ENTITIES =
+  '@farfetch/blackout-core/RESET_EXCHANGE_FILTERS_ENTITIES';

--- a/packages/core/src/exchanges/redux/actions/__tests__/__snapshots__/doCreateExchangeFilter.test.js.snap
+++ b/packages/core/src/exchanges/redux/actions/__tests__/__snapshots__/doCreateExchangeFilter.test.js.snap
@@ -2,29 +2,36 @@
 
 exports[`doCreateExchangeFilter() action creator should create the correct actions for when the create exchange filter procedure is successful: create exchange filter success payload 1`] = `
 Object {
+  "meta": Object {
+    "orderItemUuid": "25C0AF64-7D1A-40B2-BA58-155A4B0C6878",
+  },
   "payload": Object {
-    "exchangeFilterItems": Array [
-      Object {
-        "orderCode": "ABC123",
-        "orderItemUuid": "25C0AF64-7D1A-40B2-BA58-155A4B0C6878",
+    "entities": Object {
+      "exchangeFilters": Object {
+        "25C0AF64-7D1A-40B2-BA58-155A4B0C6878": Object {
+          "exchangeFilterItems": Array [
+            Object {
+              "orderCode": "ABC123",
+              "orderItemUuid": "25C0AF64-7D1A-40B2-BA58-155A4B0C6878",
+            },
+          ],
+          "filters": Array [
+            Object {
+              "comparator": "Equals",
+              "criteria": "ProductId",
+              "values": "18061196",
+            },
+            Object {
+              "comparator": "LessThanOrEqual",
+              "criteria": "Price",
+              "values": "1.0",
+            },
+          ],
+          "id": "25301c32-d738-4315-8e9c-d43d2b57f009",
+        },
       },
-    ],
-    "id": "25301c32-d738-4315-8e9c-d43d2b57f009",
-    "logicOperator": Object {
-      "logicOperatorType": "And",
-      "operators": Array [
-        Object {
-          "comparator": "Equals",
-          "criteria": "ProductId",
-          "value": 18061196,
-        },
-        Object {
-          "comparator": "LessThanEqual",
-          "criteria": "Price",
-          "value": 1,
-        },
-      ],
     },
+    "result": "25C0AF64-7D1A-40B2-BA58-155A4B0C6878",
   },
   "type": "@farfetch/blackout-core/CREATE_EXCHANGE_FILTER_SUCCESS",
 }

--- a/packages/core/src/exchanges/redux/actions/__tests__/doCreateExchangeFilter.test.js
+++ b/packages/core/src/exchanges/redux/actions/__tests__/doCreateExchangeFilter.test.js
@@ -1,5 +1,10 @@
+import {
+  expectedExchangeFiltersNormalizedPayload,
+  orderItemUuid,
+  requestData,
+  responses,
+} from '../../__fixtures__/exchanges.fixtures';
 import { mockStore } from '../../../../../tests';
-import { requestData, responses } from '../../__fixtures__/exchanges.fixtures';
 import doCreateExchangeFilter from '../../actions/doCreateExchangeFilter';
 import find from 'lodash/find';
 import reducer, { actionTypes } from '../..';
@@ -14,6 +19,8 @@ describe('doCreateExchangeFilter() action creator', () => {
   const postExchangeFilter = jest.fn();
   const action = doCreateExchangeFilter(postExchangeFilter);
   const data = { ...requestData.postExchangeFilter };
+  const dataWithoutOrderItemUuid =
+    requestData.postExchangeFilterWithoutOrderItemUuid;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -34,9 +41,13 @@ describe('doCreateExchangeFilter() action creator', () => {
       expect(postExchangeFilter).toHaveBeenCalledWith(data, expectedConfig);
       expect(store.getActions()).toEqual(
         expect.arrayContaining([
-          { type: actionTypes.CREATE_EXCHANGE_FILTER_REQUEST },
+          {
+            type: actionTypes.CREATE_EXCHANGE_FILTER_REQUEST,
+            meta: { orderItemUuid },
+          },
           {
             type: actionTypes.CREATE_EXCHANGE_FILTER_FAILURE,
+            meta: { orderItemUuid },
             payload: { error: expectedError },
           },
         ]),
@@ -56,16 +67,43 @@ describe('doCreateExchangeFilter() action creator', () => {
     expect(postExchangeFilter).toHaveBeenCalledTimes(1);
     expect(postExchangeFilter).toHaveBeenCalledWith(data, expectedConfig);
     expect(actionResults).toMatchObject([
-      { type: actionTypes.CREATE_EXCHANGE_FILTER_REQUEST },
       {
-        payload: responses.postExchangeFilter.success,
+        type: actionTypes.CREATE_EXCHANGE_FILTER_REQUEST,
+        meta: { orderItemUuid },
+      },
+      {
+        payload: expectedExchangeFiltersNormalizedPayload,
+        meta: { orderItemUuid },
         type: actionTypes.CREATE_EXCHANGE_FILTER_SUCCESS,
       },
     ]);
     expect(
       find(actionResults, {
         type: actionTypes.CREATE_EXCHANGE_FILTER_SUCCESS,
+        meta: { orderItemUuid },
       }),
     ).toMatchSnapshot('create exchange filter success payload');
+  });
+
+  it('should create the correct actions when the orderItemUuid is not provided and the procedure fails', async () => {
+    const expectedError = new Error('No orderItemUuid found');
+
+    postExchangeFilter.mockRejectedValueOnce(expectedError);
+
+    try {
+      await store.dispatch(action(dataWithoutOrderItemUuid));
+    } catch (error) {
+      expect(error).toStrictEqual(expectedError);
+      expect(postExchangeFilter).toHaveBeenCalledTimes(0);
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          {
+            type: actionTypes.CREATE_EXCHANGE_FILTER_FAILURE,
+            meta: { orderItemUuid: '' },
+            payload: { error: expectedError },
+          },
+        ]),
+      );
+    }
   });
 });

--- a/packages/core/src/exchanges/redux/actions/__tests__/doResetExchangeFilters.test.js
+++ b/packages/core/src/exchanges/redux/actions/__tests__/doResetExchangeFilters.test.js
@@ -1,0 +1,26 @@
+import { actionTypes } from '../../';
+import { mockStore } from '../../../../../tests';
+import doResetExchangeFilters from '../doResetExchangeFilters';
+
+let store;
+
+describe('reset action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = mockStore();
+  });
+
+  it('should dispatch the correct action type', () => {
+    store.dispatch(doResetExchangeFilters());
+    const actionResults = store.getActions();
+
+    expect(actionResults).toMatchObject([
+      {
+        type: actionTypes.RESET_EXCHANGE_FILTERS_STATE,
+      },
+      {
+        type: actionTypes.RESET_EXCHANGE_FILTERS_ENTITIES,
+      },
+    ]);
+  });
+});

--- a/packages/core/src/exchanges/redux/actions/doResetExchangeFilters.js
+++ b/packages/core/src/exchanges/redux/actions/doResetExchangeFilters.js
@@ -1,0 +1,39 @@
+import {
+  RESET_EXCHANGE_FILTERS_ENTITIES,
+  RESET_EXCHANGE_FILTERS_STATE,
+} from '../actionTypes';
+
+/**
+ * Reset exchange filters slice state only
+ * to its initial value.
+ *
+ * @returns {Function} - Thunk.
+ */
+const resetExchangeFilterState = () => dispatch => {
+  dispatch({
+    type: RESET_EXCHANGE_FILTERS_STATE,
+  });
+};
+
+/**
+ * Reset exchange filters related entities to its initial value.
+ *
+ * @returns {Function} - Dispatch reset bag entities action.
+ */
+const resetEntities = () => dispatch => {
+  dispatch({
+    type: RESET_EXCHANGE_FILTERS_ENTITIES,
+  });
+};
+
+/**
+ * Reset exchange filters state and related entities to its initial value.
+ *
+ * @returns {Function} - Dispatch reset exchange filters state and entities action.
+ */
+const resetExchangeFilters = () => dispatch => {
+  dispatch(resetExchangeFilterState());
+  dispatch(resetEntities());
+};
+
+export default resetExchangeFilters;

--- a/packages/core/src/exchanges/redux/actions/index.js
+++ b/packages/core/src/exchanges/redux/actions/index.js
@@ -11,4 +11,5 @@ export { default as doCreateExchangeBookRequest } from './doCreateExchangeBookRe
 export { default as doCreateExchangeFilter } from './doCreateExchangeFilter';
 export { default as doGetExchange } from './doGetExchange';
 export { default as doGetExchangeBookRequest } from './doGetExchangeBookRequest';
+export { default as doResetExchangeFilters } from './doResetExchangeFilters';
 export { default as reset } from './reset';

--- a/packages/core/src/exchanges/redux/index.js
+++ b/packages/core/src/exchanges/redux/index.js
@@ -1,9 +1,9 @@
 import * as actionTypes from './actionTypes';
-import reducer from './reducer';
+import reducer, { entitiesMapper } from './reducer';
 
 export * from './actions';
 export * from './selectors';
 
-export { actionTypes };
+export { actionTypes, entitiesMapper };
 
 export default reducer;

--- a/packages/core/src/exchanges/redux/reducer.js
+++ b/packages/core/src/exchanges/redux/reducer.js
@@ -7,15 +7,15 @@
 import * as actionTypes from './actionTypes';
 import { combineReducers } from 'redux';
 import { createReducerWithResult } from '../../helpers/redux';
+import { LOGOUT_SUCCESS } from '../../authentication/redux/actionTypes';
 
 const INITIAL_STATE = {
   error: null,
   isLoading: false,
   result: null,
-  exchangeFilter: {
-    result: null,
-    error: null,
-    isLoading: false,
+  exchangeFilters: {
+    error: {},
+    isLoading: {},
   },
   exchangeBookRequests: {
     result: null,
@@ -62,11 +62,48 @@ const result = (state = INITIAL_STATE.result, action = {}) => {
   }
 };
 
-export const exchangeFilter = createReducerWithResult(
-  'CREATE_EXCHANGE_FILTER',
-  INITIAL_STATE.exchangeFilter,
-  actionTypes,
-);
+export const exchangeFilters = (
+  state = INITIAL_STATE.exchangeFilters,
+  action = {},
+) => {
+  switch (action.type) {
+    case actionTypes.CREATE_EXCHANGE_FILTER_REQUEST:
+      return {
+        isLoading: {
+          ...state.isLoading,
+          [action.meta.orderItemUuid]: true,
+        },
+        error: {
+          ...state.error,
+          [action.meta.orderItemUuid]: null,
+        },
+      };
+    case actionTypes.CREATE_EXCHANGE_FILTER_SUCCESS:
+      return {
+        ...state,
+        isLoading: {
+          ...state.isLoading,
+          [action.meta.orderItemUuid]: false,
+        },
+      };
+    case actionTypes.CREATE_EXCHANGE_FILTER_FAILURE:
+      return {
+        ...state,
+        isLoading: {
+          ...state.isLoading,
+          [action.meta.orderItemUuid]: false,
+        },
+        error: {
+          ...state.error,
+          [action.meta.orderItemUuid]: action.payload.error,
+        },
+      };
+    case actionTypes.RESET_EXCHANGE_FILTERS_STATE:
+      return INITIAL_STATE.exchangeFilters;
+    default:
+      return state;
+  }
+};
 
 export const exchangeBookRequests = createReducerWithResult(
   ['GET_EXCHANGE_BOOK_REQUEST', 'CREATE_EXCHANGE_BOOK_REQUEST'],
@@ -74,17 +111,32 @@ export const exchangeBookRequests = createReducerWithResult(
   actionTypes,
 );
 
+const resetExchangeFiltersEntities = state => {
+  if (!state) {
+    return state;
+  }
+
+  const { exchangeFilters, ...rest } = state;
+
+  return rest;
+};
+
+export const entitiesMapper = {
+  [actionTypes.RESET_EXCHANGE_FILTERS_ENTITIES]: resetExchangeFiltersEntities,
+  [LOGOUT_SUCCESS]: resetExchangeFiltersEntities,
+};
+
 export const getError = state => state.error;
 export const getIsLoading = state => state.isLoading;
 export const getResult = state => state.result;
-export const getExchangeFilter = state => state.exchangeFilter;
+export const getExchangeFilters = state => state.exchangeFilters;
 export const getExchangeBookRequests = state => state.exchangeBookRequests;
 
 const reducer = combineReducers({
   error,
   isLoading,
   result,
-  exchangeFilter,
+  exchangeFilters,
   exchangeBookRequests,
 });
 

--- a/packages/core/src/exchanges/redux/selectors.js
+++ b/packages/core/src/exchanges/redux/selectors.js
@@ -4,10 +4,11 @@
  * @subcategory Selectors
  */
 
+import { getEntity } from '../../entities/redux/selectors';
 import {
   getError,
   getExchangeBookRequests as getExchangeBookRequestsGetter,
-  getExchangeFilter as getExchangeFilterGetter,
+  getExchangeFilters as getExchangeFiltersGetter,
   getIsLoading,
   getResult as Result,
 } from './reducer';
@@ -47,15 +48,24 @@ export const isExchangesLoading = state => getIsLoading(state.exchanges);
 
 /**
  * Returns the exchange filter.
- *
- * @function
+ * Returns the exchange filter by id.
  *
  * @param {object} state - Application state.
+ * @param {string} orderItemUuid - ShippingOrderLineId value from OrderItem.
  *
  * @returns {object} Exchange filter.
  */
-export const getExchangeFilter = state =>
-  getExchangeFilterGetter(state.exchanges).result;
+export const getExchangeFilterById = (state, orderItemUuid) =>
+  getEntity(state, 'exchangeFilters', orderItemUuid);
+
+/**
+ * Returns the exchange filters.
+ *
+ * @param {object} state - Application state.
+ *
+ * @returns {object} Exchange filters.
+ */
+export const getExchangeFilters = state => getEntity(state, 'exchangeFilters');
 
 /**
  * Returns the loading status for the create exchange filter request.
@@ -63,11 +73,12 @@ export const getExchangeFilter = state =>
  * @function
  *
  * @param {object} state - Application state.
+ * @param {string} orderItemUuid - ShippingOrderLineId value from OrderItem.
  *
  * @returns {boolean} Loading status.
  */
-export const isExchangeFilterLoading = state =>
-  getExchangeFilterGetter(state.exchanges).isLoading;
+export const isExchangeFilterLoading = (state, orderItemUuid = '') =>
+  getExchangeFiltersGetter(state.exchanges).isLoading[orderItemUuid];
 
 /**
  * Returns the error for the create exchange filter request.
@@ -75,11 +86,12 @@ export const isExchangeFilterLoading = state =>
  * @function
  *
  * @param {object} state - Application state.
+ * @param {string} orderItemUuid - ShippingOrderLineId value from OrderItem.
  *
  * @returns {object} Exchange filter error.
  */
-export const getExchangeFilterError = state =>
-  getExchangeFilterGetter(state.exchanges).error;
+export const getExchangeFilterError = (state, orderItemUuid = '') =>
+  getExchangeFiltersGetter(state.exchanges).error[orderItemUuid];
 
 /**
  * Returns the exchange book requests.


### PR DESCRIPTION
## Description

BREAKING CHANGE: Exchange filters are now stored under entities by orderItemUuid (shippingOrderLineId). Previously the user wasn't able to fetch multiple filters because each request cleared the previous data, which this PR aims to fix.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
