### PR TITLE
fix: fix useUser hook infinite loading

### DIFF
--- a/packages/react/src/users/hooks/__tests__/useUser.test.ts
+++ b/packages/react/src/users/hooks/__tests__/useUser.test.ts
@@ -249,7 +249,7 @@ describe('useUser', () => {
   describe('options', () => {
     it('should call `fetchUser` data if `enableAutoFetch` option is true and `useLegacyActions` is false', () => {
       renderHook(() => useUser({ enableAutoFetch: true }), {
-        wrapper: withStore(mockStore),
+        wrapper: withStore({ entities: {}, users: mockUserInitialState }),
       });
 
       expect(fetchUser).toHaveBeenCalled();
@@ -259,7 +259,7 @@ describe('useUser', () => {
       renderHook(
         () => useUser({ enableAutoFetch: true, useLegacyActions: true }),
         {
-          wrapper: withStore(mockStore),
+          wrapper: withStore({ entities: {}, users: mockUserInitialState }),
         },
       );
 
@@ -269,6 +269,17 @@ describe('useUser', () => {
     it('should not fetch data if `enableAutoFetch` option is false', () => {
       renderHook(() => useUser(), {
         wrapper: withStore(mockStore),
+      });
+
+      expect(fetchUser).not.toHaveBeenCalled();
+    });
+
+    it('should not fetch data if `enableAutoFetch` option is true but the user has already been fetched', () => {
+      renderHook(() => useUser(), {
+        wrapper: withStore({
+          entities: mockGuestUserEntities,
+          users: mockUserInitialState,
+        }),
       });
 
       expect(fetchUser).not.toHaveBeenCalled();

--- a/packages/react/src/users/hooks/useUser.ts
+++ b/packages/react/src/users/hooks/useUser.ts
@@ -136,9 +136,13 @@ function useUser(options: UseUserOptions = {}) {
   useEffect(() => {
     const updatedState = store.getState() as StoreState;
 
+    const updatedUser = getUser(updatedState);
+    const updatedError = getUserError(updatedState);
+    const updatedIsFetched =
+      (!!updatedUser && !!updatedUser.id) || updatedError;
     const updatedIsLoading = isUserLoadingSelector(updatedState);
 
-    if (enableAutoFetch && !updatedIsLoading && !userError) {
+    if (enableAutoFetch && !updatedIsFetched && !updatedIsLoading) {
       fetch(fetchConfig);
     }
   }, [


### PR DESCRIPTION
## Description

This fixes the bug with the `useUser` hook which could enter an infinite loop when enableAutoFetch is set to true.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
