### PR TITLE
fix: fix recentlyViewedProducts reducer to sort descending

### DIFF
--- a/packages/redux/src/products/actions/__tests__/__snapshots__/fetchRecentlyViewedProducts.test.ts.snap
+++ b/packages/redux/src/products/actions/__tests__/__snapshots__/fetchRecentlyViewedProducts.test.ts.snap
@@ -5,12 +5,12 @@ Object {
   "payload": Object {
     "entries": Array [
       Object {
-        "lastVisitDate": "2020-02-02T15:57:30.238Z",
-        "productId": 11111111,
-      },
-      Object {
         "lastVisitDate": "2020-02-01T15:57:30.238Z",
         "productId": 22222222,
+      },
+      Object {
+        "lastVisitDate": "2020-02-02T15:57:30.238Z",
+        "productId": 11111111,
       },
     ],
     "number": 1,

--- a/packages/redux/src/products/reducer/__tests__/recentlyViewed.test.ts
+++ b/packages/redux/src/products/reducer/__tests__/recentlyViewed.test.ts
@@ -194,7 +194,7 @@ describe('Recently Viewed reducer', () => {
         result: {
           pagination: initialState.result?.pagination,
           remote: expectedRecentlyViewedRemotePayload,
-          computed: expectedRecentlyViewedLocalPayload,
+          computed: expectRecentlyViewedLocalPayloadSorted,
         },
       };
       const productId = 33333333;

--- a/packages/redux/src/products/reducer/recentlyViewedProducts.ts
+++ b/packages/redux/src/products/reducer/recentlyViewedProducts.ts
@@ -1,7 +1,7 @@
 import * as actionTypes from '../actionTypes/index.js';
 import * as authenticationActionTypes from '../../users/authentication/actionTypes.js';
 import { type AnyAction, combineReducers, type Reducer } from 'redux';
-import { omit, sortBy, uniqBy } from 'lodash-es';
+import { omit, orderBy, uniqBy } from 'lodash-es';
 import type { RecentlyViewedProducts } from '@farfetch/blackout-client';
 import type { RecentlyViewedState } from '../types/index.js';
 
@@ -55,9 +55,10 @@ const result = (
         remote: action.payload,
         pagination: omit(action.payload, 'entries') as RecentlyViewedProducts,
         computed: uniqBy(
-          sortBy(
+          orderBy(
             [...action.payload.entries, ...computed],
             entry => new Date(entry.lastVisitDate),
+            'desc',
           ),
           'productId',
         ),
@@ -71,9 +72,10 @@ const result = (
         remote: state?.remote,
         pagination: state?.pagination,
         computed: uniqBy(
-          sortBy(
+          orderBy(
             [...action.payload, ...computed],
             entry => new Date(entry.lastVisitDate),
+            'desc',
           ),
           'productId',
         ),

--- a/packages/redux/src/products/selectors/__tests__/recentlyViewed.test.ts
+++ b/packages/redux/src/products/selectors/__tests__/recentlyViewed.test.ts
@@ -1,10 +1,10 @@
 import * as recentlyViewedReducer from '../../reducer/recentlyViewedProducts.js';
 import * as selectors from '../recentlyViewedProducts.js';
 import {
-  expectedRecentlyViewedLocalPayload,
   expectedRecentlyViewedRemotePayload,
+  expectRecentlyViewedLocalPayloadSorted,
 } from 'tests/__fixtures__/products/index.mjs';
-import { omit, uniqBy } from 'lodash-es';
+import { omit } from 'lodash-es';
 import type { StoreState } from '../../../types/index.js';
 
 describe('RecentlyViewed redux selectors', () => {
@@ -15,13 +15,7 @@ describe('RecentlyViewed redux selectors', () => {
         error: null,
         result: {
           remote: expectedRecentlyViewedRemotePayload,
-          computed: uniqBy(
-            [
-              ...expectedRecentlyViewedLocalPayload,
-              ...expectedRecentlyViewedRemotePayload.entries,
-            ],
-            'productId',
-          ),
+          computed: expectRecentlyViewedLocalPayloadSorted,
           pagination: omit(expectedRecentlyViewedRemotePayload, 'entries'),
         },
       },
@@ -52,15 +46,9 @@ describe('RecentlyViewed redux selectors', () => {
     it('should get the result', () => {
       const spy = jest.spyOn(recentlyViewedReducer, 'getResult');
 
-      expect(selectors.getRecentlyViewedProducts(mockState)).toEqual([
-        ...expectedRecentlyViewedLocalPayload,
-        // mimic the lodash `uniqBy` method effect for the given payload
-        ...expectedRecentlyViewedRemotePayload.entries.filter(
-          item =>
-            item.productId !==
-            expectedRecentlyViewedLocalPayload?.[0]?.productId,
-        ),
-      ]);
+      expect(selectors.getRecentlyViewedProducts(mockState)).toEqual(
+        expectRecentlyViewedLocalPayloadSorted,
+      );
       expect(spy).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/__fixtures__/products/recentlyViewed.fixtures.mts
+++ b/tests/__fixtures__/products/recentlyViewed.fixtures.mts
@@ -1,7 +1,21 @@
-import { sortBy } from 'lodash-es';
-
 export const id = 1345678;
 export const expectedRecentlyViewedRemotePayload = {
+  number: 1,
+  totalPages: 1,
+  totalItems: 1,
+  entries: [
+    {
+      productId: 22222222,
+      lastVisitDate: '2020-02-01T15:57:30.238Z',
+    },
+    {
+      productId: 11111111,
+      lastVisitDate: '2020-02-02T15:57:30.238Z',
+    },
+  ],
+};
+
+export const expectedRecentlyViewedRemotePayloadSorted = {
   number: 1,
   totalPages: 1,
   totalItems: 1,
@@ -17,15 +31,11 @@ export const expectedRecentlyViewedRemotePayload = {
   ],
 };
 
-export const expectedRecentlyViewedRemotePayloadSorted = {
-  ...expectedRecentlyViewedRemotePayload,
-  entries: sortBy(
-    expectedRecentlyViewedRemotePayload.entries,
-    entry => new Date(entry.lastVisitDate),
-  ),
-};
-
 export const expectedRecentlyViewedLocalPayload = [
+  {
+    productId: 44444444,
+    lastVisitDate: '2020-02-03T10:08:50.010Z',
+  },
   {
     productId: 22222222,
     lastVisitDate: '2020-02-03T11:08:50.010Z',
@@ -34,13 +44,22 @@ export const expectedRecentlyViewedLocalPayload = [
     productId: 33333333,
     lastVisitDate: '2020-02-03T12:08:50.010Z',
   },
-  { productId: 44444444, lastVisitDate: '2020-02-03T10:08:50.010Z' },
 ];
 
-export const expectRecentlyViewedLocalPayloadSorted = sortBy(
-  expectedRecentlyViewedLocalPayload,
-  entry => new Date(entry.lastVisitDate),
-);
+export const expectRecentlyViewedLocalPayloadSorted = [
+  {
+    productId: 33333333,
+    lastVisitDate: '2020-02-03T12:08:50.010Z',
+  },
+  {
+    productId: 22222222,
+    lastVisitDate: '2020-02-03T11:08:50.010Z',
+  },
+  {
+    productId: 44444444,
+    lastVisitDate: '2020-02-03T10:08:50.010Z',
+  },
+];
 
 export const mockRecentlyViewedState = {
   recentlyViewed: {


### PR DESCRIPTION
## Description

This fixes recentlyViewedProducts reducer to sort the products by descending order instead of ascending.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
