### PR TITLE
feat: add delivery bundles usecheckout

### DIFF
--- a/packages/react/src/checkout/hooks/__tests__/useCheckout.test.tsx
+++ b/packages/react/src/checkout/hooks/__tests__/useCheckout.test.tsx
@@ -6,6 +6,7 @@ import {
   mockCheckoutState,
   mockCheckoutStateWithGuestUser,
   mockCheckoutStateWithoutDetails,
+  mockDeliveryBundlesEntityDenormalized,
   mockErrorState,
   mockInitialState,
   mockInitialStateWithGuestUser,
@@ -177,6 +178,7 @@ const defaultReturn = {
     isOrderConfirmed: expect.any(Function),
     isOrderAwaitingPayment: expect.any(Function),
     getSelectedShippingOption: expect.any(Function),
+    getSelectedDeliveryBundle: expect.any(Function),
     isShippingAddressZipCodeValid: expect.any(Function),
   },
 };
@@ -257,6 +259,7 @@ describe('useCheckout', () => {
         collectPoints:
           mockCheckoutState.checkout.collectPoints[`${checkoutId}|false|false`]
             ?.result,
+        deliveryBundles: mockDeliveryBundlesEntityDenormalized,
       },
     });
   });

--- a/packages/react/src/checkout/hooks/useCheckout.ts
+++ b/packages/react/src/checkout/hooks/useCheckout.ts
@@ -3,6 +3,7 @@ import {
   areCheckoutOrderTagsLoading as areCheckoutOrderTagsLoadingSelector,
   createCheckoutOrder,
   fetchCheckoutOrder,
+  getCheckoutOrderDeliveryBundles,
   getCheckoutOrderError,
   getCheckoutOrderPromocodesError,
   getCheckoutOrderResult,
@@ -16,7 +17,6 @@ import {
   setCheckoutOrderPromocodes,
   setCheckoutOrderTags,
   updateCheckoutOrder,
-  getCheckoutOrderDeliveryBundles,
 } from '@farfetch/blackout-redux';
 import {
   type CheckoutAddress,
@@ -86,8 +86,12 @@ function useCheckout(
   const setPromocodesAction = useAction(setCheckoutOrderPromocodes);
   const removePromocodesAction = useAction(removeCheckoutOrderPromocodes);
   const resetCheckoutState = useAction(resetCheckout);
-  const getDeliveryBundles = useSelector(getCheckoutOrderDeliveryBundles);
-  const deliveryBundlesSelect = getDeliveryBundles?.find((item: { isSelected: boolean; }) => item.isSelected);
+  const deliveryBundles = useSelector(getCheckoutOrderDeliveryBundles);
+  const getSelectedDeliveryBundle = useCallback(
+    () =>
+      deliveryBundles?.find((item: { isSelected: boolean }) => item.isSelected),
+    [deliveryBundles],
+  );
   const { data: user } = useUser();
 
   const isAuthorized =
@@ -461,12 +465,14 @@ function useCheckout(
       details: checkoutOrderDetails,
       instruments,
       collectPoints,
+      deliveryBundles,
     };
   }, [
     chargeResult,
     checkoutOrderDetails,
     checkoutOrderResult,
     collectPoints,
+    deliveryBundles,
     instruments,
   ]);
 
@@ -606,8 +612,7 @@ function useCheckout(
       isOrderConfirmed,
       isOrderAwaitingPayment,
       getSelectedShippingOption,
-      getDeliveryBundles,
-      deliveryBundlesSelect,
+      getSelectedDeliveryBundle,
       isShippingAddressZipCodeValid,
     },
     data,

--- a/packages/react/src/checkout/hooks/useCheckout.ts
+++ b/packages/react/src/checkout/hooks/useCheckout.ts
@@ -21,6 +21,7 @@ import {
 import {
   type CheckoutAddress,
   type CheckoutOrder,
+  type CheckoutOrderDeliveryBundle,
   type Config,
   type CountryAddressSchema,
   type GetCheckoutOrderQuery,
@@ -89,7 +90,10 @@ function useCheckout(
   const deliveryBundles = useSelector(getCheckoutOrderDeliveryBundles);
   const getSelectedDeliveryBundle = useCallback(
     () =>
-      deliveryBundles?.find((item: { isSelected: boolean }) => item.isSelected),
+      deliveryBundles?.find(
+        (deliveryBundle: CheckoutOrderDeliveryBundle) =>
+          deliveryBundle.isSelected,
+      ),
     [deliveryBundles],
   );
   const { data: user } = useUser();

--- a/packages/react/src/checkout/hooks/useCheckout.ts
+++ b/packages/react/src/checkout/hooks/useCheckout.ts
@@ -16,6 +16,7 @@ import {
   setCheckoutOrderPromocodes,
   setCheckoutOrderTags,
   updateCheckoutOrder,
+  getCheckoutOrderDeliveryBundles,
 } from '@farfetch/blackout-redux';
 import {
   type CheckoutAddress,
@@ -85,6 +86,8 @@ function useCheckout(
   const setPromocodesAction = useAction(setCheckoutOrderPromocodes);
   const removePromocodesAction = useAction(removeCheckoutOrderPromocodes);
   const resetCheckoutState = useAction(resetCheckout);
+  const getDeliveryBundles = useSelector(getCheckoutOrderDeliveryBundles);
+  const deliveryBundlesSelect = getDeliveryBundles?.find((item: { isSelected: boolean; }) => item.isSelected);
   const { data: user } = useUser();
 
   const isAuthorized =
@@ -603,6 +606,8 @@ function useCheckout(
       isOrderConfirmed,
       isOrderAwaitingPayment,
       getSelectedShippingOption,
+      getDeliveryBundles,
+      deliveryBundlesSelect,
       isShippingAddressZipCodeValid,
     },
     data,

--- a/packages/redux/src/checkout/__tests__/selectors.test.ts
+++ b/packages/redux/src/checkout/__tests__/selectors.test.ts
@@ -13,6 +13,7 @@ import {
   checkoutOrderItemId,
   contextId,
   deliveryBundleId,
+  deliveryBundleId_2,
   deliveryBundlesEntity,
   deliveryBundleUpgradeId_1,
   deliveryBundleUpgradesEntity,
@@ -56,7 +57,7 @@ describe('checkout redux selectors', () => {
         selectors.getCheckoutOrderDeliveryBundles(mockCheckoutState),
       ).toEqual([
         deliveryBundlesEntity[deliveryBundleId],
-        deliveryBundlesEntity['090998'],
+        deliveryBundlesEntity[deliveryBundleId_2],
       ]);
     });
   });

--- a/packages/redux/src/checkout/__tests__/selectors.test.ts
+++ b/packages/redux/src/checkout/__tests__/selectors.test.ts
@@ -54,7 +54,10 @@ describe('checkout redux selectors', () => {
     it('should get the checkout delivery bundles', () => {
       expect(
         selectors.getCheckoutOrderDeliveryBundles(mockCheckoutState),
-      ).toEqual([deliveryBundlesEntity[deliveryBundleId]]);
+      ).toEqual([
+        deliveryBundlesEntity[deliveryBundleId],
+        deliveryBundlesEntity['090998'],
+      ]);
     });
   });
 

--- a/tests/__fixtures__/checkout/checkout.fixtures.mts
+++ b/tests/__fixtures__/checkout/checkout.fixtures.mts
@@ -1054,6 +1054,8 @@ export const deliveryBundlesEntity = {
   },
 };
 
+export const mockDeliveryBundlesEntityDenormalized = [deliveryBundle];
+
 export const deliveryBundleUpgradesEntity = {
   [deliveryBundleId]: {
     [itemId1]: {
@@ -1491,6 +1493,7 @@ export const mockCheckoutState = {
       error: null,
       result: [contextId],
     },
+    deliveryBundles: [deliveryBundleId, '090998'],
   },
   payments: {
     ...mockInitialState.payments,

--- a/tests/__fixtures__/checkout/checkout.fixtures.mts
+++ b/tests/__fixtures__/checkout/checkout.fixtures.mts
@@ -997,7 +997,7 @@ export const checkoutEntity = {
   checkoutOrder: checkoutOrderId,
   id: checkoutId,
   shippingOptions: [shippingOption],
-  deliveryBundles: [deliveryBundleId],
+  deliveryBundles: [deliveryBundleId, '090998'],
   orderStatus: OrderStatusError.NoError,
 };
 
@@ -1054,7 +1054,10 @@ export const deliveryBundlesEntity = {
   },
 };
 
-export const mockDeliveryBundlesEntityDenormalized = [deliveryBundle];
+export const mockDeliveryBundlesEntityDenormalized = [
+  deliveryBundle,
+  { ...deliveryBundle, id: '090998', name: 'fake bundle', isSelected: false },
+];
 
 export const deliveryBundleUpgradesEntity = {
   [deliveryBundleId]: {

--- a/tests/__fixtures__/checkout/checkout.fixtures.mts
+++ b/tests/__fixtures__/checkout/checkout.fixtures.mts
@@ -38,6 +38,7 @@ export const operationId = '987654321';
 export const upgradeId = '123456';
 export const chargeId = 'eb92d414-68de-496e-96db-a0c6582b74d4';
 export const deliveryBundleId = '1234';
+export const deliveryBundleId_2 = '090998';
 export const merchantLocationId = 1212121212;
 export const collectPointId = 999;
 export const itemId1 = 0;
@@ -997,7 +998,7 @@ export const checkoutEntity = {
   checkoutOrder: checkoutOrderId,
   id: checkoutId,
   shippingOptions: [shippingOption],
-  deliveryBundles: [deliveryBundleId, '090998'],
+  deliveryBundles: [deliveryBundleId, deliveryBundleId_2],
   orderStatus: OrderStatusError.NoError,
 };
 
@@ -1046,9 +1047,9 @@ const deliveryBundle = {
 
 export const deliveryBundlesEntity = {
   [deliveryBundleId]: deliveryBundle,
-  '090998': {
+  [deliveryBundleId_2]: {
     ...deliveryBundle,
-    id: '090998',
+    id: deliveryBundleId_2,
     name: 'fake bundle',
     isSelected: false,
   },
@@ -1056,7 +1057,12 @@ export const deliveryBundlesEntity = {
 
 export const mockDeliveryBundlesEntityDenormalized = [
   deliveryBundle,
-  { ...deliveryBundle, id: '090998', name: 'fake bundle', isSelected: false },
+  {
+    ...deliveryBundle,
+    id: deliveryBundleId_2,
+    name: 'fake bundle',
+    isSelected: false,
+  },
 ];
 
 export const deliveryBundleUpgradesEntity = {
@@ -1496,7 +1502,7 @@ export const mockCheckoutState = {
       error: null,
       result: [contextId],
     },
-    deliveryBundles: [deliveryBundleId, '090998'],
+    deliveryBundles: [deliveryBundleId, deliveryBundleId_2],
   },
   payments: {
     ...mockInitialState.payments,


### PR DESCRIPTION
## Description

We understand that the responsibility for exposing delivery bundles data lies with `useCheckout`. So I opened this PR in which I get the delivery bundles in the context of redux and expose it in the `useCheckout` hook. I also take the opportunity to add a key to the `useCheckout` that represents which delivery bundle has been selected.


<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
