### PR TITLE
fix(redux): add sort by date on recently viewed `main`

### DIFF
--- a/packages/redux/src/products/reducer/__tests__/recentlyViewed.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/recentlyViewed.test.ts
@@ -1,6 +1,8 @@
 import {
   expectedRecentlyViewedLocalPayload,
   expectedRecentlyViewedRemotePayload,
+  expectedRecentlyViewedRemotePayloadSorted,
+  expectRecentlyViewedLocalPayloadSorted,
 } from 'tests/__fixtures__/products/index.mjs';
 import { productsActionTypes } from '../../index.js';
 import reducer, {
@@ -155,6 +157,17 @@ describe('Recently Viewed reducer', () => {
       expect(state.result).toEqual(initialState.result);
     });
 
+    it('should return the products ordered by date', () => {
+      const state = reducer(undefined, {
+        type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
+        payload: expectedRecentlyViewedRemotePayload,
+      });
+
+      expect(state.result?.computed).toEqual(
+        expectedRecentlyViewedRemotePayloadSorted.entries,
+      );
+    });
+
     it(`should handle ${productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS} action type`, () => {
       const state = reducer(undefined, {
         type: productsActionTypes.FETCH_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
@@ -171,7 +184,7 @@ describe('Recently Viewed reducer', () => {
       });
 
       expect(state.result?.computed).toEqual(
-        expectedRecentlyViewedLocalPayload,
+        expectRecentlyViewedLocalPayloadSorted,
       );
     });
 
@@ -191,6 +204,10 @@ describe('Recently Viewed reducer', () => {
           {
             productId: 22222222,
             lastVisitDate: '2020-02-03T11:08:50.010Z',
+          },
+          {
+            productId: 44444444,
+            lastVisitDate: '2020-02-03T10:08:50.010Z',
           },
         ],
       };

--- a/packages/redux/src/products/reducer/recentlyViewedProducts.ts
+++ b/packages/redux/src/products/reducer/recentlyViewedProducts.ts
@@ -1,7 +1,7 @@
 import * as actionTypes from '../actionTypes/index.js';
 import * as authenticationActionTypes from '../../users/authentication/actionTypes.js';
 import { type AnyAction, combineReducers, type Reducer } from 'redux';
-import { omit, uniqBy } from 'lodash-es';
+import { omit, sortBy, uniqBy } from 'lodash-es';
 import type { RecentlyViewedProducts } from '@farfetch/blackout-client';
 import type { RecentlyViewedState } from '../types/index.js';
 
@@ -54,7 +54,13 @@ const result = (
       return {
         remote: action.payload,
         pagination: omit(action.payload, 'entries') as RecentlyViewedProducts,
-        computed: uniqBy([...action.payload.entries, ...computed], 'productId'),
+        computed: uniqBy(
+          sortBy(
+            [...action.payload.entries, ...computed],
+            entry => new Date(entry.lastVisitDate),
+          ),
+          'productId',
+        ),
       };
     }
     case actionTypes.SAVE_RECENTLY_VIEWED_PRODUCT: {
@@ -64,7 +70,13 @@ const result = (
       return {
         remote: state?.remote,
         pagination: state?.pagination,
-        computed: uniqBy([...action.payload, ...computed], 'productId'),
+        computed: uniqBy(
+          sortBy(
+            [...action.payload, ...computed],
+            entry => new Date(entry.lastVisitDate),
+          ),
+          'productId',
+        ),
       };
     }
     case actionTypes.REMOVE_RECENTLY_VIEWED_PRODUCT_SUCCESS: {

--- a/tests/__fixtures__/products/recentlyViewed.fixtures.mts
+++ b/tests/__fixtures__/products/recentlyViewed.fixtures.mts
@@ -1,3 +1,5 @@
+import { sortBy } from 'lodash-es';
+
 export const id = 1345678;
 export const expectedRecentlyViewedRemotePayload = {
   number: 1,
@@ -15,6 +17,14 @@ export const expectedRecentlyViewedRemotePayload = {
   ],
 };
 
+export const expectedRecentlyViewedRemotePayloadSorted = {
+  ...expectedRecentlyViewedRemotePayload,
+  entries: sortBy(
+    expectedRecentlyViewedRemotePayload.entries,
+    entry => new Date(entry.lastVisitDate),
+  ),
+};
+
 export const expectedRecentlyViewedLocalPayload = [
   {
     productId: 22222222,
@@ -22,9 +32,15 @@ export const expectedRecentlyViewedLocalPayload = [
   },
   {
     productId: 33333333,
-    lastVisitDate: '2020-02-03T11:08:50.010Z',
+    lastVisitDate: '2020-02-03T12:08:50.010Z',
   },
+  { productId: 44444444, lastVisitDate: '2020-02-03T10:08:50.010Z' },
 ];
+
+export const expectRecentlyViewedLocalPayloadSorted = sortBy(
+  expectedRecentlyViewedLocalPayload,
+  entry => new Date(entry.lastVisitDate),
+);
 
 export const mockRecentlyViewedState = {
   recentlyViewed: {


### PR DESCRIPTION
## Description

- Fixed the order of the data presented on recently viewed, I've added a sort by date.
- Adjusted some unit tests and added another to check specifically this logic of sorting.

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
