### PR TITLE
Revert "fix: buildQueryStringFromObject query construction"

### DIFF
--- a/packages/redux/src/brands/__tests__/utils.test.ts
+++ b/packages/redux/src/brands/__tests__/utils.test.ts
@@ -3,7 +3,7 @@ import { mockBrandsQuery } from 'tests/__fixtures__/brands/index.mjs';
 
 describe('generateBrandsHash', () => {
   it('should correctly construct the brands hash - with query object', () => {
-    const expectedResult = 'brands?id=211376%2C%20220127';
+    const expectedResult = 'brands?id=211376, 220127';
     const result = generateBrandsHash(mockBrandsQuery);
 
     expect(result).toBe(expectedResult);

--- a/packages/redux/src/helpers/__tests__/buildQueryStringFromObject.test.ts
+++ b/packages/redux/src/helpers/__tests__/buildQueryStringFromObject.test.ts
@@ -11,7 +11,7 @@ describe('buildQueryStringFromObject', () => {
 
   it('should correctly construct the correct query string given a query object with some values as array', () => {
     const mockQuery = { pageindex: 1, colors: [1, 2] };
-    const expectedResult = '?pageindex=1&colors=1%7C2';
+    const expectedResult = '?pageindex=1&colors=1|2';
     const result = buildQueryStringFromObject(mockQuery);
 
     expect(result).toBe(expectedResult);
@@ -49,14 +49,6 @@ describe('buildQueryStringFromObject', () => {
     const mockQuery = { sort: 'price', sortdirection: 'asc' };
     const expectedResult = 'sort=price&sortdirection=asc';
     const result = buildQueryStringFromObject(mockQuery, false);
-
-    expect(result).toBe(expectedResult);
-  });
-
-  it('should correctly construct the correct query string given a query object with string values url encoded', () => {
-    const mockQuery = { query: 'black & white' };
-    const expectedResult = '?query=black%20%26%20white';
-    const result = buildQueryStringFromObject(mockQuery);
 
     expect(result).toBe(expectedResult);
   });

--- a/packages/redux/src/helpers/buildQueryStringFromObject.ts
+++ b/packages/redux/src/helpers/buildQueryStringFromObject.ts
@@ -32,11 +32,7 @@ const buildQueryStringFromObject = (
     const parsedValue = Array.isArray(value) ? value.join('|') : value;
 
     (parsedValue || typeof parsedValue === 'boolean') &&
-      paramsToUrl.push([
-        `${key.toLowerCase()}=${encodeURIComponent(
-          parsedValue as string | number | boolean,
-        )}`,
-      ]);
+      paramsToUrl.push([`${key.toLowerCase()}=${parsedValue}`]);
   }
 
   const prefix = useQuestionMark ? '?' : '';

--- a/packages/redux/src/products/serverInitialState/__tests__/lists.test.ts
+++ b/packages/redux/src/products/serverInitialState/__tests__/lists.test.ts
@@ -33,7 +33,7 @@ describe('products lists serverInitialState()', () => {
 
   it('should build the correct sorted hash with encoded query params', () => {
     const slug = '/en-pt/shopping?colors=11%7C6&another=foo';
-    const expectedHash = 'listing?colors=11%7C6&another=foo';
+    const expectedHash = 'listing?colors=11|6&another=foo';
     // @ts-expect-error A lot of properties would need to be added to make the value comply with the type which are irrelevant for the test
     const model = {
       ...mockProductsListModel,

--- a/tests/__fixtures__/brands/brands.fixtures.mts
+++ b/tests/__fixtures__/brands/brands.fixtures.mts
@@ -6,7 +6,7 @@ import {
 
 export const mockBrandId = 211376;
 export const mockBrandId2 = 220127;
-export const mockHash = 'brands?id=211376%2C%20220127';
+export const mockHash = 'brands?id=211376, 220127';
 
 export const mockBrandsQuery = {
   id: `${mockBrandId}, ${mockBrandId2}`,

--- a/tests/__fixtures__/products/productsLists.fixtures.mts
+++ b/tests/__fixtures__/products/productsLists.fixtures.mts
@@ -37,7 +37,7 @@ export const mockProductsListHashWithPageIndexParameter =
   'listing/woman/clothing?pageindex=1';
 export const mockProductsListHashWithSingleProductId = 'listing?id=12913172';
 export const mockProductsListHashWithProductIds =
-  'listing?id=12913172%7C12913174';
+  'listing?id=12913172|12913174';
 export const mockProductsListHashForSets =
   'sets/woman/clothing?categories=135971&colors=6&pageindex=1';
 export const mockProductsListHashForSetsWithId = `sets/${mockSetId}`;


### PR DESCRIPTION
## Description

This reverts commit 871a98db22326e88566f98ce23d235695b39776a.

The change to buildQueryStringFromObject function broke range filters (like price). The original problem that caused this commit in the first place will be addressed in another PR as it will affect getSearchRedirectUrl util function in @farfetch/blackout-react.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
