### PR TITLE
fix: referencedListing serverInitialState Validation

### DIFF
--- a/packages/redux/src/products/serverInitialState/listings.ts
+++ b/packages/redux/src/products/serverInitialState/listings.ts
@@ -37,8 +37,9 @@ const serverInitialState: ProductListingsServerInitialState = ({
   const hash = generateProductListingHash(builtSlug, query, {
     isSet,
   });
+  const referencedListing = get(model, 'relatedCommerceData.referencedListing');
 
-  if (get(model, 'relatedCommerceData.referencedListing')) {
+  if (referencedListing && referencedListing.length) {
     const {
       breadCrumbs,
       config,


### PR DESCRIPTION
## Description

This fixes a validation of the products serverInitialState where we validate if the referencedListing has a value, both null and empty arrays are possible outputs so we need to include the empty array validation by length to avoid the error by spreading the first of the referencedListings.

This has been tested in Whitelabel.

### Dependencies

No.

## Checklist

<!--
Go over all the following points, and mark with an `x` all boxes that apply.
If you're unsure about any of these, don't hesitate to ask; we're here to help!
-->

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [ ] The code is commented, particularly in hard-to-understand areas
- [ ] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
