### PR TITLE
fix(core): add sort by date on recently viewed `v1`

### DIFF
--- a/packages/core/src/recentlyViewed/redux/__mocks__/getRecentlyViewed.js
+++ b/packages/core/src/recentlyViewed/redux/__mocks__/getRecentlyViewed.js
@@ -21,6 +21,6 @@ export const expectedLocalPayload = [
   },
   {
     productId: 33333333,
-    lastVisitDate: '2020-02-03T11:08:50.010Z',
+    lastVisitDate: '2020-02-02T11:08:50.010Z',
   },
 ];

--- a/packages/core/src/recentlyViewed/redux/__tests__/reducer.test.js
+++ b/packages/core/src/recentlyViewed/redux/__tests__/reducer.test.js
@@ -4,6 +4,7 @@ import {
   expectedRemotePayload,
 } from '../__mocks__/getRecentlyViewed';
 import reducer, { actionTypes } from '..';
+import sortBy from 'lodash/sortBy';
 
 let initialState;
 
@@ -137,6 +138,20 @@ describe('Recently Viewed reducer', () => {
       expect(state.result).toEqual(initialState.result);
     });
 
+    it('should return the products ordered by date', () => {
+      const state = reducer(undefined, {
+        type: actionTypes.GET_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
+        payload: expectedRemotePayload,
+      });
+
+      expect(state.result?.computed).toEqual(
+        sortBy(
+          expectedRemotePayload.entries,
+          entry => new Date(entry.lastVisitDate),
+        ),
+      );
+    });
+
     it(`should handle ${actionTypes.GET_RECENTLY_VIEWED_PRODUCTS_SUCCESS} action type`, () => {
       const state = reducer(undefined, {
         type: actionTypes.GET_RECENTLY_VIEWED_PRODUCTS_SUCCESS,
@@ -152,7 +167,9 @@ describe('Recently Viewed reducer', () => {
         payload: expectedLocalPayload,
       });
 
-      expect(state.result.computed).toEqual(expectedLocalPayload);
+      expect(state.result.computed).toEqual(
+        sortBy(expectedLocalPayload, entry => new Date(entry.lastVisitDate)),
+      );
     });
 
     it(`should handle ${actionTypes.DELETE_RECENTLY_VIEWED_PRODUCT_SUCCESS} action type`, () => {

--- a/packages/core/src/recentlyViewed/redux/reducer.js
+++ b/packages/core/src/recentlyViewed/redux/reducer.js
@@ -6,6 +6,7 @@
 import * as actionTypes from './actionTypes';
 import { combineReducers } from 'redux';
 import omit from 'lodash/omit';
+import sortBy from 'lodash/sortBy';
 import uniqBy from 'lodash/uniqBy';
 
 export const INITIAL_STATE = {
@@ -61,7 +62,13 @@ const result = (
       return {
         remote: action.payload,
         pagination: omit(action.payload, 'entries'),
-        computed: uniqBy([...action.payload.entries, ...computed], 'productId'),
+        computed: uniqBy(
+          sortBy(
+            [...action.payload.entries, ...computed],
+            entry => new Date(entry.lastVisitDate),
+          ),
+          'productId',
+        ),
       };
     }
     case actionTypes.SAVE_RECENTLY_VIEWED_PRODUCT: {
@@ -70,7 +77,13 @@ const result = (
       // Merge the new payload before the previously computed entries and filter the repeated ones
       return {
         ...state,
-        computed: uniqBy([...action.payload, ...computed], 'productId'),
+        computed: uniqBy(
+          sortBy(
+            [...action.payload, ...computed],
+            entry => new Date(entry.lastVisitDate),
+          ),
+          'productId',
+        ),
       };
     }
     case actionTypes.DELETE_RECENTLY_VIEWED_PRODUCT_SUCCESS: {


### PR DESCRIPTION
## Description

- Fixed the order of the data presented on recently viewed, I've added a sort by date.
- Adjusted some unit tests and added another to check specifically this logic of sorting.

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

None.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
