### PR TITLE
fix: add segments and benefits targets to commerce pages fetch

### DIFF
--- a/packages/client/src/contents/__tests__/getCommercePages.test.ts
+++ b/packages/client/src/contents/__tests__/getCommercePages.test.ts
@@ -2,6 +2,7 @@ import { CommercePagesType } from '../types/index.js';
 import { getCommercePages } from '../index.js';
 import client from '../../helpers/client/index.js';
 import fixtures from '../__fixtures__/commercepages.fixtures.js';
+import join from 'proper-url-join';
 import mswServer from '../../../tests/mswServer.js';
 
 describe('getCommercePages()', () => {
@@ -64,6 +65,23 @@ describe('getCommercePages()', () => {
       '/content/v2/commercepages?id=100200&type=PRODUCT',
       expectedConfig,
     );
+  });
+
+  it('should handle a client request successfully with target benefits and target segments', async () => {
+    mswServer.use(fixtures.get.success(response));
+
+    const query = {
+      type: CommercePagesType.Product,
+      id: 100200,
+      'target.benefits': 'private-sale,vip',
+      'target.segments': '45,full',
+    };
+
+    await expect(getCommercePages(query)).resolves.toEqual(response);
+
+    const url = join('content/v2/commercepages', { query });
+
+    expect(spy).toHaveBeenCalledWith(url, expectedConfig);
   });
 
   it('should handle a client request error', async () => {

--- a/packages/client/src/contents/__tests__/getContentPage.test.ts
+++ b/packages/client/src/contents/__tests__/getContentPage.test.ts
@@ -2,6 +2,7 @@ import { type ContentPage, ContentPageType } from '../types/index.js';
 import { getContentPage } from '../index.js';
 import client from '../../helpers/client/index.js';
 import fixture from '../__fixtures__/contentPage.fixtures.js';
+import join from 'proper-url-join';
 import mswServer from '../../../tests/mswServer.js';
 
 describe('getContentPage()', () => {
@@ -63,6 +64,22 @@ describe('getContentPage()', () => {
       `/wl/v1/content/pages/${contentType}?slug=%2Fshopping%2Ftest`,
       expectedConfig,
     );
+  });
+
+  it('should handle a client request successfully with target benefits and target segments', async () => {
+    mswServer.use(fixture.get.success(response));
+
+    const query = {
+      slug: '/shopping/test',
+      'target.benefits': 'private-sale,vip',
+      'target.segments': '45,full',
+    };
+
+    await expect(getContentPage(contentType, query)).resolves.toEqual(response);
+
+    const url = join('/wl/v1/content/pages/', contentType, { query });
+
+    expect(spy).toHaveBeenCalledWith(url, expectedConfig);
   });
 
   it('should handle a client request error', async () => {

--- a/packages/client/src/contents/types/commercePages.types.ts
+++ b/packages/client/src/contents/types/commercePages.types.ts
@@ -27,6 +27,10 @@ export type QueryCommercePages = {
   pageIndex?: number;
   // Size of each page, as a number between 1 and 180. The default is 60.
   pageSize?: number;
+  // Query by a specified Benefit, separated by commas.
+  'target.benefits'?: string;
+  // Query by a specified Segment, separated by commas.
+  'target.segments'?: string;
 };
 
 export type CommercePages = Contents;

--- a/packages/client/src/contents/types/contentPage.types.ts
+++ b/packages/client/src/contents/types/contentPage.types.ts
@@ -15,6 +15,10 @@ export enum ContentPageStrategy {
 export type QueryContentPage = {
   slug: string;
   strategy?: ContentPageStrategy;
+  // Query by a specified Benefit, separated by commas.
+  'target.benefits'?: string;
+  // Query by a specified Segment, separated by commas.
+  'target.segments'?: string;
 };
 
 export type ContentPage = PagedResponse<ContentEntry<[ComponentType]>>;


### PR DESCRIPTION
## Description

Include target **benefits** and target **segments** to Clients commerce pages and serverless API
<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->
None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [X] The commit message follows our guidelines
- [X] Tests for the respective changes have been added
- [X] The code is commented, particularly in hard-to-understand areas
- [X] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
