### PR TITLE
chore: update wishlistset type to include sharedWishlistId

### DIFF
--- a/packages/client/src/wishlists/types/wishlistSet.types.ts
+++ b/packages/client/src/wishlists/types/wishlistSet.types.ts
@@ -13,5 +13,6 @@ export type WishlistSet = {
   description?: string;
   name: string;
   setId: string;
+  sharedWishlistId?: string;
   wishlistSetItems: Array<WishlistSetItem>;
 };


### PR DESCRIPTION
## Description

This adds the sharedWishlistId property to the `WishtlistSet` type which was missing.

<!--
Please include a summary of the changes.
Please also include relevant motivation and context.
-->

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
