### PR TITLE
feat: add support for sharing gcm

### DIFF
--- a/packages/analytics/src/utils/getters.ts
+++ b/packages/analytics/src/utils/getters.ts
@@ -134,6 +134,10 @@ export const getLocation = (
  * @returns The cookie value.
  */
 export const getCookie = (name: string): string | void => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
 

--- a/packages/react/src/analytics/analytics.ts
+++ b/packages/react/src/analytics/analytics.ts
@@ -1,4 +1,5 @@
 import { get } from 'lodash-es';
+import { PACKAGE_NAME, PACKAGE_NAME_VERSION } from './constants.js';
 import Analytics, {
   type EventContextData,
   type EventData,
@@ -10,12 +11,6 @@ import Analytics, {
 } from '@farfetch/blackout-analytics';
 import webContext, { type WebContext } from './context.js';
 import WebContextStateManager from './WebContextStateManager.js';
-
-const {
-  name: PACKAGE_NAME,
-  version: PACKAGE_VERSION,
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-} = require('../../package.json');
 
 /**
  * Analytics facade for web applications. Refer to \@farfetch/blackout-analytics
@@ -85,7 +80,7 @@ class AnalyticsWeb extends Analytics {
     if (context) {
       context.library = {
         name: PACKAGE_NAME,
-        version: `${context.library.name}@${context.library.version};${PACKAGE_NAME}@${PACKAGE_VERSION};`,
+        version: `${context.library.name}@${context.library.version};${PACKAGE_NAME_VERSION};`,
       };
 
       const webContextStateSnapshot = this.webContextStateManager.getSnapshot();

--- a/packages/react/src/analytics/constants.ts
+++ b/packages/react/src/analytics/constants.ts
@@ -1,0 +1,9 @@
+// We use a require here to avoid typescript complaining of `package.json` is not
+// under rootDir that we would get if we used an import. Typescript apparently ignores
+// requires.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { name, version } = require('../../package.json');
+
+export const PACKAGE_VERSION = version as string;
+export const PACKAGE_NAME = name as string;
+export const PACKAGE_NAME_VERSION = `${PACKAGE_NAME}@${PACKAGE_VERSION}`;

--- a/packages/react/src/analytics/integrations/shared/GoogleConsentMode/__tests__/GoogleConsentMode.test.ts
+++ b/packages/react/src/analytics/integrations/shared/GoogleConsentMode/__tests__/GoogleConsentMode.test.ts
@@ -5,6 +5,18 @@ import {
 } from '../index.js';
 import type { ConsentData } from '@farfetch/blackout-analytics';
 
+function deleteAllCookies() {
+  const cookies = document.cookie.split(';');
+
+  for (let i = 0; i < cookies.length; i++) {
+    const cookie = cookies[i];
+    const eqPos = cookie!.indexOf('=');
+    const name = eqPos > -1 ? cookie!.substr(0, eqPos) : cookie;
+
+    document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  }
+}
+
 describe('GoogleConsentMode', () => {
   const dataLayerName = 'dataLayer';
   const mockConsent: ConsentData = {
@@ -34,6 +46,8 @@ describe('GoogleConsentMode', () => {
 
   beforeEach(() => {
     window[dataLayerName] = [];
+
+    deleteAllCookies();
   });
 
   describe('Basic Google Consent Mode Configuration', () => {
@@ -46,8 +60,8 @@ describe('GoogleConsentMode', () => {
 
       expect(googleConsent).toBeInstanceOf(GoogleConsentMode);
 
-      expect(window.dataLayer).toHaveLength(2);
-      expect(window.dataLayer).toMatchSnapshot();
+      expect(window[dataLayerName]).toHaveLength(2);
+      expect(window[dataLayerName]).toMatchSnapshot();
     });
 
     it('should update dataLayer consent when "updateConsent" is called', () => {
@@ -57,34 +71,22 @@ describe('GoogleConsentMode', () => {
         defaultConsentConfig,
       );
 
-      expect(window.dataLayer).toMatchSnapshot();
+      expect(window[dataLayerName]).toMatchSnapshot();
+      expect(window[dataLayerName]).toHaveLength(2);
+
+      jest.clearAllMocks();
+
+      window[dataLayerName] = [];
 
       googleConsent.updateConsent(mockConsent);
 
-      expect(window.dataLayer).toMatchSnapshot();
-      expect(window.dataLayer).toHaveLength(2);
+      expect(window[dataLayerName]).toMatchSnapshot();
     });
 
     it('should not write to datalayer if no configuration set', () => {
       new GoogleConsentMode(dataLayerName, mockConsent);
 
-      expect(window.dataLayer).toEqual([]);
-    });
-
-    it('should not update twice dataLayer consent when "updateConsent" is called with same values', () => {
-      const googleConsent = new GoogleConsentMode(
-        dataLayerName,
-        mockConsent,
-        defaultConsentConfig,
-      );
-
-      expect(googleConsent).toBeInstanceOf(GoogleConsentMode);
-
-      expect(window.dataLayer).toHaveLength(2);
-      expect(window.dataLayer).toMatchSnapshot();
-
-      googleConsent.updateConsent(mockConsent);
-      expect(window.dataLayer).toHaveLength(2);
+      expect(window[dataLayerName]).toEqual([]);
     });
   });
 
@@ -116,7 +118,7 @@ describe('GoogleConsentMode', () => {
         // update consent with grant conditions
         googleConsent.updateConsent({ ...mockConsent, consent_x: true });
 
-        expect(window.dataLayer).toMatchSnapshot();
+        expect(window[dataLayerName]).toMatchSnapshot();
       });
 
       it('should deal with no categories or getConsentValue function set', () => {
@@ -131,7 +133,7 @@ describe('GoogleConsentMode', () => {
 
         googleConsent.updateConsent(mockConsent);
 
-        expect(window.dataLayer).toMatchSnapshot();
+        expect(window[dataLayerName]).toMatchSnapshot();
       });
     });
 
@@ -155,8 +157,8 @@ describe('GoogleConsentMode', () => {
 
         expect(googleConsent).toBeInstanceOf(GoogleConsentMode);
 
-        expect(window.dataLayer).toHaveLength(3);
-        expect(window.dataLayer).toMatchSnapshot();
+        expect(window[dataLayerName]).toHaveLength(3);
+        expect(window[dataLayerName]).toMatchSnapshot();
       });
 
       it('should update dataLayer consent when "updateConsent" is called', () => {
@@ -166,12 +168,12 @@ describe('GoogleConsentMode', () => {
           defaultRegionConsentConfig,
         );
 
-        expect(window.dataLayer).toMatchSnapshot();
+        expect(window[dataLayerName]).toMatchSnapshot();
 
         googleConsent.updateConsent(mockConsent);
 
-        expect(window.dataLayer).toMatchSnapshot();
-        expect(window.dataLayer).toHaveLength(3);
+        expect(window[dataLayerName]).toMatchSnapshot();
+        expect(window[dataLayerName]).toHaveLength(4);
       });
 
       it('should update dataLayer consent when "updateConsent" is called with `wait_for_update` property', () => {
@@ -184,13 +186,99 @@ describe('GoogleConsentMode', () => {
           },
         );
 
-        expect(window.dataLayer).toMatchSnapshot();
-        expect(window.dataLayer).toHaveLength(3);
+        expect(window[dataLayerName]).toMatchSnapshot();
+        expect(window[dataLayerName]).toHaveLength(3);
 
         googleConsent.updateConsent(mockConsent);
 
-        expect(window.dataLayer).toHaveLength(4);
-        expect(window.dataLayer).toMatchSnapshot();
+        expect(window[dataLayerName]).toHaveLength(4);
+        expect(window[dataLayerName]).toMatchSnapshot();
+      });
+    });
+
+    describe('sharing cookie with consent', () => {
+      describe('when consent configuration is provided', () => {
+        it('should save a cookie when consent is written to dataLayer', () => {
+          const googleConsent = new GoogleConsentMode(
+            dataLayerName,
+            null,
+            defaultConsentConfig,
+          );
+
+          expect(document.cookie).toMatchSnapshot();
+
+          googleConsent.updateConsent(mockConsent);
+
+          expect(document.cookie).toMatchSnapshot();
+        });
+      });
+
+      describe('when configuration is not provided', () => {
+        it('should load and write consent from the cookie if available', () => {
+          // Write cookie with consent values
+          new GoogleConsentMode(
+            dataLayerName,
+            mockConsent,
+            defaultConsentConfig,
+          );
+
+          expect(document.cookie).not.toBe('');
+
+          window[dataLayerName] = [];
+
+          // Create new instance without configuration to test
+          new GoogleConsentMode(dataLayerName, null);
+
+          expect(window[dataLayerName]).toMatchSnapshot();
+        });
+
+        it('should not write consent if cookie is not available', () => {
+          // Create new instance without configuration to test
+          new GoogleConsentMode(dataLayerName, mockConsent);
+
+          expect(window[dataLayerName]).toEqual([]);
+        });
+      });
+
+      describe('when partial configuration is provided which does not include consent configuration', () => {
+        it('should write consent to dataLayer when cookie is available', () => {
+          // Write cookie with consent values
+          new GoogleConsentMode(
+            dataLayerName,
+            mockConsent,
+            defaultConsentConfig,
+          );
+
+          expect(document.cookie).not.toBe('');
+
+          window[dataLayerName] = [];
+
+          // @ts-expect-error Force partial configuration
+          new GoogleConsentMode(dataLayerName, mockConsent, {
+            mode: 'Advanced',
+            waitForUpdate: 100,
+          });
+
+          expect(window[dataLayerName]).toMatchSnapshot();
+        });
+
+        it('should not write consent to dataLayer when cookie is not available', () => {
+          const googleConsent = new GoogleConsentMode(
+            dataLayerName,
+            mockConsent,
+            // @ts-expect-error Force partial configuration
+            {
+              mode: 'Advanced',
+              waitForUpdate: 100,
+            },
+          );
+
+          expect(window[dataLayerName]).toEqual([]);
+
+          googleConsent.updateConsent(mockConsent);
+
+          expect(window[dataLayerName]).toEqual([]);
+        });
       });
     });
   });

--- a/packages/react/src/analytics/integrations/shared/GoogleConsentMode/__tests__/__snapshots__/GoogleConsentMode.test.ts.snap
+++ b/packages/react/src/analytics/integrations/shared/GoogleConsentMode/__tests__/__snapshots__/GoogleConsentMode.test.ts.snap
@@ -25,31 +25,6 @@ Array [
 ]
 `;
 
-exports[`GoogleConsentMode Basic Google Consent Mode Configuration should not update twice dataLayer consent when "updateConsent" is called with same values 1`] = `
-Array [
-  Arguments [
-    "consent",
-    "default",
-    Object {
-      "ad_personalization": "denied",
-      "ad_storage": "denied",
-      "ad_user_data": "denied",
-      "analytics_storage": "denied",
-    },
-  ],
-  Arguments [
-    "consent",
-    "update",
-    Object {
-      "ad_personalization": "granted",
-      "ad_storage": "granted",
-      "ad_user_data": "granted",
-      "analytics_storage": "granted",
-    },
-  ],
-]
-`;
-
 exports[`GoogleConsentMode Basic Google Consent Mode Configuration should update dataLayer consent when "updateConsent" is called 1`] = `
 Array [
   Arguments [
@@ -76,6 +51,50 @@ Array [
 `;
 
 exports[`GoogleConsentMode Basic Google Consent Mode Configuration should update dataLayer consent when "updateConsent" is called 2`] = `
+Array [
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": "granted",
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
+    },
+  ],
+]
+`;
+
+exports[`GoogleConsentMode Extended Google Consent Mode Configuration sharing cookie with consent when configuration is not provided should load and write consent from the cookie if available 1`] = `
+Array [
+  Arguments [
+    "consent",
+    "default",
+    Object {
+      "ad_personalization": "denied",
+      "ad_storage": "denied",
+      "ad_user_data": "denied",
+      "analytics_storage": "denied",
+    },
+  ],
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": "granted",
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
+    },
+  ],
+]
+`;
+
+exports[`GoogleConsentMode Extended Google Consent Mode Configuration sharing cookie with consent when consent configuration is provided should save a cookie when consent is written to dataLayer 1`] = `"@farfetch/blackout-react__gcm_shared_consent_mode=[[\\"consent\\",\\"default\\",{\\"ad_storage\\":\\"denied\\",\\"ad_user_data\\":\\"denied\\",\\"ad_personalization\\":\\"denied\\",\\"analytics_storage\\":\\"denied\\"}]]"`;
+
+exports[`GoogleConsentMode Extended Google Consent Mode Configuration sharing cookie with consent when consent configuration is provided should save a cookie when consent is written to dataLayer 2`] = `"@farfetch/blackout-react__gcm_shared_consent_mode=[[\\"consent\\",\\"default\\",{\\"ad_storage\\":\\"denied\\",\\"ad_user_data\\":\\"denied\\",\\"ad_personalization\\":\\"denied\\",\\"analytics_storage\\":\\"denied\\"}],[\\"consent\\",\\"update\\",{\\"ad_storage\\":\\"granted\\",\\"ad_user_data\\":\\"granted\\",\\"ad_personalization\\":\\"granted\\",\\"analytics_storage\\":\\"granted\\"}]]"`;
+
+exports[`GoogleConsentMode Extended Google Consent Mode Configuration sharing cookie with consent when partial configuration is provided which does not include consent configuration should write consent to dataLayer when cookie is available 1`] = `
 Array [
   Arguments [
     "consent",
@@ -205,6 +224,16 @@ Array [
       "analytics_storage": "granted",
     },
   ],
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": "granted",
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
+    },
+  ],
 ]
 `;
 
@@ -318,6 +347,26 @@ Array [
     "consent",
     "update",
     Object {
+      "ad_personalization": "denied",
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
+    },
+  ],
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": "denied",
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
+    },
+  ],
+  Arguments [
+    "consent",
+    "update",
+    Object {
       "ad_personalization": "granted",
       "ad_storage": "granted",
       "ad_user_data": "granted",
@@ -337,6 +386,16 @@ Array [
       "ad_storage": "denied",
       "ad_user_data": "denied",
       "analytics_storage": "denied",
+    },
+  ],
+  Arguments [
+    "consent",
+    "update",
+    Object {
+      "ad_personalization": "denied",
+      "ad_storage": "granted",
+      "ad_user_data": "granted",
+      "analytics_storage": "granted",
     },
   ],
   Arguments [

--- a/packages/react/src/analytics/integrations/shared/GoogleConsentMode/cookieUtils.ts
+++ b/packages/react/src/analytics/integrations/shared/GoogleConsentMode/cookieUtils.ts
@@ -1,0 +1,24 @@
+import { PACKAGE_NAME } from '../../../constants.js';
+
+export const GCM_SHARED_COOKIE_NAME = `${PACKAGE_NAME}__gcm_shared_consent_mode`;
+
+function getDomain() {
+  const fullDomain = window.location.hostname;
+
+  const domainParts = fullDomain.split('.');
+
+  // Check if there is a subdomain
+  if (domainParts.length > 1) {
+    return (
+      domainParts[domainParts.length - 2] +
+      '.' +
+      domainParts[domainParts.length - 1]
+    );
+  }
+
+  return fullDomain;
+}
+
+export function setCookie(name: string, value: string, domain = getDomain()) {
+  document.cookie = name + '=' + (value || '') + '; path=/ ; domain=' + domain;
+}


### PR DESCRIPTION
## Description

This adds support for sharing google consent
mode with other apps such as Luxury Checkout
through a cookie set for the same domain.

<!--
If this contains a breaking change, your commit body message must include "BREAKING CHANGE: " and
the label "BREAKING CHANGE" must be added.
Please also describe the impact and migration path for existing applications.
-->

<!--
If this fixes an open issue, please link to the issue here.

Closes #ISSUE_NUMBER
Refs #ISSUE_NUMBER
-->

### Dependencies

<!--
If this depends on another PR, please link it here.
If this has some other dependency, please describe it here.
Please add the label "status: on hold" to inform that this is blocked.

Otherwise, you can delete this section or just state "None".
-->

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The code is commented, particularly in hard-to-understand areas
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
