### PR TITLE
fix: fix `getProductListingFacetGroups` selector

### DIFF
--- a/packages/client/src/products/types/facetValue.types.ts
+++ b/packages/client/src/products/types/facetValue.types.ts
@@ -2,7 +2,7 @@ export type FacetValue = {
   value: number;
   valueUpperBound: number;
   description: string;
-  slug: string;
+  slug: string | null;
   url: string;
   parentId: number;
   groupsOn: number;

--- a/packages/redux/src/products/actions/__tests__/fetchProductListing.test.ts
+++ b/packages/redux/src/products/actions/__tests__/fetchProductListing.test.ts
@@ -328,6 +328,7 @@ describe('fetchListing() action creator', () => {
 
   it('should create the correct actions for when the fetch listing procedure is successful and a filter segment description is not on the first facet group', async () => {
     store = productsListsMockStoreWithoutMiddlewares(state);
+
     (getProductListing as jest.Mock).mockResolvedValueOnce(
       mockProductsListWithSizesFilterSegment,
     );

--- a/packages/redux/src/products/selectors/__tests__/listings.test.ts
+++ b/packages/redux/src/products/selectors/__tests__/listings.test.ts
@@ -12,11 +12,12 @@ import {
   mockFacets,
   mockFacetsNormalized,
   mockGroupedEntries,
-  mockProductsListDenormalizedFacetGroups,
+  mockProductsListDenormalizedFacetGroupsWithMultipleValues,
   mockProductsListHash,
   mockProductsListHashWithPageIndexParameter,
   mockProductsListNormalizedPayload,
   mockProductsState,
+  mockProductsWithMultipleFacetGroupValuesState,
   mockSetId,
 } from 'tests/__fixtures__/products/index.mjs';
 import { mockCategory } from 'tests/__fixtures__/categories/index.mjs';
@@ -1008,11 +1009,13 @@ describe('product listing redux selectors', () => {
   describe('getProductListingFacetGroups()', () => {
     it('should return all the facet groups correctly', () => {
       const expectedResult =
-        mockProductsListDenormalizedFacetGroups[mockProductsListHash];
+        mockProductsListDenormalizedFacetGroupsWithMultipleValues[
+          mockProductsListHash
+        ];
 
       expect(
         selectors.getProductListingFacetGroups(
-          mockProductsState,
+          mockProductsWithMultipleFacetGroupValuesState,
           mockProductsListHash,
         ),
       ).toEqual(expectedResult);

--- a/packages/redux/src/products/selectors/listings.ts
+++ b/packages/redux/src/products/selectors/listings.ts
@@ -413,8 +413,10 @@ export const getProductListingActiveFilters: (
           valueUpperBound !== 0 ? `${value}-${valueUpperBound}` : value;
       }
 
-      if (acc[key]) {
-        acc[key]?.push(activeFilterValue);
+      const currentFacetGroupActiveFilters = acc[key];
+
+      if (currentFacetGroupActiveFilters) {
+        currentFacetGroupActiveFilters.push(activeFilterValue);
       } else {
         if (valueUpperBound !== 0 && !isDiscount) {
           acc[key] = [value, valueUpperBound];
@@ -747,15 +749,20 @@ export const getProductListingFacetGroups = createSelector(
   (listing, allFacets) =>
     listing?.facetGroups?.map(facetGroup => ({
       ...facetGroup,
-      values: facetGroup.values[0]?.reduce((acc, facetGroupId) => {
-        const facetEntity = allFacets?.[facetGroupId];
+      values: facetGroup.values.reduce<FacetEntity[]>(
+        (acc, facetGroupValues) => {
+          facetGroupValues.forEach(facetId => {
+            const facetEntity = allFacets?.[facetId];
 
-        if (facetEntity) {
-          acc.push(facetEntity);
-        }
+            if (facetEntity) {
+              acc.push(facetEntity);
+            }
+          });
 
-        return acc;
-      }, [] as FacetEntity[]),
+          return acc;
+        },
+        [],
+      ),
     })),
 ) as (
   state: StoreState,

--- a/tests/__fixtures__/products/productsLists.fixtures.mts
+++ b/tests/__fixtures__/products/productsLists.fixtures.mts
@@ -2075,6 +2075,58 @@ export const mockProductsListNormalizedPayload = {
   },
 };
 
+export const mockProductsListDenormalizedFacetGroupsWithMultipleValues = {
+  ...mockProductsListDenormalizedFacetGroups,
+  [mockProductsListHash]: [
+    ...mockProductsListDenormalizedFacetGroups[mockProductsListHash],
+    {
+      _clearUrl: null,
+      _isClearHidden: false,
+      _isClosed: false,
+      deep: 0,
+      description: 'Sizes',
+      dynamic: 0,
+      format: 'multiple',
+      hash: 'listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+      key: 'sizes',
+      order: 4,
+      type: 9,
+      values: [
+        {
+          value: 17,
+          valueUpperBound: 0,
+          description: '1 mth',
+          slug: null,
+          url: '?sizes=17',
+          parentId:
+            'sizes_0_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+          _isDisabled: false,
+          _isActive: false,
+          groupsOn: 148305,
+          count: 7,
+          id: 'sizes_17_148305_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+          groupType: 9,
+        },
+        {
+          value: 26,
+          valueUpperBound: 0,
+          description: '38',
+          slug: null,
+          url: '?sizes=26',
+          parentId:
+            'sizes_0_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+          _isDisabled: false,
+          _isActive: false,
+          groupsOn: 148177,
+          count: 2200,
+          id: 'sizes_26_148177_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+          groupType: 9,
+        },
+      ],
+    },
+  ],
+};
+
 export const mockProductsListModel = {
   slug: mockProductsListSlug,
   subfolder: 'us',

--- a/tests/__fixtures__/products/state.fixtures.mts
+++ b/tests/__fixtures__/products/state.fixtures.mts
@@ -1,3 +1,8 @@
+import {
+  type BlackoutError,
+  FacetGroupFormat,
+  FacetGroupKey,
+} from '@farfetch/blackout-client';
 import { mockState as brandsMockState } from '../brands/index.mjs';
 import { mockBagItemEntity } from '../bags/bagItem.fixtures.mjs';
 import { mockCategoriesState } from '../categories/index.mjs';
@@ -12,7 +17,6 @@ import {
 import { mockRecentlyViewedState } from './recentlyViewed.fixtures.mjs';
 import { mockRecommendedProductSetState } from './recommendedProductSet.fixtures.mjs';
 import { mockRecommendedProductsState } from './recommendedProducts.fixtures.mjs';
-import type { BlackoutError } from '@farfetch/blackout-client';
 import type { ProductEntity } from '@farfetch/blackout-redux';
 
 export const mockAttributesState = {
@@ -281,6 +285,79 @@ export const mockProductsState = {
         ProductEntity
       >),
       [mockProductId]: mockProduct,
+    },
+  },
+};
+
+export const mockProductsWithMultipleFacetGroupValuesState = {
+  ...mockProductsState,
+  entities: {
+    ...mockProductsState.entities,
+    facets: {
+      ...mockProductsState.entities.facets,
+      'sizes_17_148305_listing/woman/clothing?categories=135971&colors=6&pageindex=1':
+        {
+          value: 17,
+          valueUpperBound: 0,
+          description: '1 mth',
+          slug: null,
+          url: '?sizes=17',
+          parentId:
+            'sizes_0_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+          _isDisabled: false,
+          _isActive: false,
+          groupsOn: 148305,
+          count: 7,
+          id: 'sizes_17_148305_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+          groupType: 9,
+        },
+      'sizes_26_148177_listing/woman/clothing?categories=135971&colors=6&pageindex=1':
+        {
+          value: 26,
+          valueUpperBound: 0,
+          description: '38',
+          slug: null,
+          url: '?sizes=26',
+          parentId:
+            'sizes_0_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+          _isDisabled: false,
+          _isActive: false,
+          groupsOn: 148177,
+          count: 2200,
+          id: 'sizes_26_148177_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+          groupType: 9,
+        },
+    },
+    productsLists: {
+      ...mockProductsState.entities.productsLists,
+      [mockProductsListHash]: {
+        ...mockProductsState.entities.productsLists[mockProductsListHash],
+        facetGroups: [
+          ...mockProductsState.entities.productsLists[mockProductsListHash]
+            .facetGroups,
+          {
+            deep: 0,
+            description: 'Sizes',
+            type: 9,
+            order: 4,
+            key: FacetGroupKey.Sizes,
+            format: FacetGroupFormat.Multiple,
+            values: [
+              [
+                'sizes_17_148305_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+              ],
+              [
+                'sizes_26_148177_listing/woman/clothing?categories=135971&colors=6&pageindex=1',
+              ],
+            ],
+            _clearUrl: null,
+            _isClearHidden: false,
+            _isClosed: false,
+            dynamic: 0,
+            hash: mockProductsListHash,
+          },
+        ],
+      },
     },
   },
 };


### PR DESCRIPTION
## Description

This fixes the `getProductListingFacetGroups` selector as it was only
returning the `values` property containing only the facets for the
first value in the array.
Also, a fix for the type `FacetValue`'s slug property was added.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
