### PR TITLE
fix: fix `ids` slice reducer in wishlist sets

### DIFF
--- a/packages/redux/src/wishlists/reducer/wishlistsSets.ts
+++ b/packages/redux/src/wishlists/reducer/wishlistsSets.ts
@@ -40,8 +40,6 @@ const ids = (state = INITIAL_STATE.ids, action: AnyAction) => {
         : [action.payload.result];
     case actionTypes.REMOVE_WISHLIST_SET_SUCCESS:
       return state?.filter(id => id !== action.meta.wishlistSetId);
-    case actionTypes.FETCH_WISHLIST_SUCCESS:
-      return INITIAL_STATE.ids;
     default:
       return state;
   }


### PR DESCRIPTION
## Description

This fixes the `ids` slice reducer in wishlist sets reducer by removing the handler for the fetch wishlist success action as it is unnecessary, since it should only be reset when the user's wishlist id changes and that is already being handled in the wishlists reducer.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

Closes #878 

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
