### PR TITLE
feat: add support for sharing gcm v1

### DIFF
--- a/packages/core/src/analytics/utils/getters.js
+++ b/packages/core/src/analytics/utils/getters.js
@@ -66,6 +66,10 @@ export const getLocation = data => {
 };
 
 export const getCookie = name => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
 

--- a/packages/react/src/analytics/analytics.js
+++ b/packages/react/src/analytics/analytics.js
@@ -1,4 +1,7 @@
-import { name as PCKG_NAME, version as PCKG_VERSION } from '../../package.json';
+import {
+  PACKAGE_NAME as PCKG_NAME,
+  PACKAGE_NAME_VERSION as PCKG_VERSION,
+} from './constants';
 import Analytics, {
   trackTypes as analyticsTrackTypes,
   platformTypes,

--- a/packages/react/src/analytics/constants.js
+++ b/packages/react/src/analytics/constants.js
@@ -1,0 +1,9 @@
+// We use a require here to avoid typescript complaining of `package.json` is not
+// under rootDir that we would get if we used an import. Typescript apparently ignores
+// requires.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { name, version } = require('../../package.json');
+
+export const PACKAGE_VERSION = version;
+export const PACKAGE_NAME = name;
+export const PACKAGE_NAME_VERSION = `${PACKAGE_NAME}@${PACKAGE_VERSION}`;

--- a/packages/react/src/analytics/integrations/shared/GoogleConsentMode/GoogleConsentMode.js
+++ b/packages/react/src/analytics/integrations/shared/GoogleConsentMode/GoogleConsentMode.js
@@ -1,144 +1,213 @@
-/**
- * GoogleConsentMode handles with Google Consent Mode v2.
- */
-import isEqual from 'lodash/isEqual';
+import { GCM_SHARED_COOKIE_NAME, setCookie } from './cookieUtils';
+import { utils } from '@farfetch/blackout-core/analytics';
 import omit from 'lodash/omit';
 
 export const googleConsentTypes = {
   GRANTED: 'granted',
   DENIED: 'denied',
 };
+
+/**
+ * GoogleConsentMode handles with Google Consent Mode v2.
+ */
 export class GoogleConsentMode {
+  dataLayer; // Stores different data layer names
+  configWithConsentOnly; // exclude not consent properties from config
+  consentDataLayerCommands = [];
+  waitForUpdate;
+  regions;
+  hasConfig;
+
   /**
    * Creates a new GoogleConsentMode instance.
    *
    * @param {string} dataLayer - DataLayer name.
-   * @param {string} initConsent  - The init consent data.
+   * @param {object} initConsent  - The init consent data.
    * @param {object} config - The configuration properties of Google Consent Mode.
    */
   constructor(dataLayer, initConsent, config) {
     this.dataLayer = dataLayer;
-    this.config = config;
+
+    this.waitForUpdate = config?.waitForUpdate;
+    this.regions = config?.regions;
 
     // select only the Google Consent Elements
-    this.configExcludingModeRegionsAndWaitForUpdate = omit(this.config || {}, [
+    this.configWithConsentOnly = omit(config || {}, [
       'waitForUpdate',
       'regions',
       'mode',
     ]);
 
-    this.loadDefaults(initConsent);
+    this.hasConfig = Object.keys(this.configWithConsentOnly).length > 0;
+
+    this.initialize(initConsent);
   }
 
   /**
-   * Initialize Google Consent Mode instance.
-   *
-   * @param {string} initConsent  - The init consent data.
+   * Tries to load shared consent from cookies if available
+   * and writes it to the dataLayer.
+   * This method is only supposed to be called if no google
+   * consent config was passed.
    */
-  loadDefaults(initConsent) {
-    if (this.config) {
-      const initialValue = {};
+  loadSharedConsentFromCookies() {
+    const consentModeCookieValue = utils.getCookie(GCM_SHARED_COOKIE_NAME);
 
-      if (this.config.waitForUpdate) {
-        initialValue['wait_for_update'] = this.config.waitForUpdate;
+    if (consentModeCookieValue) {
+      try {
+        const values = JSON.parse(consentModeCookieValue);
+
+        if (Array.isArray(values)) {
+          values.forEach(value => {
+            const [consentCommand, command, consent] = value;
+
+            this.write(consentCommand, command, consent);
+          });
+        }
+      } catch {
+        // Do nothing...
       }
-
-      // Obtain default google consent registry
-      const consentRegistry = Object.keys(
-        this.configExcludingModeRegionsAndWaitForUpdate,
-      ).reduce((result, consentKey) => {
-        return {
-          ...result,
-          [consentKey]:
-            this.configExcludingModeRegionsAndWaitForUpdate[consentKey]
-              ?.default || googleConsentTypes.DENIED,
-        };
-      }, initialValue);
-
-      // Write default consent to data layer
-      this.write('consent', 'default', consentRegistry);
-
-      // write regions to data layer if they exists
-      const regions = this.config.regions;
-      if (regions) {
-        regions.forEach(region => {
-          this.write('consent', 'default', region);
-        });
-      }
-
-      // after write default consents, then write first update with initial consent data
-      this.updateConsent(initConsent);
     }
   }
 
   /**
-   * Update consent.
+   * Loads default values from the configuration and
+   * writes them in a cookie for sharing.
    *
-   * @param {object} consentData - The consent data to be set.
+   * @param {object} initConsent - The consent data available, which can be null if the user has not yet given consent.
+   */
+  loadDefaultsFromConfig(initConsent) {
+    const initialValue = {};
+
+    if (this.waitForUpdate) {
+      initialValue['wait_for_update'] = this.waitForUpdate;
+    }
+
+    // Obtain default google consent registry
+    const consentRegistry = Object.keys(this.configWithConsentOnly).reduce(
+      (result, consentKey) => ({
+        ...result,
+        [consentKey]:
+          this.configWithConsentOnly[consentKey]?.default ||
+          googleConsentTypes.DENIED,
+      }),
+      initialValue,
+    );
+
+    // Write default consent to data layer
+    this.write('consent', 'default', consentRegistry);
+
+    // write regions to data layer if they exist
+    const regions = this.regions;
+
+    if (regions) {
+      regions.forEach(region => {
+        this.write('consent', 'default', region);
+      });
+    }
+
+    this.updateConsent(initConsent);
+
+    this.saveConsent();
+  }
+
+  /**
+   * Try to set consent types with dataLayer. If a valid
+   * config was passed, default values for the consent
+   * types are used. Else, try to load the commands
+   * set from the cookie if it is available.
+   *
+   * @param initConsent - The consent data available, which can be null if the user has not yet given consent.
+   */
+  initialize(initConsent) {
+    if (this.hasConfig) {
+      this.loadDefaultsFromConfig(initConsent);
+    } else {
+      this.loadSharedConsentFromCookies();
+    }
+  }
+
+  /**
+   * Writes consent updates to the dataLayer
+   * by applying the configuration (if any) to
+   * the passed consent data.
+   *
+   * @param {object} consentData - Consent data obtained from the user or null if not available.
    */
   updateConsent(consentData) {
-    if (this.config) {
-      // Dealing with null or undefined consent values
-      const safeConsent = consentData || {};
-
+    if (this.hasConfig && consentData) {
       // Fill consent value into consent element, using analytics consent categories
-      const consentRegistry = Object.keys(
-        this.configExcludingModeRegionsAndWaitForUpdate,
-      ).reduce((result, consentKey) => {
-        let consentValue = googleConsentTypes.DENIED;
-        const consent =
-          this.configExcludingModeRegionsAndWaitForUpdate[consentKey];
+      const consentRegistry = Object.keys(this.configWithConsentOnly).reduce(
+        (result, consentKey) => {
+          let consentValue = googleConsentTypes.DENIED;
+          const consent = this.configWithConsentOnly[consentKey];
 
-        if (consent) {
-          // has consent config key
-
-          if (consent.getConsentValue) {
-            // give priority to custom function
-            consentValue = consent.getConsentValue(safeConsent);
-          } else if (
-            consent?.categories !== undefined &&
-            consent.categories.every(consent => safeConsent[consent])
-          ) {
-            // The second option to assign value is by categories list
-            consentValue = googleConsentTypes.GRANTED;
+          if (consent) {
+            // has consent config key
+            if (consent.getConsentValue) {
+              // give priority to custom function
+              consentValue = consent.getConsentValue(consentData);
+            } else if (
+              consent?.categories !== undefined &&
+              consent.categories.every(consent => consentData[consent])
+            ) {
+              // The second option to assign value is by categories list
+              consentValue = googleConsentTypes.GRANTED;
+            }
           }
-        }
 
-        return {
-          ...result,
-          [consentKey]: consentValue,
-        };
-      }, {});
+          return {
+            ...result,
+            [consentKey]: consentValue,
+          };
+        },
+        {},
+      );
 
       // Write consent to data layer
       this.write('consent', 'update', consentRegistry);
+
+      this.saveConsent();
     }
   }
 
   /**
-   * Write consent on data layer.
+   * Saves calculated google consent mode to a cookie
+   * for sharing consent between apps in same
+   * domain.
+   */
+  saveConsent() {
+    if (this.consentDataLayerCommands.length > 0) {
+      setCookie(
+        GCM_SHARED_COOKIE_NAME,
+        JSON.stringify(this.consentDataLayerCommands),
+      );
+    }
+  }
+
+  /**
+   * Handles consent by updating the data layer with consent information.
    *
-   * @param {string} consentCommand - The consent command "consent".
+   * @param {string} consent - The consent command "consent".
+   * @param consentCommand
    * @param {string} command - The command "default" or "update".
    * @param {object} consentParams - The consent arguments.
    */
-  // eslint-disable-next-line no-unused-vars
   write(consentCommand, command, consentParams) {
     // Without using the arguments reference, google debug mode would not seem to register the consent
     // that was written to the datalayer, so the parameters added to the function signature are only to
     // avoid mistakes when calling the function.
 
-    if (
-      this.config &&
-      typeof window !== 'undefined' &&
-      consentParams &&
-      !isEqual(this.lastConsent, consentParams)
-    ) {
-      // @ts-ignore
+    if (typeof window !== 'undefined' && consentParams) {
       window[this.dataLayer] = window[this.dataLayer] || [];
 
+      // eslint-disable-next-line prefer-rest-params
       window[this.dataLayer].push(arguments);
-      this.lastConsent = consentParams;
+
+      this.consentDataLayerCommands.push([
+        consentCommand,
+        command,
+        consentParams,
+      ]);
     }
   }
 }

--- a/packages/react/src/analytics/integrations/shared/GoogleConsentMode/__tests__/__snapshots__/GoogleConsentMode.test.js.snap
+++ b/packages/react/src/analytics/integrations/shared/GoogleConsentMode/__tests__/__snapshots__/GoogleConsentMode.test.js.snap
@@ -25,31 +25,6 @@ Array [
 ]
 `;
 
-exports[`GoogleConsentMode Basic Google Consent Mode Configuration should not update twice dataLayer consent when "updateConsent" is called with same values 1`] = `
-Array [
-  Arguments [
-    "consent",
-    "default",
-    Object {
-      "ad_personalization": "denied",
-      "ad_storage": "denied",
-      "ad_user_data": "denied",
-      "analytics_storage": "denied",
-    },
-  ],
-  Arguments [
-    "consent",
-    "update",
-    Object {
-      "ad_personalization": "granted",
-      "ad_storage": "granted",
-      "ad_user_data": "granted",
-      "analytics_storage": "granted",
-    },
-  ],
-]
-`;
-
 exports[`GoogleConsentMode Basic Google Consent Mode Configuration should update dataLayer consent when "updateConsent" is called 1`] = `
 Array [
   Arguments [
@@ -76,6 +51,50 @@ Array [
 `;
 
 exports[`GoogleConsentMode Basic Google Consent Mode Configuration should update dataLayer consent when "updateConsent" is called 2`] = `
+Array [
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": "granted",
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
+    },
+  ],
+]
+`;
+
+exports[`GoogleConsentMode Extended Google Consent Mode Configuration sharing cookie with consent when configuration is not provided should load and write consent from the cookie if available 1`] = `
+Array [
+  Arguments [
+    "consent",
+    "default",
+    Object {
+      "ad_personalization": "denied",
+      "ad_storage": "denied",
+      "ad_user_data": "denied",
+      "analytics_storage": "denied",
+    },
+  ],
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": "granted",
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
+    },
+  ],
+]
+`;
+
+exports[`GoogleConsentMode Extended Google Consent Mode Configuration sharing cookie with consent when consent configuration is provided should save a cookie when consent is written to dataLayer 1`] = `"@farfetch/blackout-react__gcm_shared_consent_mode=[[\\"consent\\",\\"default\\",{\\"ad_storage\\":\\"denied\\",\\"ad_user_data\\":\\"denied\\",\\"ad_personalization\\":\\"denied\\",\\"analytics_storage\\":\\"denied\\"}]]"`;
+
+exports[`GoogleConsentMode Extended Google Consent Mode Configuration sharing cookie with consent when consent configuration is provided should save a cookie when consent is written to dataLayer 2`] = `"@farfetch/blackout-react__gcm_shared_consent_mode=[[\\"consent\\",\\"default\\",{\\"ad_storage\\":\\"denied\\",\\"ad_user_data\\":\\"denied\\",\\"ad_personalization\\":\\"denied\\",\\"analytics_storage\\":\\"denied\\"}],[\\"consent\\",\\"update\\",{\\"ad_storage\\":\\"granted\\",\\"ad_user_data\\":\\"granted\\",\\"ad_personalization\\":\\"granted\\",\\"analytics_storage\\":\\"granted\\"}]]"`;
+
+exports[`GoogleConsentMode Extended Google Consent Mode Configuration sharing cookie with consent when partial configuration is provided which does not include consent configuration should write consent to dataLayer when cookie is available 1`] = `
 Array [
   Arguments [
     "consent",
@@ -205,6 +224,16 @@ Array [
       "analytics_storage": "granted",
     },
   ],
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": "granted",
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
+    },
+  ],
 ]
 `;
 
@@ -314,6 +343,36 @@ Array [
       "analytics_storage": "granted",
     },
   ],
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": undefined,
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
+    },
+  ],
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": undefined,
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
+    },
+  ],
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": undefined,
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
+    },
+  ],
 ]
 `;
 
@@ -327,6 +386,16 @@ Array [
       "ad_storage": "denied",
       "ad_user_data": "denied",
       "analytics_storage": "denied",
+    },
+  ],
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": "denied",
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
     },
   ],
   Arguments [

--- a/packages/react/src/analytics/integrations/shared/GoogleConsentMode/cookieUtils.js
+++ b/packages/react/src/analytics/integrations/shared/GoogleConsentMode/cookieUtils.js
@@ -1,0 +1,31 @@
+import { PACKAGE_NAME } from '../../../constants';
+
+export const GCM_SHARED_COOKIE_NAME = `${PACKAGE_NAME}__gcm_shared_consent_mode`;
+
+/**
+ *
+ */
+function getDomain() {
+  const fullDomain = window.location.hostname;
+  const domainParts = fullDomain.split('.');
+
+  // Check if there is a subdomain
+  if (domainParts.length > 1) {
+    return (
+      domainParts[domainParts.length - 2] +
+      '.' +
+      domainParts[domainParts.length - 1]
+    );
+  }
+
+  return fullDomain;
+}
+
+/**
+ * @param name - Cookie name.
+ * @param value - Cookie value.
+ * @param domain - Domain to set. If not passed, will use the parent domain from the hostname.
+ */
+export function setCookie(name, value, domain = getDomain()) {
+  document.cookie = name + '=' + (value || '') + '; path=/ ; domain=' + domain;
+}


### PR DESCRIPTION
## Description

This adds support for sharing google consent
mode with other apps such as Luxury Checkout
through a cookie set for the same domain.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
