### PR TITLE
fix: fix `productsList` schema handling of `filterSegments`

### DIFF
--- a/packages/client/src/users/authentication/getUserExternalLogins.ts
+++ b/packages/client/src/users/authentication/getUserExternalLogins.ts
@@ -15,7 +15,6 @@ const getUserExternalLogins: GetUserExternalLogins = (userId, config) =>
     .get(join('/account/v1/users', userId, '/externalLogins/'), config)
     .then(response => response.data)
     .catch(error => {
-      // console.log(error);
       throw adaptError(error);
     });
 

--- a/packages/redux/src/entities/schemas/productsList.ts
+++ b/packages/redux/src/entities/schemas/productsList.ts
@@ -67,7 +67,7 @@ export default new schema.Entity(
           // If the filter segment is an ProductVariantAttribute, filteredFacetGroups will be an array with
           // all attributes so the flow is a little different.
           if (filterSegment.type === ATTRIBUTES_TYPE) {
-            let facetIndex;
+            let facetIndex: number | undefined;
             const facetGroup = filteredFacetGroups.find(facet =>
               facet.values[0]?.find(({ value }, i) => {
                 if (value === filterSegment.value) {
@@ -79,9 +79,10 @@ export default new schema.Entity(
                 return false;
               }),
             );
-            const facet = facetIndex
-              ? facetGroup?.values[0]?.[facetIndex]
-              : undefined;
+            const facet =
+              typeof facetIndex === 'number'
+                ? facetGroup?.values[0]?.[facetIndex]
+                : undefined;
 
             return {
               ...filterSegment,
@@ -92,7 +93,13 @@ export default new schema.Entity(
             };
           }
 
-          const facet = filteredFacetGroups[0]?.values[0]?.find(
+          const allFacetGroupValues = filteredFacetGroups.reduce<
+            FacetGroup['values'][number]
+          >((acc, facetGroup) => {
+            return [...acc, ...facetGroup.values.flat()];
+          }, []);
+
+          const facet = allFacetGroupValues?.find(
             ({ value }) => value === filterSegment.value,
           );
 

--- a/packages/redux/src/products/actions/__tests__/fetchProductListing.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchProductListing.test.ts
@@ -8,7 +8,9 @@ import {
   mockProductsListNormalized,
   mockProductsListNormalizedPayload,
   mockProductsListNormalizedWithoutImageOptions,
+  mockProductsListNormalizedWithSizesFilterSegment,
   mockProductsListSlug,
+  mockProductsListWithSizesFilterSegment,
   mockQuery,
 } from 'tests/__fixtures__/products/index.mjs';
 import { mockStore } from '../../../../tests/index.js';
@@ -319,6 +321,46 @@ describe('fetchListing() action creator', () => {
       {
         meta: { hash: mockProductsListHash },
         payload: mockProductsListNormalized,
+        type: productsActionTypes.FETCH_PRODUCT_LISTING_SUCCESS,
+      },
+    ]);
+  });
+
+  it('should create the correct actions for when the fetch listing procedure is successful and a filter segment description is not on the first facet group', async () => {
+    store = productsListsMockStoreWithoutMiddlewares(state);
+    (getProductListing as jest.Mock).mockResolvedValueOnce(
+      mockProductsListWithSizesFilterSegment,
+    );
+
+    await fetchProductListing(mockProductsListSlug, mockQuery)(
+      store.dispatch,
+      store.getState as () => StoreState,
+      {} as GetOptionsArgument,
+    ).then(clientResult => {
+      expect(clientResult).toBe(mockProductsListWithSizesFilterSegment);
+    });
+
+    const actionResults = store.getActions();
+
+    expect(normalizeSpy).toHaveBeenCalledTimes(1);
+    expect(getProductListing).toHaveBeenCalledTimes(1);
+    expect(getProductListing).toHaveBeenCalledWith(
+      mockProductsListSlug,
+      mockQuery,
+      expectedConfig,
+    );
+    expect(actionResults).toEqual([
+      {
+        meta: { hash: mockProductsListHash },
+        type: productsActionTypes.SET_PRODUCT_LISTING_HASH,
+      },
+      {
+        meta: { hash: mockProductsListHash },
+        type: productsActionTypes.FETCH_PRODUCT_LISTING_REQUEST,
+      },
+      {
+        meta: { hash: mockProductsListHash },
+        payload: mockProductsListNormalizedWithSizesFilterSegment,
         type: productsActionTypes.FETCH_PRODUCT_LISTING_SUCCESS,
       },
     ]);

--- a/tests/__fixtures__/products/productsLists.fixtures.mts
+++ b/tests/__fixtures__/products/productsLists.fixtures.mts
@@ -242,6 +242,7 @@ export const mockSortOptions = [
     value: 0,
   },
 ];
+
 export const mockFacets = [
   {
     count: 13,
@@ -517,6 +518,251 @@ export const mockFacetGroupsNormalized = mockFacetGroups.map((facet, index) => {
   };
 });
 
+export const mockFacetGroupValuesWithSizesByCategory = [
+  {
+    value: 19,
+    valueUpperBound: 0,
+    description: 'XS',
+    slug: 'clothing-dresses',
+    url: 'clothing-dresses?sizes=19',
+    parentId: 0,
+    _isDisabled: false,
+    _isActive: false,
+    groupsOn: 182544,
+    count: 1,
+  },
+  {
+    value: 19,
+    valueUpperBound: 0,
+    description: 'XS',
+    slug: 'clothing-jumpsuits',
+    url: 'clothing-jumpsuits?sizes=19',
+    parentId: 0,
+    _isDisabled: false,
+    _isActive: false,
+    groupsOn: 182569,
+    count: 1,
+  },
+  {
+    value: 20,
+    valueUpperBound: 0,
+    description: 'S',
+    slug: 'clothing-jumpsuits',
+    url: 'clothing-jumpsuits?sizes=20',
+    parentId: 0,
+    _isDisabled: false,
+    _isActive: false,
+    groupsOn: 182569,
+    count: 1,
+  },
+  {
+    value: 21,
+    valueUpperBound: 0,
+    description: 'M',
+    slug: 'clothing-jumpsuits',
+    url: 'clothing-jumpsuits?sizes=21',
+    parentId: 0,
+    _isDisabled: false,
+    _isActive: false,
+    groupsOn: 182569,
+    count: 1,
+  },
+  {
+    value: 22,
+    valueUpperBound: 0,
+    description: 'L',
+    slug: 'clothing-jumpsuits',
+    url: 'clothing-jumpsuits?sizes=22',
+    parentId: 0,
+    _isDisabled: false,
+    _isActive: false,
+    groupsOn: 182569,
+    count: 1,
+  },
+  {
+    value: 23,
+    valueUpperBound: 0,
+    description: 'XL',
+    slug: 'clothing-jumpsuits',
+    url: 'clothing-jumpsuits?sizes=23',
+    parentId: 0,
+    _isDisabled: false,
+    _isActive: false,
+    groupsOn: 182569,
+    count: 1,
+  },
+] as const;
+
+export const mockSizesByCategoryFacetGroups = [
+  {
+    deep: 0,
+    description: 'SizesByCategory',
+    type: 24,
+    values: [[mockFacetGroupValuesWithSizesByCategory[0]]],
+    order: 6,
+    key: FacetGroupKey.SizesByCategory,
+    format: FacetGroupFormat.Multiple,
+    _clearUrl: null,
+    _isClearHidden: false,
+    _isClosed: false,
+    dynamic: 182544,
+  },
+  {
+    deep: 0,
+    description: 'SizesByCategory',
+    type: 24,
+    values: [
+      [
+        mockFacetGroupValuesWithSizesByCategory[1],
+        mockFacetGroupValuesWithSizesByCategory[2],
+        mockFacetGroupValuesWithSizesByCategory[3],
+        mockFacetGroupValuesWithSizesByCategory[4],
+        mockFacetGroupValuesWithSizesByCategory[5],
+      ],
+    ],
+    order: 6,
+    key: FacetGroupKey.SizesByCategory,
+    format: FacetGroupFormat.Multiple,
+    _clearUrl: null,
+    _isClearHidden: false,
+    _isClosed: false,
+    dynamic: 182569,
+  },
+];
+
+export const mockFacetGroupsWithSizesByCategory: FacetGroup[] = [
+  ...mockFacetGroups,
+  ...mockSizesByCategoryFacetGroups,
+];
+
+export const mockFacetEntitiesWithSizesByCategory = [
+  ...mockFacets,
+  {
+    _isActive: false,
+    _isDisabled: false,
+    count: 1,
+    description: 'XS',
+    groupType: 24,
+    groupsOn: 182544,
+    id: 'sizesbycategory_19_182544_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    parentId:
+      'sizesbycategory_0_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    slug: 'clothing-dresses',
+    url: 'clothing-dresses?sizes=19',
+    value: 19,
+    valueUpperBound: 0,
+  },
+  {
+    _isActive: false,
+    _isDisabled: false,
+    count: 1,
+    description: 'XS',
+    groupType: 24,
+    groupsOn: 182569,
+    id: 'sizesbycategory_19_182569_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    parentId:
+      'sizesbycategory_0_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    slug: 'clothing-jumpsuits',
+    url: 'clothing-jumpsuits?sizes=19',
+    value: 19,
+    valueUpperBound: 0,
+  },
+  {
+    _isActive: false,
+    _isDisabled: false,
+    count: 1,
+    description: 'S',
+    groupType: 24,
+    groupsOn: 182569,
+    id: 'sizesbycategory_20_182569_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    parentId:
+      'sizesbycategory_0_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    slug: 'clothing-jumpsuits',
+    url: 'clothing-jumpsuits?sizes=20',
+    value: 20,
+    valueUpperBound: 0,
+  },
+  {
+    _isActive: false,
+    _isDisabled: false,
+    count: 1,
+    description: 'M',
+    groupType: 24,
+    groupsOn: 182569,
+    id: 'sizesbycategory_21_182569_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    parentId:
+      'sizesbycategory_0_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    slug: 'clothing-jumpsuits',
+    url: 'clothing-jumpsuits?sizes=21',
+    value: 21,
+    valueUpperBound: 0,
+  },
+  {
+    _isActive: false,
+    _isDisabled: false,
+    count: 1,
+    description: 'L',
+    groupType: 24,
+    groupsOn: 182569,
+    id: 'sizesbycategory_22_182569_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    parentId:
+      'sizesbycategory_0_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    slug: 'clothing-jumpsuits',
+    url: 'clothing-jumpsuits?sizes=22',
+    value: 22,
+    valueUpperBound: 0,
+  },
+  {
+    _isActive: false,
+    _isDisabled: false,
+    count: 1,
+    description: 'XL',
+    groupType: 24,
+    groupsOn: 182569,
+    id: 'sizesbycategory_23_182569_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    parentId:
+      'sizesbycategory_0_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+    slug: 'clothing-jumpsuits',
+    url: 'clothing-jumpsuits?sizes=23',
+    value: 23,
+    valueUpperBound: 0,
+  },
+];
+
+export const mockFacetEntitiesWithSizesByCategoryNormalized =
+  mockFacetEntitiesWithSizesByCategory.reduce(
+    (oldFacet, newFacet) => ({
+      ...oldFacet,
+      [newFacet.id]: {
+        ...newFacet,
+        _isActive: false,
+        _isDisabled: false,
+      },
+    }),
+    {},
+  ) as Record<string, FacetEntity>;
+
+export const mockFacetGroupsWithSizesByCategoryNormalized = [
+  ...mockFacetGroupsNormalized,
+  ...mockSizesByCategoryFacetGroups.map(facet => {
+    const dynamic = facet.dynamic;
+
+    const mockFacetGroupValues = mockFacetEntitiesWithSizesByCategory
+      .filter(facetEntity => {
+        return facetEntity.groupsOn === dynamic;
+      })
+      .map(facetEntity => facetEntity.id);
+
+    const values = [mockFacetGroupValues];
+
+    return {
+      ...facet,
+      values,
+      hash: mockProductsListHash,
+    };
+  }),
+];
+
 export const mockProductsList = {
   breadCrumbs: mockBreadCrumbs,
   name: null,
@@ -578,6 +824,44 @@ export const mockProductsList = {
   config: {
     pageSize: 20,
   },
+};
+
+export const mockProductsListWithSizesFilterSegment = {
+  ...mockProductsList,
+  facetGroups: mockFacetGroupsWithSizesByCategory,
+  filterSegments: [
+    ...mockProductsList.filterSegments,
+    {
+      order: 0,
+      type: 9,
+      key: 'sizes',
+      gender: null,
+      value: 19,
+      valueUpperBound: 0,
+      slug: null,
+      description: null,
+      deep: 0,
+      parentId: 0,
+      fromQueryString: true,
+      negativeFilter: false,
+      prefixValue: '',
+    },
+    {
+      order: 0,
+      type: 9,
+      key: 'sizes',
+      gender: null,
+      value: 20,
+      valueUpperBound: 0,
+      slug: null,
+      description: null,
+      deep: 0,
+      parentId: 0,
+      fromQueryString: true,
+      negativeFilter: false,
+      prefixValue: '',
+    },
+  ],
 };
 
 const getMockProductsListNormalized = (includeImageQueryParam = true) => ({
@@ -686,6 +970,61 @@ const getMockProductsListNormalized = (includeImageQueryParam = true) => ({
 export const mockProductsListNormalized = getMockProductsListNormalized();
 export const mockProductsListNormalizedWithoutImageOptions =
   getMockProductsListNormalized(false);
+
+export const mockProductsListNormalizedWithSizesFilterSegment = {
+  ...mockProductsListNormalizedWithoutImageOptions,
+  entities: {
+    ...mockProductsListNormalizedWithoutImageOptions.entities,
+    facets: mockFacetEntitiesWithSizesByCategoryNormalized,
+    productsLists: {
+      ...mockProductsListNormalizedWithoutImageOptions.entities.productsLists,
+      [mockProductsListHash]: {
+        ...mockProductsListNormalizedWithoutImageOptions.entities.productsLists[
+          mockProductsListHash
+        ],
+        facetGroups: mockFacetGroupsWithSizesByCategoryNormalized,
+        filterSegments: [
+          ...mockProductsListNormalizedWithoutImageOptions.entities
+            .productsLists[mockProductsListHash].filterSegments,
+          {
+            order: 0,
+            type: 9,
+            key: 'sizes',
+            gender: null,
+            value: 19,
+            valueUpperBound: 0,
+            slug: null,
+            deep: 0,
+            parentId: 0,
+            fromQueryString: true,
+            negativeFilter: false,
+            prefixValue: '',
+            description: 'XS',
+            facetId:
+              'sizes_19_182544_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+          },
+          {
+            order: 0,
+            type: 9,
+            key: 'sizes',
+            gender: null,
+            value: 20,
+            valueUpperBound: 0,
+            slug: null,
+            deep: 0,
+            parentId: 0,
+            fromQueryString: true,
+            negativeFilter: false,
+            prefixValue: '',
+            description: 'S',
+            facetId:
+              'sizes_20_182569_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+          },
+        ],
+      },
+    },
+  },
+};
 
 const getMockProductsListForSetsWithIdNormalized = (
   includeImageQueryParam = true,


### PR DESCRIPTION
## Description

This fixes `productsList` schema handling of the `filterSegments` property which was not finding the correct facet when the filter segment was not pointing to the first facet of the first facet group.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

Closes #906 

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
