### PR TITLE
feat: add itemListName parameter to analytics events `main`

### DIFF
--- a/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/__snapshots__/Omnitracking.test.ts.snap
@@ -155,10 +155,9 @@ Object {
 exports[`Omnitracking track events definitions \`Product Added to Cart\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "Wishlist",
+  "itemListName": "my_wishlist",
   "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":19}]",
   "listIndex": 2,
-  "moduleId": "[\\"d3618128-5aa9-4caa-a452-1dd1377a6190\\"]",
-  "moduleTitle": "[\\"my_wishlist\\"]",
   "priceCurrency": "USD",
   "productId": "507f1f77bcf86cd799439011",
   "tid": 2915,
@@ -169,10 +168,9 @@ exports[`Omnitracking track events definitions \`Product Added to Wishlist\` ret
 Object {
   "actionArea": "Plp",
   "isMainWishlist": true,
+  "itemListName": "Woman shopping",
   "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":19}]",
   "listIndex": 2,
-  "moduleId": "[\\"/en-pt/shopping/woman\\"]",
-  "moduleTitle": "[\\"Woman shopping\\"]",
   "priceCurrency": "USD",
   "productId": "507f1f77bcf86cd799439011",
   "tid": 2916,
@@ -182,7 +180,8 @@ Object {
 
 exports[`Omnitracking track events definitions \`Product Clicked\` return should match the snapshot 1`] = `
 Object {
-  "actionArea": "Plp",
+  "actionArea": "Recommendations",
+  "itemListName": "Woman shopping",
   "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":3,\\"unitSalePrice\\":19}]",
   "listIndex": 3,
   "moduleId": "[\\"/en-pt/shopping/woman\\"]",
@@ -195,9 +194,8 @@ Object {
 exports[`Omnitracking track events definitions \`Product List Viewed\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "Plp",
+  "itemListName": "Woman shopping",
   "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25,\\"listIndex\\":2,\\"unitSalePrice\\":19},{\\"productId\\":\\"507f1f77bcf86cd799439012\\",\\"itemPromotion\\":6,\\"category\\":\\"\\",\\"itemFullPrice\\":25,\\"listIndex\\":3,\\"unitSalePrice\\":19}]",
-  "moduleId": "[\\"d3618128-5aa9-4caa-a452-1dd1377a6190\\"]",
-  "moduleTitle": "[\\"Woman shopping\\"]",
   "tid": 2832,
 }
 `;
@@ -206,10 +204,9 @@ exports[`Omnitracking track events definitions \`Product Removed From Wishlist\`
 Object {
   "actionArea": "Plp",
   "isMainWishlist": true,
+  "itemListName": "Woman shopping",
   "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":2,\\"unitSalePrice\\":19}]",
   "listIndex": 2,
-  "moduleId": "[\\"/en-pt/shopping/woman\\"]",
-  "moduleTitle": "[\\"Woman shopping\\"]",
   "priceCurrency": "USD",
   "productId": "507f1f77bcf86cd799439011",
   "tid": 2925,
@@ -220,10 +217,9 @@ Object {
 exports[`Omnitracking track events definitions \`Product Removed from Cart\` return should match the snapshot 1`] = `
 Object {
   "actionArea": "Bag",
+  "itemListName": "Bag",
   "lineItems": "[{\\"productId\\":\\"507f1f77bcf86cd799439011\\",\\"itemPromotion\\":6,\\"designerName\\":\\"Just A T-Shirt\\",\\"category\\":\\"Clothing\\",\\"itemFullPrice\\":25,\\"itemQuantity\\":1,\\"listIndex\\":1,\\"unitSalePrice\\":19}]",
   "listIndex": 1,
-  "moduleId": "[\\"e0030b3c-b970-4496-bc72-f9a38d6270b1\\"]",
-  "moduleTitle": "[\\"Bag\\"]",
   "priceCurrency": "USD",
   "productId": "507f1f77bcf86cd799439011",
   "tid": 131,

--- a/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
+++ b/packages/analytics/src/integrations/Omnitracking/__tests__/omnitracking-helper.test.ts
@@ -1,7 +1,6 @@
 import {
   EventType,
   FromParameterType,
-  PageType,
   SignupNewsletterGenderType,
 } from '../../../types/index.js';
 import {
@@ -262,12 +261,13 @@ describe('omnitracking-helper', () => {
       moduleId: JSON.stringify([mockedRecommendationsValues.listId]),
     };
 
-    it('should return undefined in case its non recommendations product-details event', () => {
+    it('should return undefined in case its non recommendations event', () => {
       expect(
         getRecommendationsTrackingData({
-          event: PageType.ProductDetails,
+          event: 'abc',
           properties: {
             from: 'abc',
+            list: 'dummy',
           } as Record<string, unknown>,
         } as EventData<TrackTypesValues>),
       ).toBeUndefined();
@@ -301,7 +301,7 @@ describe('omnitracking-helper', () => {
         getRecommendationsTrackingData({
           event: 'abc',
           properties: {
-            from: 'abc',
+            from: FromParameterType.Recommendations,
             list: mockedRecommendationsValues.list,
           } as Record<string, unknown>,
         } as EventData<TrackTypesValues>),

--- a/packages/analytics/src/integrations/Omnitracking/definitions.ts
+++ b/packages/analytics/src/integrations/Omnitracking/definitions.ts
@@ -555,6 +555,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     listIndex: data.properties?.position,
     isMainWishlist: data.properties?.isMainWishlist,
     productId: getProductIdFromLineItems(data),
+    itemListName: data.properties?.list,
     ...getRecommendationsTrackingData(data),
   }),
   [EventType.ProductRemovedFromWishlist]: (
@@ -568,12 +569,14 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
     productId: getProductIdFromLineItems(data),
+    itemListName: data.properties?.list,
     ...getRecommendationsTrackingData(data),
   }),
   [EventType.ProductListViewed]: data => ({
     tid: 2832,
     lineItems: getProductLineItems(data),
     actionArea: data.properties?.from,
+    itemListName: data.properties?.list,
     ...getRecommendationsTrackingData(data),
   }),
   [EventType.CheckoutAbandoned]: data => ({
@@ -613,6 +616,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     productId: getProductIdFromLineItems(data),
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
+    itemListName: data.properties?.list,
     ...getRecommendationsTrackingData(data),
   }),
   [EventType.ProductAddedToCart]: data => ({
@@ -622,6 +626,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
     productId: getProductIdFromLineItems(data),
+    itemListName: data.properties?.list,
     ...getRecommendationsTrackingData(data),
   }),
   [EventType.ProductRemovedFromCart]: (data: EventData<TrackTypesValues>) => ({
@@ -631,6 +636,7 @@ export const trackEventsMapper: Readonly<OmnitrackingTrackEventsMapper> = {
     lineItems: getProductLineItems(data),
     listIndex: data.properties?.position,
     productId: getProductIdFromLineItems(data),
+    itemListName: data.properties?.list,
     ...getRecommendationsTrackingData(data),
   }),
   [EventType.SelectContent]: data => {

--- a/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
+++ b/packages/analytics/src/integrations/Omnitracking/omnitracking-helper.ts
@@ -8,7 +8,6 @@ import {
   type AnalyticsProduct,
   type EventData,
   FromParameterType,
-  PageType,
   SignupNewsletterGenderType,
   type TrackType,
   type TrackTypesValues,
@@ -687,10 +686,7 @@ export const getGenderValueFromProperties = (
 export const getRecommendationsTrackingData = (
   data: EventData<TrackTypesValues>,
 ) => {
-  if (
-    data.event !== PageType.ProductDetails ||
-    data.properties.from === FromParameterType.Recommendations
-  ) {
+  if (data.properties.from === FromParameterType.Recommendations) {
     const recommendationsParameters: Record<string, unknown> = {};
 
     if (data.properties?.listId) {
@@ -708,7 +704,7 @@ export const getRecommendationsTrackingData = (
     return recommendationsParameters;
   }
 
-  // In case it's a non recommendations Product Details event,
+  // In case it's a non recommendations event,
   // we do not need to send these recommendations parameters.
   return;
 };

--- a/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
+++ b/packages/react/src/analytics/integrations/GA4/__tests__/__snapshots__/GA4.test.ts.snap
@@ -746,7 +746,7 @@ Array [
     Object {
       "analytics_package_version": "0.1.0",
       "blackoutAnalyticsEventId": "4eabf689-96e3-4952-8176-248a848f1e1f",
-      "from": "Plp",
+      "from": "Recommendations",
       "index": 3,
       "item_list_id": "/en-pt/shopping/woman",
       "item_list_name": "Woman shopping",

--- a/tests/__fixtures__/analytics/track/productClickedTrackData.fixtures.mts
+++ b/tests/__fixtures__/analytics/track/productClickedTrackData.fixtures.mts
@@ -5,7 +5,7 @@ const fixtures = {
   ...baseTrackData,
   event: EventType.ProductClicked,
   properties: {
-    from: FromParameterType.Plp,
+    from: FromParameterType.Recommendations,
     id: '507f1f77bcf86cd799439011',
     name: 'Gareth McConnell Dreamscape T-Shirt',
     position: 3,


### PR DESCRIPTION
## Description

- Added itemListName parameter to some analytics events on omnitracking side.
- Updated `getRecommendationsTrackingData` function regarding a specific case: send moduleTitle and moduleId only when it's a recommendations related event. This meets the changes requested by the data team, which asks for moduleTitle and itemListName on events that are related to recommendations, otherwise, only itemListName.
- Updated unit tests as well.

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
