### PR TITLE
fix(client|redux): account settings type and reducer export

### DIFF
--- a/packages/client/src/settings/types/getAccountSetting.ts
+++ b/packages/client/src/settings/types/getAccountSetting.ts
@@ -4,7 +4,7 @@ export type AccountSetting = {
   id: string;
   channelCode?: string;
   type: string;
-  details: object;
+  details: Record<string, unknown>;
 };
 
 export type GetAccountSetting = (

--- a/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/redux/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1816,6 +1816,7 @@ Object {
   "settingsEntitiesMapper": Object {
     "@farfetch/blackout-redux/RESET_CONFIGURATIONS_STATE": [Function],
   },
+  "settingsReducer": [Function],
   "sizeGuidesActionTypes": Object {
     "FETCH_SIZE_GUIDES_FAILURE": "@farfetch/blackout-redux/FETCH_SIZE_GUIDES_FAILURE",
     "FETCH_SIZE_GUIDES_REQUEST": "@farfetch/blackout-redux/FETCH_SIZE_GUIDES_REQUEST",

--- a/packages/redux/src/settings/reducer/index.ts
+++ b/packages/redux/src/settings/reducer/index.ts
@@ -12,7 +12,7 @@ export {
   accountSettingReducer,
 };
 
-const settingsReducer = combineReducers({
+export const settingsReducer = combineReducers({
   configurations: configurationsReducer,
   accountSetting: accountSettingReducer,
   accountSettings: accountSettingsReducer,


### PR DESCRIPTION
## Description

This fixes an issue with settings reducer export, it was missing the export needed for imports using object destructuring and fixed the type of the property details in the AccountSetting type. We need it to be dynamic since backend is always pushing for new settings configurations. 

### Dependencies

None

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
